### PR TITLE
Fix/improve intellij IDEA iml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,6 @@ subprojects {
 
     group = "com.netflix.${githubProjectName}"
 
-    sourceSets.test.java.srcDir 'src/main/java'
-
     tasks.withType(Javadoc).each {
         it.classpath = sourceSets.main.compileClasspath
     }


### PR DESCRIPTION
No longer mark src/main/java as test (as well as main).  See https://github.com/Netflix/zuul/issues/29.  Note this doesn't fully fix that issue, but does produce valid iml.  Note also that for some reason, zuul-simple-webapp's iml doesn't have groovy src dir, but IDEA navigation/analysis still seems to see the code.
