### PR TITLE
Request headers to lower case

### DIFF
--- a/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRequest.groovy
+++ b/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRequest.groovy
@@ -289,7 +289,7 @@ class SimpleHostRoutingFilter extends ZuulFilter {
         def headers = new ArrayList()
         Enumeration headerNames = request.getHeaderNames();
         while (headerNames.hasMoreElements()) {
-            String name = (String) headerNames.nextElement();
+            String name = ((String) headerNames.nextElement()).toLowerCase();
             String value = request.getHeader(name);
             if (isValidHeader(name)) headers.add(new BasicHeader(name, value))
         }


### PR DESCRIPTION
Force the request headers to be lower case, just like the ones added by Zuul

Why? this way you could overwrite them with `ctx.addZuulRequestHeader("Host", "example.com");` in the PreDecoration filter.

With the current implementation, if you add a custom `Host` header, you could see something like this:

```
REQUEST_DEBUG::ZUUL:: host=http://example.com/
REQUEST_DEBUG::ZUUL::> Host  localhost:8080
REQUEST_DEBUG::ZUUL::> Connection  keep-alive
REQUEST_DEBUG::ZUUL::> Cache-Control  max-age=0
REQUEST_DEBUG::ZUUL::> Accept  text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
REQUEST_DEBUG::ZUUL::> User-Agent  Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36
REQUEST_DEBUG::ZUUL::> Accept-Language  ca,es;q=0.8,en;q=0.6
REQUEST_DEBUG::ZUUL::> host  example.com
REQUEST_DEBUG::ZUUL:: > GET  /some_url?null HTTP/1.1
```

So let's get fair and treat them equally ;p

```
REQUEST_DEBUG::ZUUL:: host=http://example.com/
REQUEST_DEBUG::ZUUL::> connection  keep-alive
REQUEST_DEBUG::ZUUL::> cache-control  max-age=0
REQUEST_DEBUG::ZUUL::> accept  text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
REQUEST_DEBUG::ZUUL::> user-agent  Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36
REQUEST_DEBUG::ZUUL::> accept-language  ca,es;q=0.8,en;q=0.6
REQUEST_DEBUG::ZUUL::> host  example.com
REQUEST_DEBUG::ZUUL:: > GET  /some_url?null HTTP/1.1
```