### PR TITLE
remove routeVIP in favor of RoutingResult

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
@@ -24,6 +24,7 @@ package com.netflix.zuul.context;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.zuul.filters.FilterError;
 import com.netflix.zuul.message.http.HttpResponseMessage;
+import com.netflix.zuul.routing.RoutingResult;
 import com.netflix.zuul.stats.Timings;
 import com.netflix.zuul.util.DeepCopy;
 import org.junit.Test;
@@ -52,7 +53,6 @@ public class SessionContext extends HashMap<String, Object> implements Cloneable
 
 
     private static final String KEY_UUID = "_uuid";
-    private static final String KEY_VIP = "routeVIP";
     private static final String KEY_ENDPOINT = "_endpoint";
     private static final String KEY_STATIC_RESPONSE = "_static_response";
 
@@ -60,6 +60,7 @@ public class SessionContext extends HashMap<String, Object> implements Cloneable
     private static final String KEY_EVENT_PROPS = "eventProperties";
     private static final String KEY_FILTER_ERRORS = "_filter_errors";
     private static final String KEY_FILTER_EXECS = "_filter_executions";
+    private static final String ROUTING_RESULT = "_routing_result";
 
     public SessionContext()
     {
@@ -353,23 +354,12 @@ public class SessionContext extends HashMap<String, Object> implements Cloneable
         return shouldStopFilterProcessing;
     }
 
