### PR TITLE
HTTP Client metrics fix.

### DIFF
--- a/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/HttpClientMetrics.java
+++ b/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/HttpClientMetrics.java
@@ -15,13 +15,13 @@ public class HttpClientMetrics extends HttpClientListener {
 
     public HttpClientMetrics(String monitorId) {
         super(monitorId);
-        hostsInPool = newGauge("requestBacklog", monitorId, new AtomicInteger());
+        hostsInPool = newGauge("hostsInPool", monitorId, new AtomicInteger());
         quarantinedHosts = newCounter("quarantinedHosts", monitorId);
         removedHosts = newCounter("removedHosts", monitorId);
     }
 
     public void onNewHost() {
-        hostsInPool.decrementAndGet();
+        hostsInPool.incrementAndGet();
     }
 
     public void onHostQuarantine() {


### PR DESCRIPTION
Name of the metrics was wrong and hostsInPool was doing decrement instead of increment.