### PR TITLE
UTF-8 encode response body when converting to bytes

### DIFF
--- a/zuul-netflix-webapp/src/main/groovy/filters/post/sendResponse.groovy
+++ b/zuul-netflix-webapp/src/main/groovy/filters/post/sendResponse.groovy
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.runners.MockitoJUnitRunner
 
+import java.nio.charset.Charset
 import java.util.zip.GZIPInputStream
 import javax.servlet.http.HttpServletResponse
 
@@ -77,7 +78,7 @@ class sendResponse extends ZuulFilter {
         try {
             if (RequestContext.currentContext.responseBody != null) {
                 String body = RequestContext.currentContext.responseBody
-                writeResponse(new ByteArrayInputStream(body.bytes), outStream)
+                writeResponse(new ByteArrayInputStream(body.getBytes(Charset.forName("UTF-8"))), outStream)
                 return;
             }
 

--- a/zuul-simple-webapp/src/main/groovy/filters/post/SendResponse.groovy
+++ b/zuul-simple-webapp/src/main/groovy/filters/post/SendResponse.groovy
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.runners.MockitoJUnitRunner
 
+import java.nio.charset.Charset
 import java.util.zip.GZIPInputStream
 import javax.servlet.http.HttpServletResponse
 
@@ -76,7 +77,7 @@ class SendResponseFilter extends ZuulFilter {
         try {
             if (RequestContext.currentContext.responseBody != null) {
                 String body = RequestContext.currentContext.responseBody
-                writeResponse(new ByteArrayInputStream(body.bytes), outStream)
+                writeResponse(new ByteArrayInputStream(body.getBytes(Charset.forName("UTF-8"))), outStream)
                 return;
             }
 


### PR DESCRIPTION
I know you're working on a 2.x branch, but this was the result of some moderately hard-won debugging and I don't want anyone else to get bit by this. (Some of our servers are inexplicably starting with ASCII as the default character set, which is just lovely...)