### PR TITLE
Report ZuulExceptions through logger in ZuulServletFilter

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulServletFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulServletFilter.java
@@ -26,8 +26,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
@@ -50,8 +48,6 @@ import static org.mockito.Mockito.*;
  *         Time: 2:54 PM
  */
 public class ZuulServletFilter implements Filter {
-
-    private static Logger LOG = LoggerFactory.getLogger(ZuulServletFilter.class);
 
     private ZuulRunner zuulRunner;
 
@@ -113,7 +109,6 @@ public class ZuulServletFilter implements Filter {
     void error(ZuulException e) {
         RequestContext.getCurrentContext().setThrowable(e);
         zuulRunner.error();
-        LOG.error(e.getMessage(), e);
     }
 
     public void destroy() {

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulServletFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulServletFilter.java
@@ -26,6 +26,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
@@ -48,6 +50,8 @@ import static org.mockito.Mockito.*;
  *         Time: 2:54 PM
  */
 public class ZuulServletFilter implements Filter {
+
+    private static Logger LOG = LoggerFactory.getLogger(ZuulServletFilter.class);
 
     private ZuulRunner zuulRunner;
 
@@ -109,7 +113,7 @@ public class ZuulServletFilter implements Filter {
     void error(ZuulException e) {
         RequestContext.getCurrentContext().setThrowable(e);
         zuulRunner.error();
-        e.printStackTrace();
+        LOG.error(e.getMessage(), e);
     }
 
     public void destroy() {

--- a/zuul-core/src/main/java/com/netflix/zuul/http/ZuulServlet.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/http/ZuulServlet.java
@@ -25,8 +25,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -47,10 +45,9 @@ import static org.mockito.Mockito.*;
  *         Time: 10:44 AM
  */
 public class ZuulServlet extends HttpServlet {
-    
+
     private static final long serialVersionUID = -3374242278843351500L;
     private ZuulRunner zuulRunner;
-    private static Logger LOG = LoggerFactory.getLogger(ZuulServlet.class);
 
 
     @Override
@@ -146,7 +143,6 @@ public class ZuulServlet extends HttpServlet {
     void error(ZuulException e) {
         RequestContext.getCurrentContext().setThrowable(e);
         zuulRunner.error();
-        LOG.error(e.getMessage(), e);
     }
 
     @RunWith(MockitoJUnitRunner.class)
@@ -196,7 +192,7 @@ public class ZuulServlet extends HttpServlet {
                 RequestContext.testSetCurrentContext(null);
 
             } catch (Exception e) {
-                LOG.error(e.getMessage(), e);
+                e.printStackTrace();
             }
 
 

--- a/zuul-netflix-webapp/src/main/groovy/filters/pre/ErrorResponse.groovy
+++ b/zuul-netflix-webapp/src/main/groovy/filters/pre/ErrorResponse.groovy
@@ -26,11 +26,15 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.runners.MockitoJUnitRunner
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 class ErrorResponse extends ZuulFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ErrorResponse.class);
 
     @Override
     String filterType() {
@@ -53,6 +57,7 @@ class ErrorResponse extends ZuulFilter {
         RequestContext context = RequestContext.currentContext
         Throwable ex = context.getThrowable()
         try {
+            LOG.error(ex.getMessage(), ex);
             throw ex
         } catch (ZuulException e) {
             String cause = e.errorCause


### PR DESCRIPTION
In ZuulServletFilter ZuulExceptions are just getting printed rather than getting added to the log like in ZuulServlet.