### PR TITLE
Add more granular HTTP status code metrics

### DIFF
--- a/zuul-contrib/zuul-servo-metrics-publisher/src/main/java/com/netflix/zuul/contrib/servopublisher/ZuulServoGlobalMetricsPublisher.java
+++ b/zuul-contrib/zuul-servo-metrics-publisher/src/main/java/com/netflix/zuul/contrib/servopublisher/ZuulServoGlobalMetricsPublisher.java
@@ -26,6 +26,7 @@ import com.netflix.zuul.metrics.ZuulExecutionEvent;
 import com.netflix.zuul.metrics.ZuulGlobalMetricsPublisher;
 import com.netflix.zuul.metrics.ZuulMetrics;
 import com.netflix.zuul.metrics.ZuulStatusCode;
+import com.netflix.zuul.metrics.ZuulStatusCodeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,13 +100,20 @@ public class ZuulServoGlobalMetricsPublisher extends AbstractZuulServoMetricsPub
             monitors.add(getCumulativeCountForEvent(prefix + "countFailure", globalExecutionMetrics, ZuulExecutionEvent.FAILURE));
         }
 
+        NumerusRollingNumber globalStatusCodeClassMetrics = ZuulMetrics.getGlobalStatusCodeClassMetrics();
+        if (globalStatusCodeClassMetrics != null) {
+            for (ZuulStatusCodeClass statusCodeClass: ZuulStatusCodeClass.values()) {
+                Monitor<?> m = getCumulativeCountForEvent(prefix + "class_count" + statusCodeClass.str(), globalStatusCodeClassMetrics, statusCodeClass);
+                monitors.add(m);
+            }
+        }
+
         NumerusRollingNumber globalStatusCodeMetrics = ZuulMetrics.getGlobalStatusCodeMetrics();
         if (globalStatusCodeMetrics != null) {
-            monitors.add(getCumulativeCountForEvent(prefix + "count1xx", globalStatusCodeMetrics, ZuulStatusCode.OneXX));
-            monitors.add(getCumulativeCountForEvent(prefix + "count2xx", globalStatusCodeMetrics, ZuulStatusCode.TwoXX));
-            monitors.add(getCumulativeCountForEvent(prefix + "count3xx", globalStatusCodeMetrics, ZuulStatusCode.ThreeXX));
-            monitors.add(getCumulativeCountForEvent(prefix + "count4xx", globalStatusCodeMetrics, ZuulStatusCode.FourXX));
-            monitors.add(getCumulativeCountForEvent(prefix + "count5xx", globalStatusCodeMetrics, ZuulStatusCode.FiveXX));
+            for (ZuulStatusCode statusCode: ZuulStatusCode.values()) {
+                Monitor<?> m = getCumulativeCountForEvent(prefix + "count" + statusCode.str(), globalStatusCodeMetrics, statusCode);
+                monitors.add(m);
+            }
         }
 
         NumerusRollingPercentile globalLatencyMetrics = ZuulMetrics.getGlobalLatencyMetrics();

