### PR TITLE
Integrate zuul with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,1 @@
-language: java
-jdk:
-  - oraclejdk7
-  - openjdk6
-  - openjdk7
+language: groovy

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/charleswhchan/zuul.svg?branch=1.x)](https://travis-ci.org/charleswhchan/zuul)
+
 zuul
 ====
 


### PR DESCRIPTION
Got Travis CI working and made the follow changes:
1. Modified .travis.yml to specify 'groovy' as the language type (instead of Java)
2. Added Travis CI build status to README.md file so that the status appears in the webpage.

Note: 
1. You will need to create Netflix account under Travis CI, follow the instructions under
http://docs.travis-ci.com/user/getting-started/. Then update the URL accordingly.
2. I removed the JDK as I want to get it running first, and I was not sure what version are required (http://docs.travis-ci.com/user/languages/java/#Testing-Against-Multiple-JDKs)

Samples: (tested with my account)

Travis CI job: https://travis-ci.org/charleswhchan/zuul
GitHub project: https://github.com/charleswhchan/zuul/tree/1.x-travis-ci