### PR TITLE
add TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+  - oraclejdk7
+  - openjdk6
+  - openjdk7


### PR DESCRIPTION
This is a very small and simple pull request with the additional question if TravisCI could be enabled for this repository.
(i.e. go to travis-ci.org, sign-in with the Netflix github account and add this zuul github project)

Note that the current state of the 1.x branch is failing on a clean checkout (see #95), hopefully with travisci enabled it's spotted faster. When travis CI gets enabled also merge in the other super small pull request (#99) that adds the junit dependency so you'll get a green build.

If all of this is implemented it would also be nice to add the travisci logo at the top in the README.md file in the following way:
```
[![Build status](https://travis-ci.org/Netflix/zuul.png?branch=1.x)](https://travis-ci.org/Netflix/zuul)
```
