### PR TITLE
Specially handle encoded ampersands in query string

### DIFF
--- a/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRoutingFilter.groovy
+++ b/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRoutingFilter.groovy
@@ -258,8 +258,24 @@ class SimpleHostRoutingFilter extends ZuulFilter {
             return ""
         }
 
-        String decodedQueryString = URLDecoder.decode(currentQueryString, encoding)
-        return new URI(null, null, null, decodedQueryString, null).toString()
+        String rebuiltQueryString = ""
+        for (String keyPair : currentQueryString.split("&")) {
+            if (rebuiltQueryString.length() > 0) {
+                rebuiltQueryString = rebuiltQueryString + "&"
+            }
+            def (name,value) = keyPair.split("=", 2)
+            if (value != null) {
+                value = URLDecoder.decode(value, encoding)
+                value = new URI(null, null, null, value, null).toString().substring(1)
+                value = value.replaceAll('&', '%26')
+                rebuiltQueryString = rebuiltQueryString + name + "=" + value
+            } else {
+                name = URLDecoder.decode(name, encoding)
+                value = new URI(null, null, null, value, null).toString().substring(1)
+                rebuiltQueryString = rebuiltQueryString + value
+            }
+        }
+        return "?" + rebuiltQueryString
     }
 
     HttpHost getHttpHost() {


### PR DESCRIPTION
If you receive a query string with an encoded ampersand and then follow
the decode and re-encode model to remove invalid query string
parameters, you end up with a no longer encoded ampersand, breaking the
query string.

Example:
Valid query string: ?keywords="Mine+%26+Yours"
When decoded and re-encoded, looks like: ?keywords=%22Mine%20&%20Yours%22
There are now 2 query params instead of 1 because of the ampersand.

This change now maintains the ampersand encoding:
?keywords=%22Mine%20%26%20Yours%22

PR that added the decode and re-encode step: https://github.com/Netflix/zuul/pull/161