### PR TITLE
Reduced generic params of FilterProcessor from <Request, Response> to <S...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,16 @@ subprojects {
         it.classpath = sourceSets.main.compileClasspath
     }
 
+    // make 'examples' use the same classpath
+    configurations { 
+        examplesCompile.extendsFrom compile
+        examplesRuntime.extendsFrom runtime
+    }
+
+    sourceSets { 
+        examples
+    }
+
     eclipse { 
         classpath { 
             downloadSources = true

--- a/zuul-core/src/examples/java/com/netflix/zuul/filter/ExampleRouteFilter.java
+++ b/zuul-core/src/examples/java/com/netflix/zuul/filter/ExampleRouteFilter.java
@@ -40,7 +40,8 @@ public class ExampleRouteFilter<T> extends RouteFilterIO<T> {
     @Override
     public Observable<IngressResponse> routeToOrigin(EgressRequest<T> egressReq) {
         System.out.println(this + " route filter");
-        return originClient.submit(egressReq.getHttpClientRequest()).map(IngressResponse::from);
+        return originClient.submit(egressReq.getHttpClientRequest()).map(httpResp ->
+                IngressResponse.from(httpResp, egressReq.get()));
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/ZuulKaryonServer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/ZuulKaryonServer.java
@@ -50,18 +50,16 @@ public class ZuulKaryonServer {
     
     /* DON'T DO THIS AT HOME */
     private static int port = 8888;
-    private static FilterProcessor<?, ?> filterProcessor;
+    private static FilterProcessor<?> filterProcessor;
     /* DON'T DO THIS AT HOME */
 
     private static final Logger logger = LoggerFactory.getLogger(ZuulKaryonServer.class);
 
-    public static <Request, Response> void startZuulServer(int port,
-                                                           FilterProcessor<Request, Response> filterProcessor) {
+    public static <State> void startZuulServer(int port, FilterProcessor<State> filterProcessor) {
         startZuulServerWithAdditionalModule(port, filterProcessor);
     }
 
-    public static <Request, Response> void startZuulServerWithAdditionalModule(int port,
-                                                                               FilterProcessor<Request, Response> filterProcessor,
+    public static <State> void startZuulServerWithAdditionalModule(int port, FilterProcessor<State> filterProcessor,
                                                                                Module... additionalModules) {
         logger.info("**** Starting Zuul with Karyon 2");
         /* DON'T DO THIS AT HOME */
@@ -104,11 +102,11 @@ public class ZuulKaryonServer {
         }
     }
 
-    private static class ZuulRouter<Request, Response> implements HttpRequestRouter<ByteBuf, ByteBuf> {
+    private static class ZuulRouter<State> implements HttpRequestRouter<ByteBuf, ByteBuf> {
 
-        private final FilterProcessor<Request, Response> filterProcessor;
+        private final FilterProcessor<State> filterProcessor;
 
-        public ZuulRouter(FilterProcessor<Request, Response> filterProcessor) {
+        public ZuulRouter(FilterProcessor<State> filterProcessor) {
             this.filterProcessor = filterProcessor;
         }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/ZuulRxNettyServer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/ZuulRxNettyServer.java
@@ -29,13 +29,13 @@ import rx.functions.Func1;
 
 import java.util.Map;
 
-public class ZuulRxNettyServer<Request, Response> {
+public class ZuulRxNettyServer<State> {
     private static final Logger logger = LoggerFactory.getLogger(ZuulRxNettyServer.class);
 
     private final int port;
-    private final FilterProcessor<Request, Response> filterProcessor;
+    private final FilterProcessor<State> filterProcessor;
 
-    public ZuulRxNettyServer(int port, FilterProcessor<Request, Response> filterProcessor) {
+    public ZuulRxNettyServer(int port, FilterProcessor<State> filterProcessor) {
         this.port = port;
         this.filterProcessor = filterProcessor;
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/ZuulServer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/ZuulServer.java
@@ -24,36 +24,23 @@ import java.util.HashMap;
 
 public class ZuulServer {
 
-    public static void start(int port, FilterStore<HashMap<String, Object>, HashMap<String, Object>> filterStore) {
+    public static void start(int port, FilterStore<HashMap<String, Object>> filterStore) {
         startWithAdditionalModules(port, filterStore);
     }
 
-    public static void startWithAdditionalModules(int port, FilterStore<HashMap<String, Object>,
-                                                  HashMap<String, Object>> filterStore,
+    public static void startWithAdditionalModules(int port, FilterStore<HashMap<String, Object>> filterStore,
                                                   Module... additionalModules) {
         startWithAdditionalModules(port, filterStore, DEFAULT_STATE_FACTORY, additionalModules);
     }
 
-    public static <T> void start(int port, FilterStore<T, T> filterStore, FilterStateFactory<T> typeFactory) {
+    public static <T> void start(int port, FilterStore<T> filterStore, FilterStateFactory<T> typeFactory) {
         startWithAdditionalModules(port, filterStore, typeFactory);
     }
 
-    public static <T> void startWithAdditionalModules(int port, FilterStore<T, T> filterStore,
-                                                      FilterStateFactory<T> typeFactory, Module... additionalModules) {
-        startWithAdditionalModules(port, filterStore, typeFactory, typeFactory, additionalModules);
-    }
-
-    public static <Request, Response> void start(int port, FilterStore<Request, Response> filterStore,
-                                                 FilterStateFactory<Request> request,
-                                                 FilterStateFactory<Response> response) {
-        startWithAdditionalModules(port, filterStore, request, response);
-    }
-
-    public static <Request, Response> void startWithAdditionalModules(int port, FilterStore<Request, Response> filterStore,
-                                                                      FilterStateFactory<Request> request,
-                                                                      FilterStateFactory<Response> response,
+    public static <T> void startWithAdditionalModules(int port, FilterStore<T> filterStore,
+                                                                      FilterStateFactory<T> stateFactory,
                                                                       Module... additionalModules) {
-        FilterProcessor<Request, Response> filterProcessor = new FilterProcessor<>(filterStore, request, response);
+        FilterProcessor<T> filterProcessor = new FilterProcessor<>(filterStore, stateFactory);
         //ZuulRxNettyServer<Request, Response> server = new ZuulRxNettyServer<>(port, filterProcessor);
         ZuulKaryonServer.startZuulServerWithAdditionalModule(port, filterProcessor, additionalModules);
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/filter/RouteFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filter/RouteFilter.java
@@ -20,6 +20,6 @@ import com.netflix.zuul.lifecycle.IngressResponse;
 import rx.Observable;
 
 //possible other name - OriginFilter, OriginRoutingFilter???
-public interface RouteFilter<Request> extends Filter {
-    public Observable<IngressResponse> execute(EgressRequest<Request> egressReq);
+public interface RouteFilter<T> extends Filter {
+    public Observable<IngressResponse> execute(EgressRequest<T> egressReq);
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/filter/RouteFilterIO.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filter/RouteFilterIO.java
@@ -20,11 +20,11 @@ import com.netflix.zuul.lifecycle.IngressResponse;
 import com.netflix.zuul.metrics.ZuulMetrics;
 import rx.Observable;
 
-public abstract class RouteFilterIO<Request> implements RouteFilter<Request> {
-    public abstract Observable<IngressResponse> routeToOrigin(EgressRequest<Request> egressReq);
+public abstract class RouteFilterIO<T> implements RouteFilter<T> {
+    public abstract Observable<IngressResponse> routeToOrigin(EgressRequest<T> egressReq);
 
     @Override
-    public Observable<IngressResponse> execute(EgressRequest<Request> egressReq) {
+    public Observable<IngressResponse> execute(EgressRequest<T> egressReq) {
         final long startTime = System.currentTimeMillis();
         return routeToOrigin(egressReq).doOnError(ex ->
                 ZuulMetrics.markFilterFailure(getClass(), System.currentTimeMillis() - startTime)).doOnCompleted(() ->

--- a/zuul-core/src/main/java/com/netflix/zuul/filterstore/FilterStore.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filterstore/FilterStore.java
@@ -23,11 +23,11 @@ import com.netflix.zuul.metrics.ZuulMetricsPublisherFactory;
 
 import java.io.IOException;
 
-public abstract class FilterStore<Request, Response> {
-    protected abstract FiltersForRoute<Request, Response> fetchFilters(IngressRequest ingressReq) throws IOException;
+public abstract class FilterStore<State> {
+    protected abstract FiltersForRoute<State> fetchFilters(IngressRequest ingressReq) throws IOException;
 
-    public FiltersForRoute<Request, Response> getFilters(IngressRequest ingressReq) throws IOException {
-        FiltersForRoute<Request, Response> filters = fetchFilters(ingressReq);
+    public FiltersForRoute<State> getFilters(IngressRequest ingressReq) throws IOException {
+        FiltersForRoute<State> filters = fetchFilters(ingressReq);
         for (Filter f: filters.all()) {
             ZuulFilterMetricsPublisher filterMetricsPublisher = ZuulMetricsPublisherFactory.createOrRetrieveFilterPublisher(f.getClass());
         }

--- a/zuul-core/src/main/java/com/netflix/zuul/filterstore/InMemoryFilterStore.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filterstore/InMemoryFilterStore.java
@@ -28,29 +28,29 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class InMemoryFilterStore<Request, Response> extends FilterStore<Request, Response> {
+public class InMemoryFilterStore<State> extends FilterStore<State> {
     private final static Logger logger = LoggerFactory.getLogger(InMemoryFilterStore.class);
 
-    private final CopyOnWriteArrayList<PreFilter<Request>> preFilters = new CopyOnWriteArrayList<>();
-    private final AtomicReference<RouteFilter<Request>> routeFilter = new AtomicReference<>();
-    private final CopyOnWriteArrayList<PostFilter<Response>> postFilters = new CopyOnWriteArrayList<>();
-    private final AtomicReference<ErrorFilter<Response>> errorFilter = new AtomicReference<>();
+    private final CopyOnWriteArrayList<PreFilter<State>> preFilters = new CopyOnWriteArrayList<>();
+    private final AtomicReference<RouteFilter<State>> routeFilter = new AtomicReference<>();
+    private final CopyOnWriteArrayList<PostFilter<State>> postFilters = new CopyOnWriteArrayList<>();
+    private final AtomicReference<ErrorFilter<State>> errorFilter = new AtomicReference<>();
 
     @Override
-    public FiltersForRoute<Request, Response> fetchFilters(IngressRequest ingressReq) {
+    public FiltersForRoute<State> fetchFilters(IngressRequest ingressReq) {
         return new FiltersForRoute<>(preFilters, routeFilter.get(), postFilters, errorFilter.get());
     }
 
     @SuppressWarnings("unchecked")
     public void addFilter(Filter filter) {
         if (filter instanceof PreFilter) {
-            preFilters.add((PreFilter<Request>) filter);
+            preFilters.add((PreFilter<State>) filter);
         } else if (filter instanceof PostFilter) {
-            postFilters.add((PostFilter<Response>) filter);
+            postFilters.add((PostFilter<State>) filter);
         } else if (filter instanceof RouteFilter) {
-            routeFilter.lazySet((RouteFilter<Request>) filter);
+            routeFilter.lazySet((RouteFilter<State>) filter);
         } else if (filter instanceof ErrorFilter) {
-            errorFilter.lazySet((ErrorFilter<Response>) filter);
+            errorFilter.lazySet((ErrorFilter<State>) filter);
         } else {
             logger.error("Unknown filter type : " + filter + " : " + filter.getClass().getCanonicalName());
         }

--- a/zuul-core/src/main/java/com/netflix/zuul/lifecycle/EgressResponse.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/lifecycle/EgressResponse.java
@@ -36,8 +36,8 @@ public class EgressResponse<T> {
         this.state = state;
     }
 
-    public static <T> EgressResponse<T> from(IngressResponse ingressResp, T state) {
-        return new EgressResponse<T>(ingressResp.getStatus(), convertHeaders(ingressResp.getHeaders()), ingressResp.getContent(), state);
+    public static <T> EgressResponse<T> from(IngressResponse<T> ingressResp) {
+        return new EgressResponse<T>(ingressResp.getStatus(), convertHeaders(ingressResp.getHeaders()), ingressResp.getContent(), ingressResp.getState());
     }
 
     public Observable<ByteBuf> getContent() {

--- a/zuul-core/src/main/java/com/netflix/zuul/lifecycle/FiltersForRoute.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/lifecycle/FiltersForRoute.java
@@ -28,13 +28,13 @@ import java.util.List;
  * Simple data holder that defines all filters for a given route and enforces
  * sortedness by {@link com.netflix.zuul.filter.Filter#getOrder()}.
  */
-public class FiltersForRoute<Request, Response> {
-    private final List<PreFilter<Request>> preFilters;
-    private final RouteFilter<Request> routeFilter;
-    private final List<PostFilter<Response>> postFilters;
-    private final ErrorFilter<Response> errorFilter;
+public class FiltersForRoute<State> {
+    private final List<PreFilter<State>> preFilters;
+    private final RouteFilter<State> routeFilter;
+    private final List<PostFilter<State>> postFilters;
+    private final ErrorFilter<State> errorFilter;
 
-    public FiltersForRoute(List<PreFilter<Request>> preFilters, RouteFilter<Request> routeFilter, List<PostFilter<Response>> postFilters, ErrorFilter<Response> errorFilter) {
+    public FiltersForRoute(List<PreFilter<State>> preFilters, RouteFilter<State> routeFilter, List<PostFilter<State>> postFilters, ErrorFilter<State> errorFilter) {
         this.preFilters = preFilters;
         this.preFilters.sort((f1, f2) -> f1.getOrder() - f2.getOrder());
         this.routeFilter = routeFilter;
@@ -43,19 +43,19 @@ public class FiltersForRoute<Request, Response> {
         this.errorFilter = errorFilter;
     }
 
-    public List<PreFilter<Request>> getPreFilters() {
+    public List<PreFilter<State>> getPreFilters() {
         return preFilters;
     }
 
-    public RouteFilter<Request> getRouteFilter() {
+    public RouteFilter<State> getRouteFilter() {
         return routeFilter;
     }
 
-    public List<PostFilter<Response>> getPostFilters() {
+    public List<PostFilter<State>> getPostFilters() {
         return postFilters;
     }
 
-    public ErrorFilter<Response> getErrorFilter() {
+    public ErrorFilter<State> getErrorFilter() {
         return errorFilter;
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/lifecycle/IngressResponse.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/lifecycle/IngressResponse.java
@@ -21,15 +21,17 @@ import io.reactivex.netty.protocol.http.client.HttpClientResponse;
 import io.reactivex.netty.protocol.http.client.HttpResponseHeaders;
 import rx.Observable;
 
-public class IngressResponse {
+public class IngressResponse<T> {
     private final HttpResponseHeaders headers;
     private final HttpResponseStatus status;
     private final Observable<ByteBuf> content;
+    private final T state;
 
-    protected IngressResponse(HttpResponseHeaders headers, HttpResponseStatus status, Observable<ByteBuf> content) {
+    protected IngressResponse(HttpResponseHeaders headers, HttpResponseStatus status, Observable<ByteBuf> content, T state) {
         this.headers = headers;
         this.status = status;
         this.content = content;
+        this.state = state;
     }
 
     public HttpResponseHeaders getHeaders() {
@@ -44,7 +46,11 @@ public class IngressResponse {
         return this.content;
     }
 
-    public static IngressResponse from(HttpClientResponse<ByteBuf> nettyResponse) {
-        return new IngressResponse(nettyResponse.getHeaders(), nettyResponse.getStatus(), nettyResponse.getContent());
+    public static <T> IngressResponse from(HttpClientResponse<ByteBuf> nettyResponse, T state) {
+        return new IngressResponse<>(nettyResponse.getHeaders(), nettyResponse.getStatus(), nettyResponse.getContent(), state);
+    }
+
+    public T getState() {
+        return this.state;
     }
 }

--- a/zuul-groovy/src/main/groovy/com/netflix/zuul/groovy/filter/ExampleRouteFilter.groovy
+++ b/zuul-groovy/src/main/groovy/com/netflix/zuul/groovy/filter/ExampleRouteFilter.groovy
@@ -30,7 +30,7 @@ public class ExampleRouteFilter<T> extends RouteFilterIO<T> {
     Observable<IngressResponse> routeToOrigin(EgressRequest<T> egressReq) {
         println("route filter " + this)
         HttpClient<ByteBuf, ByteBuf> httpClient = RxNetty.createHttpClient("api.test.netflix.com", 80)
-        httpClient.submit(egressReq.getHttpClientRequest()).map({IngressResponse.from(it) })
+        httpClient.submit(egressReq.getHttpClientRequest()).map({IngressResponse.from(it, egressReq.get()) })
     }
 
     @Override


### PR DESCRIPTION
...tate>
- This means that a single state type is available for the duration of the Zuul request
- It is up to you to attach the Request's state to the Response (if you want to)
- Also added the examples directory to build.gradle
