### PR TITLE
[2.x] API changes

### DIFF
--- a/zuul-filters/src/main/java/com/netflix/zuul/FilterFileManager.java
+++ b/zuul-filters/src/main/java/com/netflix/zuul/FilterFileManager.java
@@ -110,14 +110,16 @@ public class FilterFileManager {
         File  directory = new File(sPath);
         if (!directory.isDirectory()) {
             URL resource = FilterFileManager.class.getClassLoader().getResource(sPath);
-            try {
-                directory = new File(resource.toURI());
-            } catch (Exception e) {
-                LOG.error("Error accessing directory in classloader. path=" + sPath, e);
+            if (null != resource) {
+                try {
+                    directory = new File(resource.toURI());
+                } catch (Exception e) {
+                    LOG.error("Error accessing directory in classloader. path=" + sPath, e);
+                }
             }
-            if (!directory.isDirectory()) {
-                throw new RuntimeException(directory.getAbsolutePath() + " is not a valid directory");
-            }
+        }
+        if (!directory.isDirectory()) {
+            throw new RuntimeException(directory.getAbsolutePath() + " is not a valid directory.");
         }
         return directory;
     }

--- a/zuul-filters/src/test/java/com/netflix/zuul/FilterProcessorTest.java
+++ b/zuul-filters/src/test/java/com/netflix/zuul/FilterProcessorTest.java
@@ -59,7 +59,7 @@ public class FilterProcessorTest {
     @Test
     public void testProcessFilter() throws Exception {
         Mockito.when(filter.applyAsync(request)).thenReturn(Observable.just(request));
-        processor.processAsyncFilter(request, filter, (m) -> m).toBlocking().first();
+        processor.processAsyncFilter(request, filter, (m) -> m).toObservable().toBlocking().first();
         Mockito.verify(filter, Mockito.times(1)).applyAsync(request);
     }
 
@@ -67,7 +67,7 @@ public class FilterProcessorTest {
     public void testProcessFilter_ShouldFilterFalse() throws Exception
     {
         Mockito.when(filter.shouldFilter(request)).thenReturn(false);
-        processor.processAsyncFilter(request, filter, (m) -> m).toBlocking().first();
+        processor.processAsyncFilter(request, filter, (m) -> m).toObservable().toBlocking().first();
         Mockito.verify(filter, Mockito.times(0)).applyAsync(request);
     }
 
@@ -76,7 +76,7 @@ public class FilterProcessorTest {
     {
         Exception e = new RuntimeException("Blah");
         Mockito.when(filter.applyAsync(request)).thenThrow(e);
-        processor.processAsyncFilter(request, filter, (m) -> m).toBlocking().first();
+        processor.processAsyncFilter(request, filter, (m) -> m).toObservable().toBlocking().first();
 
         Mockito.verify(processor).recordFilterError(filter, request, e);
 

--- a/zuul-netty-sample/src/main/java/com/netflix/zuul/NettySampleStartServer.java
+++ b/zuul-netty-sample/src/main/java/com/netflix/zuul/NettySampleStartServer.java
@@ -65,7 +65,7 @@ public class NettySampleStartServer {
         SessionCleaner cleaner = context -> Observable.empty();
 
         ZuulHttpProcessor<HttpServerRequest<ByteBuf>, HttpServerResponse<ByteBuf>> processor =
-                new ZuulHttpProcessor<>(filterProcessor, sessionCtxFactory, ctxDecorator, null, filterFileManager,
+                new ZuulHttpProcessor<>(filterProcessor, sessionCtxFactory, ctxDecorator, null,
                                         cleaner);
 
         requestHandler = new ZuulRequestHandler(processor);

--- a/zuul-transport-bio/src/test/java/com/netflix/zuul/servlet/ZuulServletTest.java
+++ b/zuul-transport-bio/src/test/java/com/netflix/zuul/servlet/ZuulServletTest.java
@@ -18,7 +18,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
-import rx.Observable;
+import rx.Single;
 
 import javax.servlet.ServletInputStream;
 import javax.servlet.ServletOutputStream;
@@ -26,8 +26,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collections;
-
-import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ZuulServletTest {
@@ -62,7 +60,7 @@ public class ZuulServletTest {
         MockitoAnnotations.initMocks(this);
 
         contextFactory = new ServletSessionContextFactory();
-        zuulProcessor = new ZuulHttpProcessor(processor, contextFactory, null, null, filterFileMgr, sessionCleaner);
+        zuulProcessor = new ZuulHttpProcessor(processor, contextFactory, null, null, sessionCleaner);
         servlet = new ZuulServlet(zuulProcessor);
         servlet = Mockito.spy(servlet);
 
@@ -77,9 +75,9 @@ public class ZuulServletTest {
         response = new HttpResponseMessageImpl(context, request, 299);
         response.setBody("blah".getBytes());
 
-        Mockito.when(processor.applyInboundFilters(Matchers.any())).thenReturn(Observable.just(request));
-        Mockito.when(processor.applyEndpointFilter(Matchers.any())).thenReturn(Observable.just(response));
-        Mockito.when(processor.applyOutboundFilters(Matchers.any())).thenReturn(Observable.just(response));
+        Mockito.when(processor.applyInboundFilters(Matchers.any())).thenReturn(Single.just(request));
+        Mockito.when(processor.applyEndpointFilter(Matchers.any())).thenReturn(Single.just(response));
+        Mockito.when(processor.applyOutboundFilters(Matchers.any())).thenReturn(Single.just(response));
     }
 
     @Test

--- a/zuul-transport/src/main/java/com/netflix/zuul/context/SessionContextFactory.java
+++ b/zuul-transport/src/main/java/com/netflix/zuul/context/SessionContextFactory.java
@@ -21,6 +21,6 @@ import rx.Observable;
 public interface SessionContextFactory<T, V>
 {
     public ZuulMessage create(SessionContext context, T nativeRequest, V nativeResponse);
-    public Observable<ZuulMessage> write(ZuulMessage msg, V nativeResponse);
+    public Observable<Void> write(ZuulMessage msg, V nativeResponse);
 
 }

--- a/zuul-transport/src/main/java/com/netflix/zuul/message/http/BasicRequestCompleteHandler.java
+++ b/zuul-transport/src/main/java/com/netflix/zuul/message/http/BasicRequestCompleteHandler.java
@@ -3,6 +3,7 @@ package com.netflix.zuul.message.http;
 import com.google.inject.Inject;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.stats.RequestMetricsPublisher;
+import rx.Observable;
 
 import javax.annotation.Nullable;
 
@@ -17,7 +18,7 @@ public class BasicRequestCompleteHandler implements RequestCompleteHandler
     private RequestMetricsPublisher requestMetricsPublisher;
 
     @Override
-    public void handle(HttpResponseMessage response)
+    public Observable<Void> handle(HttpResponseMessage response)
     {
         SessionContext context = response.getContext();
 
@@ -25,5 +26,7 @@ public class BasicRequestCompleteHandler implements RequestCompleteHandler
         if (requestMetricsPublisher != null) {
             requestMetricsPublisher.collectAndPublish(context);
         }
+
+        return Observable.empty();
     }
 }

--- a/zuul-transport/src/main/java/com/netflix/zuul/message/http/RequestCompleteHandler.java
+++ b/zuul-transport/src/main/java/com/netflix/zuul/message/http/RequestCompleteHandler.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.zuul.message.http;
 
-import com.netflix.zuul.message.http.HttpResponseMessage;
+import rx.Observable;
 
 /**
  * User: michaels@netflix.com
@@ -28,6 +28,6 @@ public interface RequestCompleteHandler
      *
      * @param response HttpResponseMessage
      */
-    public void handle(HttpResponseMessage response);
+    Observable<Void> handle(HttpResponseMessage response);
 }
 


### PR DESCRIPTION
Did the following API changes:

* Have `SessionContextFactory.write()` return `Observable<Void>` instead of `Observable<ZuulMessage>` as `ZuulMessage` is passed into the method anyways.
* Have `FilterProcessor` return `Single<ZuulMessage>` instead of `Observable<ZuulMessage>` as there always should be a single `ZuulMessage` after processing the filter chain.
* Have `RequestCompleteHandler` return `Observable<Void>` instead of `void`