### PR TITLE
Fix local httpRequest shadowing httpRequest() method

### DIFF
--- a/zuul-netflix-webapp/src/main/groovy/filters/route/ZuulHostRequest.groovy
+++ b/zuul-netflix-webapp/src/main/groovy/filters/route/ZuulHostRequest.groovy
@@ -264,7 +264,7 @@ class ZuulHostRequest extends ZuulFilter {
 
         try {
             httpRequest.setHeaders(headers)
-            HttpResponse zuulResponse = httpRequest(httpclient, httpHost, httpRequest)
+            HttpResponse zuulResponse = executeHttpRequest(httpclient, httpHost, httpRequest)
             return zuulResponse
 
 
@@ -277,7 +277,7 @@ class ZuulHostRequest extends ZuulFilter {
 
     }
 
-    HttpResponse httpRequest(HttpClient httpclient, HttpHost httpHost, HttpRequest httpRequest) {
+    HttpResponse executeHttpRequest(HttpClient httpclient, HttpHost httpHost, HttpRequest httpRequest) {
         HostCommand command = new HostCommand(httpclient, httpHost, httpRequest)
         command.execute();
     }
@@ -649,5 +649,3 @@ class ZuulHostRequest extends ZuulFilter {
 
     }
 }
-
-


### PR DESCRIPTION
Routing of requests fails when filters in zuul-netflix-webapp `setRouteHost()` on the `RequestContext`. The problem appears to be that the local binding of `httpRequest` in `ZuulHostRequest.forward()` shadows the `httpRequest()` method in the same class.

Renaming the method resolves this issue in my environment.