-    /**
-     * returns the routeVIP; that is the Eureka "vip" of registered instances
-     *
-     * @return
-     */
-    public String getRouteVIP() {
-        return (String) get(KEY_VIP);
+    public RoutingResult getRoutingResult() {
+        return (RoutingResult)get(ROUTING_RESULT);
     }
 
-    /**
-     * sets routeVIP; that is the Eureka "vip" of registered instances
-     *
-     * @return
-     */
-
-    public void setRouteVIP(String sVip) {
-        set(KEY_VIP, sVip);
+    public void setRoutingResult(RoutingResult routingResult) {
+        set(ROUTING_RESULT, routingResult);
     }
 
     public void setEndpoint(String endpoint)

--- a/zuul-core/src/main/java/com/netflix/zuul/routing/Route.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/routing/Route.java
@@ -1,0 +1,75 @@
+package com.netflix.zuul.routing;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Created by chrisp on 6/9/15.
+ */
+public class Route {
+
+    private final String vip;
+    private final boolean fallback;
+    private final boolean dryRun;
+
+    public Route(String vip) {
+        this(vip, false, false);
+    }
+
+    public Route(String vip, boolean fallback) {
+        this(vip, fallback, false);
+    }
+
+    public Route(String vip, boolean fallback, boolean dryRun) {
+        this.fallback = fallback;
+        checkArgument(vip != null && vip.trim().length() > 0);
+        this.vip = vip;
+        this.dryRun = dryRun;
+    }
+
+    public String getVip() {
+        return vip;
+    }
+
+
+    public boolean shouldFallback() {
+        return fallback;
+    }
+
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
+    public static Route asDryRun(Route route) {
+        return new Route(route.vip, route.fallback, true);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Route route = (Route) o;
+
+        if (fallback != route.fallback) return false;
+        if (dryRun != route.dryRun) return false;
+        return vip.equals(route.vip);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = vip.hashCode();
+        result = 31 * result + (fallback ? 1 : 0);
+        result = 31 * result + (dryRun ? 1 : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Route{" +
+                "vip='" + vip + '\'' +
+                ", fallback=" + fallback +
+                ", dryRun=" + dryRun +
+                '}';
+    }
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/routing/RoutingResult.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/routing/RoutingResult.java
@@ -1,0 +1,157 @@
+package com.netflix.zuul.routing;
+
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.netflix.util.Pair;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by chrisp on 5/18/15.
+ */
+public class RoutingResult {
+
+    private final ImmutableList.Builder<Pair<String, Route>> assignedRoutes = new ImmutableList.Builder<>();
+
+    private Route fallback = null;
+    private Route assigned = null;
+
+    public RoutingResult() {
+    }
+
+    public void assign(Route route, String assignedBy) {
+        this.assignedRoutes.add(new Pair(assignedBy, route));
+        if (!route.isDryRun()) {
+            if (route.shouldFallback()) {
+                this.fallback = assigned;
+            }
+            this.assigned = route;
+        }
+    }
+
+    public Route getAssigned() {
+        return assigned;
+    }
+
+    public List<Pair<String, Route>> getTrace() {
+        return assignedRoutes.build();
+    }
+
+    public Optional<Route> getFallback() {
+        return this.assigned.shouldFallback() ? Optional.fromNullable(fallback) : Optional.absent();
+    }
+
+    @Override
+    public String toString() {
+        return "RoutingResult{" +
+                "assignedRoutes=" + assignedRoutes.build() +
+                ", fallback=" + fallback +
+                ", assigned=" + assigned +
+                '}';
+    }
+
+    public static class TestUnit {
+
+        private RoutingResult routingResult;
+
+        @Before
+        public void setup() {
+            routingResult = new RoutingResult();
+        }
+
+
+        @Test
+        public void singleRoute() {
+            Route r = new Route("test", true);
+            routingResult.assign(r, "test");
+
+            assertThat(routingResult.getAssigned(), is(r));
+            assertThat(routingResult.getFallback().isPresent(), is(false));
+        }
+
+        @Test
+        public void singleRouteNoFallback() {
+            Route r = new Route("test", false);
+            routingResult.assign(r, "test");
+            assertThat(routingResult.getAssigned(), is(r));
+            assertThat(routingResult.getFallback().isPresent(), is(false));
+        }
+
+        @Test
+        public void multipleShouldNotFallback() {
+            Route r1 = new Route("test", true);
+            Route r2 = new Route("test2", false);
+            routingResult.assign(r1, "test");
+            routingResult.assign(r2, "test");
+
+            assertThat(routingResult.getAssigned(), is(r2));
+            assertThat(routingResult.getFallback(), is(Optional.absent()));
+        }
+
+        @Test
+        public void multipleShouldFallback() {
+            Route r1 = new Route("test", true);
+            Route r2 = new Route("test2", true);
+            routingResult.assign(r1, "test");
+            routingResult.assign(r2, "test");
+
+            assertThat(routingResult.getAssigned(), is(r2));
+            assertThat(routingResult.getFallback().isPresent(), is(true));
+            assertThat(routingResult.getFallback().get(), is(r1));
+        }
+
+        @Test
+        public void noFallbackStreak() {
+            Route r1 = new Route("test", false);
+            Route r2 = new Route("test2", false);
+            Route r3 = new Route("test3", false);
+            Route r4 = new Route("test4", true);
+            routingResult.assign(r1, "test");
+            routingResult.assign(r2, "test");
+            routingResult.assign(r3, "test");
+            routingResult.assign(r4, "test");
+
+            assertThat(routingResult.getAssigned(), is(r4));
+            assertThat(routingResult.getFallback().isPresent(), is(true));
+            assertThat(routingResult.getFallback().get(), is(r3));
+        }
+
+        @Test
+        public void dryRun() {
+            Route r1 = new Route("test", true);
+            Route r2 = new Route("test2", true);
+            Route r3 = new Route("test3", true, true);
+            routingResult.assign(r1, "test");
+            routingResult.assign(r2, "test");
+            routingResult.assign(r3, "test");
+
+            assertThat(routingResult.getAssigned(), is(r2));
+            assertThat(routingResult.getFallback().isPresent(), is(true));
+            assertThat(routingResult.getFallback().get(), is(r1));
+        }
+
+        @Test
+        public void dryRunInBetween() {
+            Route r1 = new Route("test", true);
+            Route r2 = new Route("test2", false, true);
+            Route r3 = new Route("test3", true);
+            routingResult.assign(r1, "test");
+            routingResult.assign(r2, "test");
+            routingResult.assign(r3, "test");
+
+            assertThat(routingResult.getAssigned(), is(r3));
+            assertThat(routingResult.getFallback().isPresent(), is(true));
+            assertThat(routingResult.getFallback().get(), is(r1));
+        }
+
+    }
+
+
+
+}

--- a/zuul-netty-sample/src/main/filters/inbound/Routing.groovy
+++ b/zuul-netty-sample/src/main/filters/inbound/Routing.groovy
@@ -18,6 +18,7 @@ package inbound
 import com.netflix.zuul.message.http.HttpRequestMessage
 import com.netflix.zuul.context.SessionContext
 import com.netflix.zuul.filters.http.HttpInboundSyncFilter
+import com.netflix.zuul.routing.Route
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -47,20 +48,19 @@ class Routing extends HttpInboundSyncFilter
 
         // Choose vip to proxy to.
         if (request.getPath().startsWith("/yahoo/") || "www.yahoo.com" == request.getHeaders().getFirst("Host")) {
-            context.setRouteVIP("yahoo")
+            context.getRoutingResult().assign(new Route("yahoo"), Routing.class.getName())
             context.setEndpoint("endpoint.ZuulNFRequest")
         }
         else if (request.getPath() == "/blah") {
             // TEST - make use the static filters.
-            context.setRouteVIP(null)
             context.setEndpoint("endpoint.ExampleStaticFilter")
         }
         else if (request.getPath() == "/simulator/") {
-            context.setRouteVIP("simulator")
+            context.getRoutingResult().assign(new Route("simulator"), Routing.class.getName())
             context.setEndpoint("endpoint.ZuulNFRequest")
         }
         else {
-            context.setRouteVIP("api_netflix")
+            context.getRoutingResult().assign(new Route("api_netflix"), Routing.class.getName())
             context.setEndpoint("endpoint.ZuulNFRequest")
         }
 

--- a/zuul-netty-sample/src/main/java/com/netflix/zuul/context/SampleSessionContextDecorator.java
+++ b/zuul-netty-sample/src/main/java/com/netflix/zuul/context/SampleSessionContextDecorator.java
@@ -16,6 +16,7 @@
 package com.netflix.zuul.context;
 
 import com.netflix.zuul.origins.OriginManager;
+import com.netflix.zuul.routing.RoutingResult;
 
 import javax.inject.Inject;
 import java.util.UUID;
@@ -42,6 +43,7 @@ public class SampleSessionContextDecorator implements SessionContextDecorator
 
         // Generate a UUID for this session.
         ctx.setUUID(UUID.randomUUID().toString());
+        ctx.setRoutingResult(new RoutingResult());
 
         return ctx;
     }

--- a/zuul-servletapi-sample/src/main/java/com/netflix/zuul/context/SampleSessionContextDecorator.java
+++ b/zuul-servletapi-sample/src/main/java/com/netflix/zuul/context/SampleSessionContextDecorator.java
@@ -16,6 +16,7 @@
 package com.netflix.zuul.context;
 
 import com.netflix.zuul.origins.OriginManager;
+import com.netflix.zuul.routing.RoutingResult;
 
 import javax.inject.Inject;
 import java.util.UUID;
@@ -42,7 +43,7 @@ public class SampleSessionContextDecorator implements SessionContextDecorator
 
         // Generate a UUID for this session.
         ctx.setUUID(UUID.randomUUID().toString());
-
+        ctx.setRoutingResult(new RoutingResult());
         return ctx;
     }
 }


### PR DESCRIPTION
keeps track of who assigned the vip and allows for fallback and dry run semantics