### PR TITLE
update ribbon to 0.3.13

### DIFF
--- a/zuul-netflix/build.gradle
+++ b/zuul-netflix/build.gradle
@@ -13,9 +13,9 @@ dependencies {
     compile 'com.netflix.astyanax:astyanax-cassandra:1.56.48'
     compile 'com.netflix.astyanax:astyanax-thrift:1.56.48'
     compile 'com.netflix.hystrix:hystrix-core:1.4.0-RC4'
-    compile 'com.netflix.ribbon:ribbon-core:0.3.12'
-    compile 'com.netflix.ribbon:ribbon-eureka:0.3.12'
-    compile 'com.netflix.ribbon:ribbon-httpclient:0.3.12'
+    compile 'com.netflix.ribbon:ribbon-core:0.3.13'
+    compile 'com.netflix.ribbon:ribbon-eureka:0.3.13'
+    compile 'com.netflix.ribbon:ribbon-httpclient:0.3.13'
     compile 'com.netflix.turbine:turbine-core:[0.4,)'
     
     provided 'org.powermock:powermock-api-mockito:1.5.4'


### PR DESCRIPTION
Need updated ribbon to get the UseIPAddrForServer functionality for environments that don't have full DNS resolvable hostnames,
