### PR TITLE
[2.x] Bug fixes

### DIFF
--- a/zuul-common/src/test/java/com/netflix/zuul/bytebuf/ByteBufUtilsTest.java
+++ b/zuul-common/src/test/java/com/netflix/zuul/bytebuf/ByteBufUtilsTest.java
@@ -1,0 +1,20 @@
+package com.netflix.zuul.bytebuf;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.Test;
+import rx.Observable;
+import rx.observers.TestSubscriber;
+
+public class ByteBufUtilsTest {
+
+    @Test(timeout = 60000)
+    public void testAggregateEmptySource() throws Exception {
+        TestSubscriber<ByteBuf> subscriber = new TestSubscriber<>();
+        ByteBufUtils.aggregate(Observable.<ByteBuf>empty(), 10).subscribe(subscriber);
+
+        subscriber.awaitTerminalEvent();
+        subscriber.assertNoErrors();
+
+        subscriber.assertNoValues();
+    }
+}

--- a/zuul-common/src/test/java/com/netflix/zuul/bytebuf/ByteBufUtilsTest.java
+++ b/zuul-common/src/test/java/com/netflix/zuul/bytebuf/ByteBufUtilsTest.java
@@ -15,6 +15,6 @@ public class ByteBufUtilsTest {
         subscriber.awaitTerminalEvent();
         subscriber.assertNoErrors();
 
-        subscriber.assertNoValues();
+        subscriber.assertValueCount(1);
     }
 }

--- a/zuul-filters/src/main/java/com/netflix/zuul/FilterProcessor.java
+++ b/zuul-filters/src/main/java/com/netflix/zuul/FilterProcessor.java
@@ -257,7 +257,7 @@ public class FilterProcessor {
                 // equal or above the requested.
                 int requiredPriority = msg.getContext().getFilterPriorityToApply();
                 if (isFilterPriority(filter, requiredPriority) && filter.shouldFilter(msg)) {
-                    resultObs = filter.applyAsync(msg).toSingle();
+                    resultObs = filter.applyAsync(msg).defaultIfEmpty(msg).toSingle();
                 } else {
                     resultObs = Single.just(defaultFilterResultChooser.call(msg));
                     info.status = SKIPPED;

--- a/zuul-transport-netty/src/main/java/com/netflix/zuul/eureka/EurekaHostSourceFactory.java
+++ b/zuul-transport-netty/src/main/java/com/netflix/zuul/eureka/EurekaHostSourceFactory.java
@@ -35,6 +35,7 @@ public class EurekaHostSourceFactory implements HostSourceFactory {
     public Observable<Instance<SocketAddress>> call(String vip) {
         return getInterestDsl().forVip(vip)
                                .asObservable()
+                               .filter(ii ->  ii != null)
                                .map(instance -> {
                                    final InstanceInfo ii = instance.getValue();
                                    final SocketAddress addr = toSocketAddress(ii);

--- a/zuul-transport-netty/src/main/java/com/netflix/zuul/rxnetty/RxNettySessionContextFactory.java
+++ b/zuul-transport-netty/src/main/java/com/netflix/zuul/rxnetty/RxNettySessionContextFactory.java
@@ -92,7 +92,7 @@ public class RxNettySessionContextFactory
             nativeResponse = nativeResponse.addHeader(entry.getKey(), entry.getValue());
         }
 
-        return nativeResponse.write(zuulResp.getBodyStream());
+        return zuulResp.hasBody() ? nativeResponse.write(zuulResp.getBodyStream()) : nativeResponse;
     }
 
 

--- a/zuul-transport-netty/src/main/java/com/netflix/zuul/rxnetty/origin/RxNettyOrigin.java
+++ b/zuul-transport-netty/src/main/java/com/netflix/zuul/rxnetty/origin/RxNettyOrigin.java
@@ -21,6 +21,7 @@ import com.netflix.zuul.message.http.HttpResponseMessageImpl;
 import com.netflix.zuul.origins.Origin;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.logging.LogLevel;
 import io.reactivex.netty.client.ConnectionProvider;
 import io.reactivex.netty.protocol.http.client.HttpClient;
 import io.reactivex.netty.protocol.http.client.HttpClientRequest;
@@ -53,7 +54,7 @@ public class RxNettyOrigin implements Origin {
             throw new IllegalArgumentException("VIP can not be null.");
         }
         this.vip = vip;
-        client = HttpClient.newClient(loadBalancer);
+        client = HttpClient.newClient(loadBalancer).enableWireLogging(LogLevel.DEBUG);
         client.subscribe(new HttpClientListener("origin-" + vip));
     }
 


### PR DESCRIPTION
- `ByteBufUtils.aggregate()` was not handling empty streams.
- Handling empty streams from filters.
- Add wire logging (debug level) for origins.
- Handling HTTP empty contents.