### PR TITLE
Updated groovy version to fix build of zuul-simple-webapp

### DIFF
--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'groovy'
 
 dependencies {
     compile 'commons-io:commons-io:2.4'
-    compile 'org.codehaus.groovy:groovy-all:2.3.6'
+    compile 'org.codehaus.groovy:groovy-all:2.3.10'
     compile 'org.mockito:mockito-all:1.9.5'
     compile 'org.slf4j:slf4j-api:1.7.6'
     


### PR DESCRIPTION
This fixes the build of zuul-simple-webapp by updating the version of groovy in the core project. 