### PR TITLE
Implementing dispose on the inbound content for content that wasn't written to the client

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/ZuulKaryonServer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/ZuulKaryonServer.java
@@ -22,7 +22,6 @@ import com.netflix.karyon.KaryonBootstrap;
 import com.netflix.karyon.archaius.ArchaiusBootstrap;
 import com.netflix.karyon.eureka.KaryonEurekaModule;
 import com.netflix.karyon.transport.http.AbstractHttpModule;
-import com.netflix.karyon.transport.http.HttpRequestHandler;
 import com.netflix.karyon.transport.http.HttpRequestRouter;
 import com.netflix.zuul.lifecycle.FilterProcessor;
 import com.netflix.zuul.lifecycle.IngressRequest;
@@ -31,16 +30,13 @@ import com.netflix.zuul.metrics.ZuulMetricsPublisherFactory;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.reactivex.netty.protocol.http.server.HttpServerBuilder;
 import io.reactivex.netty.protocol.http.server.HttpServerRequest;
 import io.reactivex.netty.protocol.http.server.HttpServerResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
-import rx.Subscription;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class ZuulKaryonServer {
 
@@ -106,85 +102,57 @@ public class ZuulKaryonServer {
             bind.toInstance(new ZuulRouter(ZuulKaryonServer.filterProcessor));
         }
 
-        @Override
-        protected HttpServerBuilder<ByteBuf, ByteBuf> newServerBuilder(int port, HttpRequestHandler<ByteBuf, ByteBuf> requestHandler) {
-            /**
-             * Why do we need to cache the content here longer?
-             *
-             * This is the processing flow:
-             *
-             *  (1) RxNetty server receives request headers -> (2) invokes Zuul's request handler ->
-             *  (3) Runs through pre-filters -> (4) Submits request to the origin (RxClient) ->
-             *  (5) RxNetty connects to origin -> (6) Write headers -> (7) Subscribes to the ServerRequest content
-             *  -> (8) Writes each content to the connection.
-             *
-             *  Since step (4) terminates the server pipeline handling for Http Server request, RxNetty will start reading
-             *  content from the inbound, potentially even before step (5) and the subscription on step (7)
-             *  If we do not cache data here, the data will be lost.
-             *  OTOH, we can not eagerly subscribe to the content as the RxClient does the subscription only after the
-             *  connection to origin is successful. The behavior of RxClient is appropriate as we do not really want to
-             *  subscribe to content before we are ready to write.
-             *  In this case, we are not requesting content from upstream on demand so we need to cache.
-             *
-             *  What happens in a streaming scenario?
-             *
-             *  We would have to leverage backpressure if we handle cases wherein the content is streamed as part of the
-             *  Server request. So, when we are overwhelmed with data (client slow) we can stop reading from upstream.
-             *
-             *  TODO: Should the timeout be configurable?
-             */
-            return super.newServerBuilder(port, requestHandler).withRequestContentSubscriptionTimeout(1, TimeUnit.MINUTES);
-        }
-    }
+        private static class ZuulRouter<State> implements HttpRequestRouter<ByteBuf, ByteBuf> {
 
-    private static class ZuulRouter<State> implements HttpRequestRouter<ByteBuf, ByteBuf> {
+            private final FilterProcessor<State> filterProcessor;
 
-        private final FilterProcessor<State> filterProcessor;
-
-        public ZuulRouter(FilterProcessor<State> filterProcessor) {
-            this.filterProcessor = filterProcessor;
-        }
-
-        @Override
-        public Observable<Void> route(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
-            final IngressRequest ingressReq = IngressRequest.from(request);
-            logger.info(request.getHttpMethod().name() + " " + request.getUri() + " " + request.getNettyChannel().remoteAddress().toString());
-            if (request.getHttpMethod().equals(HttpMethod.GET) && request.getUri().startsWith("/healthcheck")) {
-                response.setStatus(HttpResponseStatus.OK);
-                Subscription eagerSubscription = request.getContent().subscribe();
-                response.close();
-                return Observable.empty();
+            public ZuulRouter(FilterProcessor<State> filterProcessor) {
+                this.filterProcessor = filterProcessor;
             }
 
-            Observable<ByteBuf> responseContent = filterProcessor.applyAllFilters(ingressReq).
-                    flatMap(egressResp -> {
-                        response.setStatus(egressResp.getStatus());
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("Setting Outgoing HTTP Status : " + egressResp.getStatus());
-                        }
-                        logger.info(egressResp.getStatus().code() + " " + request.getHttpMethod().name() + " " + request.getUri() + " " + request.getNettyChannel().remoteAddress().toString());
+            @Override
+            public Observable<Void> route(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+                final IngressRequest ingressReq = IngressRequest.from(request);
+                logger.info(request.getHttpMethod().name() + " " + request.getUri() + " " + request.getNettyChannel()
+                                                                                                   .remoteAddress()
+                                                                                                   .toString());
+                if (request.getHttpMethod().equals(HttpMethod.GET) && request.getUri().startsWith("/healthcheck")) {
+                    response.setStatus(HttpResponseStatus.OK);
+                    return response.close();
+                }
 
-
-                        for (String headerName : egressResp.getHeaders().keySet()) {
-                            List<String> headerValues = egressResp.getHeaders().get(headerName);
+                Observable<ByteBuf> responseContent = filterProcessor.applyAllFilters(ingressReq).
+                        flatMap(egressResp -> {
+                            response.setStatus(egressResp.getStatus());
                             if (logger.isDebugEnabled()) {
-                                for (String headerValue : headerValues) {
-                                    logger.debug("Setting Outgoing HTTP Header : " + headerName + " -> " + headerValue);
-                                }
+                                logger.debug("Setting Outgoing HTTP Status : " + egressResp.getStatus());
                             }
-                            response.getHeaders().add(headerName, headerValues);
-                        }
+                            logger.info(
+                                    egressResp.getStatus().code() + " " + request.getHttpMethod().name() + " " + request
+                                            .getUri() + " " + request.getNettyChannel().remoteAddress().toString());
 
-                        return egressResp.getContent();
-                    });
 
-            Observable<Void> writeResponseContent = responseContent.map(byteBuf -> {
-                byteBuf.retain();
-                response.write(byteBuf);
-                return byteBuf;
-            }).ignoreElements().cast(Void.class).doOnCompleted(response::close);
+                            for (String headerName : egressResp.getHeaders().keySet()) {
+                                List<String> headerValues = egressResp.getHeaders().get(headerName);
+                                if (logger.isDebugEnabled()) {
+                                    for (String headerValue : headerValues) {
+                                        logger.debug(
+                                                "Setting Outgoing HTTP Header : " + headerName + " -> " + headerValue);
+                                    }
+                                }
+                                response.getHeaders().add(headerName, headerValues);
+                            }
 
-            return writeResponseContent;
+                            return egressResp.getContent();
+                        });
+
+                return responseContent.map(byteBuf -> {
+                    byteBuf.retain();
+                    response.write(byteBuf);
+                    return null;
+                }).ignoreElements().cast(Void.class).doOnCompleted(response::close);
+            }
         }
     }
 }
