### PR TITLE
Getting feet wet, added origin host header for sites which require it ma...

### DIFF
--- a/zuul-simple-webapp/src/main/groovy/filters/pre/PreDecoration.groovy
+++ b/zuul-simple-webapp/src/main/groovy/filters/pre/PreDecoration.groovy
@@ -44,6 +44,9 @@ class PreDecorationFilter extends ZuulFilter {
         // sets origin
         ctx.setRouteHost(new URL("http://apache.org/"));
 
+        // set origin host header
+        ctx.addZuulRequestHeader("Host","apache.org");
+
         // sets custom header to send to the origin
         ctx.addOriginResponseHeader("cache-control", "max-age=3600");
     }

--- a/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRequest.groovy
+++ b/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRequest.groovy
@@ -278,6 +278,7 @@ class SimpleHostRoutingFilter extends ZuulFilter {
 
     boolean isValidHeader(String name) {
         if (name.toLowerCase().contains("content-length")) return false;
+        if (name.toLowerCase().equals("host")) return false; // set host according to origin vhost
         if (!RequestContext.currentContext.responseGZipped) {
             if (name.toLowerCase().contains("accept-encoding")) return false;
         }


### PR DESCRIPTION
Getting feet wet, added origin host header for sites which require it match the site name.

I changed this because if routing to other sites, for example, example.org, or google.com, there will be a forbidden response due to seeing a host header of localhost:8080.  Below is the tcpdump to strings trace:

google
GET /?q=edge+router HTTP/1.1
Host: localhost:8080
User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:24.0) Gecko/20100101 Firefox/24.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-US,en;q=0.5
Connection: keep-alive
HTTP/1.1 403 Forbidden
Connection: close
Via: HTTP/1.1 proxy1732
