### PR TITLE
Added FilterFactory interface and default implementation

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/DefaultFilterFactory.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/DefaultFilterFactory.java
@@ -1,0 +1,20 @@
+package com.netflix.zuul;
+
+/**
+ * Default factory for creating instances of ZuulFilter. 
+ */
+public class DefaultFilterFactory implements FilterFactory {
+
+    /**
+     * Returns a new implementation of ZuulFilter as specified by the provided 
+     * Class. The Class is instantiated using its nullary constructor.
+     * 
+     * @param clazz the Class to instantiate
+     * @return A new instance of ZuulFilter
+     */
+    @Override
+    public ZuulFilter newInstance(Class clazz) throws InstantiationException, IllegalAccessException {
+        return (ZuulFilter) clazz.newInstance();
+    }
+
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/FilterFactory.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/FilterFactory.java
@@ -1,0 +1,16 @@
+package com.netflix.zuul;
+
+/**
+ * Interface to provide instances of ZuulFilter from a given class.
+ */
+public interface FilterFactory {
+    
+    /**
+     * Returns an instance of the specified class.
+     * 
+     * @param clazz the Class to instantiate
+     * @return an instance of ZuulFilter
+     * @throws Exception if an error occurs
+     */
+    public ZuulFilter newInstance(Class clazz) throws Exception;
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/FilterLoader.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/FilterLoader.java
@@ -62,6 +62,8 @@ public class FilterLoader {
     private FilterRegistry filterRegistry = FilterRegistry.instance();
 
     static DynamicCodeCompiler COMPILER;
+    
+    static FilterFactory FILTER_FACTORY = new DefaultFilterFactory();
 
     /**
      * Sets a Dynamic Code Compiler
@@ -77,6 +79,15 @@ public class FilterLoader {
         this.filterRegistry = r;
     }
 
+    /**
+     * Sets a FilterFactory
+     * 
+     * @param factory
+     */
+    public void setFilterFactory(FilterFactory factory) {
+        FILTER_FACTORY = factory;
+    }
+    
     /**
      * @return Singleton FilterLoader
      */
@@ -107,7 +118,7 @@ public class FilterLoader {
         if (filter == null) {
             Class clazz = COMPILER.compile(sCode, sName);
             if (!Modifier.isAbstract(clazz.getModifiers())) {
-                filter = (ZuulFilter) clazz.newInstance();
+                filter = (ZuulFilter) FILTER_FACTORY.newInstance(clazz);
             }
         }
         return filter;
@@ -142,7 +153,7 @@ public class FilterLoader {
         if (filter == null) {
             Class clazz = COMPILER.compile(file);
             if (!Modifier.isAbstract(clazz.getModifiers())) {
-                filter = (ZuulFilter) clazz.newInstance();
+                filter = (ZuulFilter) FILTER_FACTORY.newInstance(clazz);
                 List<ZuulFilter> list = hashFiltersByType.get(filter.filterType());
                 if (list != null) {
                     hashFiltersByType.remove(filter.filterType()); //rebuild this list


### PR DESCRIPTION
Added a FilterFactory interface and a default implementation to the FilterLoader class to allow the dynamically compiled ZuulFilters to be instantiated via alternate methods. We use this to allow the filters to take advantage of dependency injection.
