### PR TITLE
Ensure pollers end when requested

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/FilterFileManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/FilterFileManager.java
@@ -51,7 +51,7 @@ public class FilterFileManager {
     String[] aDirectories;
     int pollingIntervalSeconds;
     Thread poller;
-    boolean bRunning = true;
+    volatile boolean bRunning = true;
 
     static FilenameFilter FILENAME_FILTER;
 

--- a/zuul-netflix/src/main/java/com/netflix/zuul/scriptManager/ZuulFilterPoller.java
+++ b/zuul-netflix/src/main/java/com/netflix/zuul/scriptManager/ZuulFilterPoller.java
@@ -77,7 +77,7 @@ public class ZuulFilterPoller {
     }
 
 
-    boolean running = true;
+    volatile boolean running = true;
     private long INTERVAL = 30000; //30 seconds
     Thread checkerThread = new Thread("ZuulFilterPoller") {
         public void run() {


### PR DESCRIPTION
I haven't witnessed this causing any actual issues, and I'm not sure there's a good way to write a failing unit test for it, but Java Concurrency in Practice made me worry enough about these kinds of things that I thought I'd at least bring it up.

Using volatile makes sure the compiler won't optimize us into an infinite loop. There may be implementation details in this case that prevent this optimization from happening in practice, but it's probably safer and clearer to just use volatile.

See http://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.3