--- a/zuul-core/src/main/java/com/netflix/zuul/lifecycle/FilterProcessor.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/lifecycle/FilterProcessor.java
@@ -72,7 +72,7 @@ public class FilterProcessor<State> {
                 long duration = System.currentTimeMillis() - startTime;
                 ZuulMetrics.markError(ingressReq, duration);
                 return applyErrorFilter(ex, ingressReq, filtersForRoute.getErrorFilter());
-            }).doOnNext(httpResp -> recordHttpStatusCode(ingressReq, httpResp.getStatus().code(), startTime));
+            }).doOnNext(httpResp -> ZuulMetrics.markStatus(httpResp.getStatus().code(), ingressReq, startTime));
         } catch (IOException ex) {
             logger.error("Couldn't load the filters");
             return Observable.error(new ZuulException("Could not load filters", 500));
@@ -119,19 +119,5 @@ public class FilterProcessor<State> {
         if (errorFilter != null) {
             return errorFilter.execute(ex, ingressReq);
         } else return Observable.error(ex);
-    }
-
-    private static void recordHttpStatusCode(IngressRequest ingressReq, int statusCode, long startTime) {
-        if (statusCode >= 100 && statusCode < 200) {
-            ZuulMetrics.mark1xx(ingressReq, System.currentTimeMillis() - startTime);
-        } else if (statusCode >= 200 && statusCode < 300) {
-            ZuulMetrics.mark2xx(ingressReq, System.currentTimeMillis() - startTime);
-        } else if (statusCode >= 300 && statusCode < 400) {
-            ZuulMetrics.mark3xx(ingressReq, System.currentTimeMillis() - startTime);
-        } else if (statusCode >= 400 && statusCode < 500) {
-            ZuulMetrics.mark4xx(ingressReq, System.currentTimeMillis() - startTime);
-        } else if (statusCode >= 500 && statusCode < 600) {
-            ZuulMetrics.mark5xx(ingressReq, System.currentTimeMillis() - startTime);
-        }
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/metrics/ZuulStatusCode.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/metrics/ZuulStatusCode.java
@@ -19,12 +19,32 @@ package com.netflix.zuul.metrics;
 import com.netflix.numerus.NumerusRollingNumberEvent;
 
 public enum ZuulStatusCode implements NumerusRollingNumberEvent {
-    OneXX("1xx"), TwoXX("2xx"), ThreeXX("3xx"), FourXX("4xx"), FiveXX("5xx"), INIT("???");
+    HTTP1xx("1xx", ZuulStatusCodeClass.HTTP1xx),
+    HTTP200("200", ZuulStatusCodeClass.HTTP2xx),
+    HTTP201("201", ZuulStatusCodeClass.HTTP2xx),
+    HTTP202("202", ZuulStatusCodeClass.HTTP2xx),
+    HTTP2xx("2xx", ZuulStatusCodeClass.HTTP2xx),
+    HTTP301("301", ZuulStatusCodeClass.HTTP3xx),
+    HTTP302("302", ZuulStatusCodeClass.HTTP3xx),
+    HTTP304("304", ZuulStatusCodeClass.HTTP3xx),
+    HTTP3xx("3xx", ZuulStatusCodeClass.HTTP3xx),
+    HTTP400("400", ZuulStatusCodeClass.HTTP4xx),
+    HTTP401("401", ZuulStatusCodeClass.HTTP4xx),
+    HTTP403("403", ZuulStatusCodeClass.HTTP4xx),
+    HTTP404("404", ZuulStatusCodeClass.HTTP4xx),
+    HTTP410("410", ZuulStatusCodeClass.HTTP4xx),
+    HTTP4xx("4xx", ZuulStatusCodeClass.HTTP4xx),
+    HTTP500("500", ZuulStatusCodeClass.HTTP5xx),
+    HTTP503("503", ZuulStatusCodeClass.HTTP5xx),
+    HTTP5xx("5xx", ZuulStatusCodeClass.HTTP5xx),
+    INIT("???", ZuulStatusCodeClass.INIT);
 
     private final String asString;
+    private final ZuulStatusCodeClass statusCodeClass;
 
-    private ZuulStatusCode(String s) {
+    private ZuulStatusCode(String s, ZuulStatusCodeClass statusCodeClass) {
         asString = s;
+        this.statusCodeClass = statusCodeClass;
     }
 
     @Override
@@ -44,5 +64,37 @@ public enum ZuulStatusCode implements NumerusRollingNumberEvent {
 
     public String str() {
         return asString;
+    }
+
+    public static ZuulStatusCode from(final int statusCode) {
+        switch (statusCode) {
+            case 200: return HTTP200;
+            case 201: return HTTP201;
+            case 202: return HTTP202;
+            case 301: return HTTP301;
+            case 302: return HTTP302;
+            case 304: return HTTP304;
+            case 400: return HTTP400;
+            case 401: return HTTP401;
+            case 403: return HTTP403;
+            case 404: return HTTP404;
+            case 410: return HTTP410;
+            case 500: return HTTP500;
+            case 503: return HTTP503;
+            default:
+                if (statusCode >= 100 && statusCode < 200) {
+                    return HTTP1xx;
+                } else if (statusCode >= 200 && statusCode < 300) {
+                    return HTTP2xx;
+                } else if (statusCode >= 300 && statusCode < 400) {
+                    return HTTP3xx;
+                } else if (statusCode >= 400 && statusCode < 500) {
+                    return HTTP4xx;
+                } else return HTTP5xx;
+        }
+    }
+
+    public ZuulStatusCodeClass getStatusClass() {
+        return statusCodeClass;
     }
 }


### PR DESCRIPTION
- ZuulStatusCodeClass tracks 1xx, 2xx, 3xx, 4xx, 5xx
- ZuulStatusCode tracks "interesting" codes (200, 201, 202, 301, 302, 304, 400, 401, 403, 404, 410, 500, 503) and dumps the rest in 1xx/2xx/3xx/4xx/5xx buckets
