### PR TITLE
Handle query params without an `=`

### DIFF
--- a/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRoutingFilter.groovy
+++ b/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRoutingFilter.groovy
@@ -263,14 +263,15 @@ class SimpleHostRoutingFilter extends ZuulFilter {
             if (rebuiltQueryString.length() > 0) {
                 rebuiltQueryString = rebuiltQueryString + "&"
             }
-            def (name,value) = keyPair.split("=", 2)
-            if (value != null) {
+
+            if (keyPair.contains("=")) {
+                def (name,value) = keyPair.split("=", 2)
                 value = URLDecoder.decode(value, encoding)
                 value = new URI(null, null, null, value, null).toString().substring(1)
                 value = value.replaceAll('&', '%26')
                 rebuiltQueryString = rebuiltQueryString + name + "=" + value
             } else {
-                name = URLDecoder.decode(name, encoding)
+                def value = URLDecoder.decode(keyPair, encoding)
                 value = new URI(null, null, null, value, null).toString().substring(1)
                 rebuiltQueryString = rebuiltQueryString + value
             }


### PR DESCRIPTION
If a query string contained a key pair without an `=` in the string then
it would cause an array out of bounds exception because the split was
not wrapped defensively to test for the presence of an `=` first.

Example: ?&abc=123&xyz
Split on `&` would look like: `['', 'abc=123', 'xyz']`
Both cases are now handled where the string is missing `=`

This defensive programing was unfortunately missed in my previous PR https://github.com/Netflix/zuul/pull/198