### PR TITLE
Fixed thread local leak

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/http/ZuulServlet.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/http/ZuulServlet.java
@@ -90,6 +90,7 @@ public class ZuulServlet extends HttpServlet {
         } catch (Throwable e) {
             error(new ZuulException(e, 500, "UNHANDLED_EXCEPTION_" + e.getClass().getName()));
         } finally {
+            RequestContext.getCurrentContext().unset();
         }
     }
 


### PR DESCRIPTION
Unsetting thread local in finally block, so data from previous requests will not be there