+

--- a/zuul-core/src/main/java/com/netflix/zuul/lifecycle/EgressResponse.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/lifecycle/EgressResponse.java
@@ -39,7 +39,8 @@ public class EgressResponse<T> {
     }
 
     public static <T> EgressResponse<T> from(IngressResponse<T> ingressResp) {
-        return new EgressResponse<T>(ingressResp.getStatus(), convertHeaders(ingressResp.getHeaders()), ingressResp.getContent(), ingressResp.getState());
+        return new EgressResponse<>(ingressResp.getStatus(), convertHeaders(ingressResp.getHeaders()),
+                                     ingressResp.getContent(), ingressResp.getState());
     }
 
     public Observable<ByteBuf> getContent() {

--- a/zuul-core/src/main/java/com/netflix/zuul/lifecycle/UnicastDisposableCachingSubject.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/lifecycle/UnicastDisposableCachingSubject.java
@@ -1,0 +1,241 @@
+package com.netflix.zuul.lifecycle;
+
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
+import rx.Observer;
+import rx.Subscriber;
+import rx.internal.operators.NotificationLite;
+import rx.observers.Subscribers;
+import rx.subjects.Subject;
+import rx.subscriptions.Subscriptions;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+/**
+ * A {@link Subject} implementation for caching {@link ReferenceCounted} objects which can be disposed if not sent to
+ * the sole subscriber of this subject.
+ *
+ * @author Nitesh Kant
+ */
+final class UnicastDisposableCachingSubject<T extends ReferenceCounted> extends Subject<T, T> {
+
+    private final State<T> state;
+
+    private UnicastDisposableCachingSubject(State<T> state) {
+        super(new OnSubscribeAction<>(state));
+        this.state = state;
+    }
+
+    public static <T extends ReferenceCounted> UnicastDisposableCachingSubject<T> create() {
+        State<T> state = new State<>();
+        return new UnicastDisposableCachingSubject<>(state);
+    }
+
+    /**
+     * Disposes the items held by this subject which were not given out to the lone subscriber.
+     */
+    public void dispose() {
+        if (state.casState(State.STATES.UNSUBSCRIBED, State.STATES.DISPOSED)) {
+            _dispose();
+        } else if (state.casState(State.STATES.SUBSCRIBED, State.STATES.DISPOSED)) {
+            state.observerRef.onCompleted(); // Complete the existing subscription in case it is still not unsubscribed.
+            _dispose();
+        }
+    }
+
+    private void _dispose() {
+        Subscriber<T> noOpSub = new PassThruObserver<>(Subscribers.empty(), state); // Any buffering post buffer draining must not be lying in the buffer
+        state.buffer.sendAllNotifications(noOpSub); // It is important to empty the buffer before setting the observer.
+        // If not done, there can be two threads draining the buffer
+        // (PassThroughObserver on any notification) and this thread.
+        state.setObserverRef(noOpSub); // All future notifications are not sent anywhere.
+    }
+
+    /** The common state. */
+    private static final class State<T> {
+
+        /**
+         * Following are the only possible state transitions:
+         * UNSUBSCRIBED -> SUBSCRIBED
+         * UNSUBSCRIBED -> DISPOSED
+         */
+        private enum STATES {
+            UNSUBSCRIBED /*Initial*/, SUBSCRIBED /*Terminal state*/, DISPOSED/*Terminal state*/
+        }
+
+        private volatile int state = STATES.UNSUBSCRIBED.ordinal(); /*Values are the ordinals of STATES enum*/
+
+        /** Following Observers are associated with the states:
+         * UNSUBSCRIBED => {@link BufferedObserver}
+         * SUBSCRIBED => {@link PassThruObserver}
+         * DISPOSED => {@link Subscribers#empty()}
+         */
+        private volatile Observer<? super T> observerRef = new BufferedObserver();
+
+        /**
+         * The only buffer associated with this state. All notifications go to this buffer if no one has subscribed and
+         * the {@link UnicastDisposableCachingSubject} instance is not disposed.
+         */
+        private final ByteBufAwareBuffer<T> buffer = new ByteBufAwareBuffer<>();
+
+        /** Field updater for observerRef. */
+        @SuppressWarnings("rawtypes")
+        private static final AtomicReferenceFieldUpdater<State, Observer> OBSERVER_UPDATER
+                = AtomicReferenceFieldUpdater.newUpdater(State.class, Observer.class, "observerRef");
+
+        /** Field updater for state. */
+        @SuppressWarnings("rawtypes")
+        private static final AtomicIntegerFieldUpdater<State> STATE_UPDATER
+                = AtomicIntegerFieldUpdater.newUpdater(State.class, "state");
+
+        public boolean casState(STATES expected, STATES next) {
+            return STATE_UPDATER.compareAndSet(this, expected.ordinal(), next.ordinal());
+        }
+
+        public void setObserverRef(Observer<? super T> o) { // Guarded by casState()
+            observerRef = o;
+        }
+
+        public boolean casObserverRef(Observer<? super T> expected, Observer<? super T> next) {
+            return OBSERVER_UPDATER.compareAndSet(this, expected, next);
+        }
+
+        /**
+         * The default subscriber when the enclosing state is created.
+         */
+        private final class BufferedObserver extends Subscriber<T> {
+
+            private final NotificationLite<Object> nl = NotificationLite.instance();
+
+            @Override
+            public void onCompleted() {
+                buffer.add(nl.completed());
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                buffer.add(nl.error(e));
+            }
+
+            @Override
+            public void onNext(T t) {
+                buffer.add(nl.next(t));
+            }
+        }
+    }
+
+    private static final class OnSubscribeAction<T> implements OnSubscribe<T> {
+
+        private final State<T> state;
+
+        public OnSubscribeAction(State<T> state) {
+            this.state = state;
+        }
+
+        @Override
+        public void call(final Subscriber<? super T> subscriber) {
+            if (state.casState(State.STATES.UNSUBSCRIBED, State.STATES.SUBSCRIBED)) {
+
+                // drain queued notifications before subscription
+                // we do this here before PassThruObserver so the consuming thread can do this before putting itself in
+                // the line of the producer
+                state.buffer.sendAllNotifications(subscriber);
+
+                // register real observer for pass-thru ... and drain any further events received on first notification
+                state.setObserverRef(new PassThruObserver<>(subscriber, state));
+                subscriber.add(Subscriptions.create(() -> state.setObserverRef(Subscribers.empty())));
+            } else if(State.STATES.SUBSCRIBED.ordinal() == state.state) {
+                subscriber.onError(new IllegalStateException("Content can only have one subscription. Use Observable.publish() if you want to multicast."));
+            } else if(State.STATES.DISPOSED.ordinal() == state.state) {
+                subscriber.onError(new IllegalStateException("Content stream is already disposed."));
+            }
+        }
+
+    }
+
+    @Override
+    public void onCompleted() {
+        state.observerRef.onCompleted();
+    }
+
+    @Override
+    public void onError(Throwable e) {
+        state.observerRef.onError(e);
+    }
+
+    @Override
+    public void onNext(T t) {
+        state.observerRef.onNext(t);
+    }
+
+    /**
+     * This is a temporary observer between buffering and the actual that gets into the line of notifications
+     * from the producer and will drain the queue of any items received during the race of the initial drain and
+     * switching this.
+     *
+     * It will then immediately swap itself out for the actual (after a single notification), but since this is
+     * now being done on the same producer thread no further buffering will occur.
+     */
+    private static final class PassThruObserver<T> extends Subscriber<T> {
+
+        private final Observer<? super T> actual;
+        // this assumes single threaded synchronous notifications (the Rx contract for a single Observer)
+        private final ByteBufAwareBuffer<T> buffer; // Same buffer instance from the original BufferedObserver.
+        private final State<T> state;
+
+        PassThruObserver(Observer<? super T> actual, State<T> state) {
+            this.actual = actual;
+            buffer = state.buffer;
+            this.state = state;
+        }
+
+        @Override
+        public void onCompleted() {
+            drainIfNeededAndSwitchToActual();
+            actual.onCompleted();
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            drainIfNeededAndSwitchToActual();
+            actual.onError(e);
+        }
+
+        @Override
+        public void onNext(T t) {
+            drainIfNeededAndSwitchToActual();
+            actual.onNext(t);
+        }
+
+        private void drainIfNeededAndSwitchToActual() {
+            buffer.sendAllNotifications(this);
+            // now we can safely change over to the actual and get rid of the pass-thru
+            // but only if not unsubscribed
+            state.casObserverRef(this, actual);
+        }
+    }
+
+    private static final class ByteBufAwareBuffer<T> {
+
+        private final ConcurrentLinkedQueue<Object> actual = new ConcurrentLinkedQueue<>();
+        private final NotificationLite<T> nl = NotificationLite.instance();
+
+        private void add(Object toAdd) {
+            ReferenceCountUtil.retain(toAdd); // Released when the notification is sent.
+            actual.add(toAdd);
+        }
+
+        public void sendAllNotifications(Subscriber<? super T> subscriber) {
+            Object notification; // Can be onComplete notification, onError notification or just the actual "T".
+            while ((notification = actual.poll()) != null) {
+                try {
+                    nl.accept(subscriber, notification);
+                } finally {
+                    ReferenceCountUtil.release(notification); // If it is the actual T for onNext and is a ByteBuf, it will be released.
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently we are using `Observable.cache()` which does not release the `ByteBuffer` if no one subscribes to it.
This change provides the method to release any cached `ByteBuffer`s which were not consumed in case of success or error.
