### PR TITLE
Upgrading to latest RxNetty snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,4 +95,11 @@ subprojects {
         compile(group: 'com.google.inject.extensions', name: 'guice-servlet', version: "${versions_guice}")
         compile(group: 'com.google.inject.extensions', name: 'guice-throwingproviders', version: "${versions_guice}")
     }
+
+
+    test {
+        testLogging {
+            showStandardStreams = true
+        }
+    }
 }

--- a/zuul-netty/build.gradle
+++ b/zuul-netty/build.gradle
@@ -2,9 +2,7 @@
 dependencies {
     compile project(':zuul-core')
 
-    compile 'io.reactivex:rxnetty-http:0.5.0-SNAPSHOT'
-    compile 'io.reactivex:rxnetty-spectator-http:0.5.0-SNAPSHOT'
-    compile "com.netflix.ocelli:ocelli-rxnetty:0.0.8-SNAPSHOT"
-    compile "com.netflix.ocelli:ocelli-eureka:0.0.8-SNAPSHOT"
+    compile 'io.reactivex:rxnetty-http:0.5.2-SNAPSHOT'
+    compile 'io.reactivex:rxnetty-spectator-http:0.5.2-SNAPSHOT'
     compile 'com.netflix.numerus:numerus:1.1'
 }

--- a/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/HostSourceFactory.java
+++ b/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/HostSourceFactory.java
@@ -1,10 +1,8 @@
 package com.netflix.zuul.rxnetty;
 
-import netflix.ocelli.Instance;
+import io.reactivex.netty.client.Host;
 import rx.Observable;
 import rx.functions.Func1;
 
-import java.net.SocketAddress;
-
-public interface HostSourceFactory extends Func1<String, Observable<Instance<SocketAddress>>> {
+public interface HostSourceFactory extends Func1<String, Observable<Host>> {
 }

--- a/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/HttpClientListenerImpl.java
+++ b/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/HttpClientListenerImpl.java
@@ -4,29 +4,43 @@ import com.netflix.numerus.NumerusProperty;
 import com.netflix.numerus.NumerusRollingNumber;
 import com.netflix.numerus.NumerusRollingNumberEvent;
 import com.netflix.numerus.NumerusRollingPercentile;
-import netflix.ocelli.rxnetty.FailureListener;
-import netflix.ocelli.rxnetty.protocol.http.WeightedHttpClientListener;
+import com.netflix.zuul.rxnetty.HttpClientListenerImpl.HostMetrics.EventType;
+import io.reactivex.netty.protocol.http.client.events.HttpClientEventsListener;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.netflix.numerus.NumerusProperty.Factory.asProperty;
+import static com.netflix.numerus.NumerusProperty.Factory.*;
 
-public class HttpClientListenerImpl extends WeightedHttpClientListener {
+public class HttpClientListenerImpl extends HttpClientEventsListener {
 
-    private final HostMetrics hostMetrics = new HostMetrics();
-    private final FailureListener failureListener;
-    private final HttpClientMetrics clientMetrics;
+    private final HostMetrics hostMetrics;
 
-    public HttpClientListenerImpl(FailureListener failureListener, HttpClientMetrics clientMetrics) {
-        this.failureListener = failureListener;
-        this.clientMetrics = clientMetrics;
-        clientMetrics.onNewHost();
+    public HttpClientListenerImpl(HostMetrics hostMetrics) {
+        this.hostMetrics = hostMetrics;
     }
 
-    @Override
+    public HttpClientListenerImpl() {
+        this(new HostMetrics());
+    }
+
     public int getWeight() {
+        if (getConnectFailedInCurrentWindow() > 2) {
+            /*If more than two connect failed in the current window, then consider host unavailable.*/
+            return Integer.MIN_VALUE;
+        }
+
+        int additionCost = 0;
+        if (getThrottledRequestsInCurrentWindow() > 3) {
+            /*If we receive more than 3 throttled responses, then add an additional cost to lower the probability of
+            selection*/
+            additionCost = 60000; /*Will be selected in favor of servers that have 95 percentile latency > 1 min*/
+        }
+
         /*Higher 95 percentile latency, lower weight*/
-        return Integer.MAX_VALUE - hostMetrics.getRollingLatencyPercentile().getPercentile(95);
+        return Integer.MAX_VALUE - (hostMetrics.getRollingLatencyPercentile().getPercentile(95) + additionCost);
     }
 
     @Override
@@ -39,17 +53,14 @@ public class HttpClientListenerImpl extends WeightedHttpClientListener {
         hostMetrics.getRollingCounter().add(HostMetrics.EventType.PENDING_REQUESTS, -1);
     }
 
+    public boolean isUnusable(int weight) {
+        return weight == Integer.MIN_VALUE;
+    }
+
     @Override
     public void onResponseHeadersReceived(int responseCode, long duration, TimeUnit timeUnit) {
         if (responseCode == 503) {
             hostMetrics.getRollingCounter().add(HostMetrics.EventType.SERVICE_UNAVAILABLE, 1);
-            long unavailableInCurrentWindow =
-                    hostMetrics.getRollingCounter().getValueOfLatestBucket(HostMetrics.EventType.SERVICE_UNAVAILABLE);
-            if (unavailableInCurrentWindow > 3) {
-                /*If we receive more than 3 throttled responses, then quarantine host*/
-                failureListener.quarantine(1, TimeUnit.MINUTES);
-                clientMetrics.onHostQuarantine();
-            }
         }
         hostMetrics.getRollingLatencyPercentile().addValue((int) duration);
     }
@@ -57,24 +68,27 @@ public class HttpClientListenerImpl extends WeightedHttpClientListener {
     @Override
     public void onConnectFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
         hostMetrics.getRollingCounter().add(HostMetrics.EventType.CONNECT_FAILURES, 1);
-        long connectFailedInCurrentWindow =
-                hostMetrics.getRollingCounter().getValueOfLatestBucket(HostMetrics.EventType.CONNECT_FAILURES);
-        if (connectFailedInCurrentWindow > 2) {
-            /*If more than two connect failed in the current window, then consider host unavailable.*/
-            failureListener.remove();
-            clientMetrics.onHostRemoved();
-        }
     }
 
-    public static final class HostMetrics {
+    protected long getConnectFailedInCurrentWindow() {
+        return hostMetrics.getRollingCounter().getValueOfLatestBucket(EventType.CONNECT_FAILURES);
+    }
+
+    protected long getThrottledRequestsInCurrentWindow() {
+        return hostMetrics.getRollingCounter().getValueOfLatestBucket(EventType.SERVICE_UNAVAILABLE);
+    }
+
+    public static class HostMetrics {
 
         private static final NumerusProperty<Integer> latency_timeInMilliseconds = asProperty(60000);
-        private static final NumerusProperty<Integer> latency_numberOfBuckets = asProperty(12); // 12 buckets at 5000ms each
+        private static final NumerusProperty<Integer> latency_numberOfBuckets = asProperty(12);
+                // 12 buckets at 5000ms each
         private static final NumerusProperty<Integer> latency_bucketDataLength = asProperty(1000);
         private static final NumerusProperty<Boolean> latency_enabled = asProperty(true);
 
         private static final NumerusProperty<Integer> count_timeInMilliseconds = asProperty(10000);
-        private static final NumerusProperty<Integer> count_numberOfBuckets = asProperty(10); // 11 buckets at 1000ms each
+        private static final NumerusProperty<Integer> count_numberOfBuckets = asProperty(10);
+                // 11 buckets at 1000ms each
 
         private final NumerusRollingPercentile p = new NumerusRollingPercentile(latency_timeInMilliseconds,
                                                                                 latency_numberOfBuckets,
@@ -118,4 +132,35 @@ public class HttpClientListenerImpl extends WeightedHttpClientListener {
         }
     }
 
+
+    public static class UnitTest {
+
+        @Test
+        public void testWithConnectFailures() {
+            HttpClientListenerImpl listener = new HttpClientListenerImpl();
+
+            for (int i =0; i < 4; i++) {
+                listener.onConnectFailed(1, TimeUnit.MILLISECONDS, new NullPointerException());
+            }
+
+            Assert.assertEquals("Unexpected weight.", Integer.MIN_VALUE, listener.getWeight());
+        }
+
+        @Test
+        public void testWithThrottle() {
+            HttpClientListenerImpl listener = new HttpClientListenerImpl() {
+                @Override
+                protected long getThrottledRequestsInCurrentWindow() {
+                    return 5;
+                }
+            };
+
+            for (int i =0; i < 5; i++) {
+                listener.onResponseHeadersReceived(503, 1, TimeUnit.MILLISECONDS);
+            }
+
+            Assert.assertEquals("Unexpected weight.", Integer.MAX_VALUE - 60000, listener.getWeight());
+        }
+    }
 }
+

--- a/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/HttpClientMetrics.java
+++ b/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/HttpClientMetrics.java
@@ -10,39 +10,37 @@ import static io.reactivex.netty.spectator.SpectatorUtils.*;
 public class HttpClientMetrics extends HttpClientListener {
 
     private final AtomicInteger hostsInPool;
-    private final Counter quarantinedHosts;
-    private final Counter removedHosts;
+    private final Counter foundUnusableHosts;
+    private final Counter noUsableHosts;
 
     public HttpClientMetrics(String monitorId) {
         super(monitorId);
         hostsInPool = newGauge("hostsInPool", monitorId, new AtomicInteger());
-        quarantinedHosts = newCounter("quarantinedHosts", monitorId);
-        removedHosts = newCounter("removedHosts", monitorId);
+        foundUnusableHosts = newCounter("foundUnusableHosts", monitorId);
+        noUsableHosts = newCounter("noUnusableHosts", monitorId);
     }
 
-    public void onNewHost() {
-        hostsInPool.incrementAndGet();
+    public void setHostsInPool(int hostsInPool) {
+        this.hostsInPool.set(hostsInPool);
     }
 
-    public void onHostQuarantine() {
-        quarantinedHosts.increment();
-        hostsInPool.decrementAndGet();
+    public void foundTwoUnusableHosts() {
+        this.foundUnusableHosts.increment();
     }
 
-    public void onHostRemoved() {
-        removedHosts.increment();
-        hostsInPool.decrementAndGet();
+    public void noUsableHostsFound() {
+        this.noUsableHosts.increment();
     }
 
-    public int getHostsInPool() {
-        return hostsInPool.intValue();
+    public AtomicInteger getHostsInPool() {
+        return hostsInPool;
     }
 
-    public long getQuarantinedHosts() {
-        return quarantinedHosts.count();
+    public Counter getFoundUnusableHosts() {
+        return foundUnusableHosts;
     }
 
-    public long getRemovedHosts() {
-        return removedHosts.count();
+    public Counter getNoUsableHosts() {
+        return noUsableHosts;
     }
 }

--- a/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/PowerOfTwoChoices.java
+++ b/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/PowerOfTwoChoices.java
@@ -70,7 +70,7 @@ class PowerOfTwoChoices implements LoadBalancingStrategy<ByteBuf, ByteBuf> {
             }
 
             private HostHolder<ByteBuf, ByteBuf> selectNext() {
-                for (int i = 0; i < 3; i++) {
+                for (int i = 0; i < 5; i++) {
                     int pos  = rand.nextInt(hosts.size());
                     HostHolder<ByteBuf, ByteBuf> first  = hosts.get(pos);
                     int pos2 = (rand.nextInt(hosts.size() - 1) + pos + 1) % hosts.size();
@@ -144,7 +144,7 @@ class PowerOfTwoChoices implements LoadBalancingStrategy<ByteBuf, ByteBuf> {
             sub.assertError(NoHostsAvailableException.class);
 
             Assert.assertEquals("Unexpected number of hosts in the pool.", 2, rule.clientMetrics.getHostsInPool().get());
-            Assert.assertEquals("Unexpected number of Unusable hosts found count.", 3,
+            Assert.assertEquals("Unexpected number of Unusable hosts found count.", 5,
                                 rule.clientMetrics.getFoundUnusableHosts().count());
             Assert.assertEquals("Unexpected number of no usable hosts count.", 1,
                                 rule.clientMetrics.getNoUsableHosts().count());
@@ -177,7 +177,7 @@ class PowerOfTwoChoices implements LoadBalancingStrategy<ByteBuf, ByteBuf> {
                 return new Statement() {
                     @Override
                     public void evaluate() throws Throwable {
-                        clientMetrics = new HttpClientMetrics("");
+                        clientMetrics = new HttpClientMetrics(StrategyRule.this.toString());
                         strategy = new PowerOfTwoChoices(clientMetrics);
                         base.evaluate();
                     }

--- a/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/PowerOfTwoChoices.java
+++ b/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/PowerOfTwoChoices.java
@@ -1,0 +1,206 @@
+package com.netflix.zuul.rxnetty;
+
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.channel.Connection;
+import io.reactivex.netty.client.ConnectionProvider;
+import io.reactivex.netty.client.Host;
+import io.reactivex.netty.client.HostConnector;
+import io.reactivex.netty.client.loadbalancer.HostHolder;
+import io.reactivex.netty.client.loadbalancer.LoadBalancingStrategy;
+import io.reactivex.netty.client.loadbalancer.NoHostsAvailableException;
+import io.reactivex.netty.events.EventPublisher;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import rx.Observable;
+import rx.observers.TestSubscriber;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import static java.lang.Integer.*;
+
+class PowerOfTwoChoices implements LoadBalancingStrategy<ByteBuf, ByteBuf> {
+
+    private final HttpClientMetrics clientMetrics;
+
+    PowerOfTwoChoices(HttpClientMetrics clientMetrics) {
+        this.clientMetrics = clientMetrics;
+    }
+
+    @Override
+    public ConnectionProvider<ByteBuf, ByteBuf> newStrategy(final List<HostHolder<ByteBuf, ByteBuf>> hosts) {
+        clientMetrics.setHostsInPool(hosts.size());
+
+        return new ConnectionProvider<ByteBuf, ByteBuf>() {
+
+            private final Random rand = new Random();
+
+            @Override
+            public Observable<Connection<ByteBuf, ByteBuf>> newConnectionRequest() {
+                HostHolder<ByteBuf, ByteBuf> selected;
+                if (hosts.isEmpty()) {
+                    clientMetrics.noUsableHostsFound();
+                    return Observable.error(NoHostsAvailableException.EMPTY_INSTANCE);
+                }
+                else if (hosts.size() == 1) {
+                    HostHolder<ByteBuf, ByteBuf> holder = hosts.get(0);
+                    HttpClientListenerImpl eventListener = (HttpClientListenerImpl) holder.getEventListener();
+                    if (eventListener.isUnusable(eventListener.getWeight())) {
+                        clientMetrics.noUsableHostsFound();
+                        return Observable.error(new NoHostsAvailableException("No usable hosts found."));
+                    }
+                    selected = holder;
+                }
+                else {
+                    selected = selectNext();
+                    if (null == selected) {
+                        clientMetrics.noUsableHostsFound();
+                        return Observable.error(new NoHostsAvailableException("No usable hosts found after 3 tries."));
+                    }
+                }
+
+                return selected.getConnector().getConnectionProvider().newConnectionRequest();
+            }
+
+            private HostHolder<ByteBuf, ByteBuf> selectNext() {
+                for (int i = 0; i < 3; i++) {
+                    int pos  = rand.nextInt(hosts.size());
+                    HostHolder<ByteBuf, ByteBuf> first  = hosts.get(pos);
+                    int pos2 = (rand.nextInt(hosts.size() - 1) + pos + 1) % hosts.size();
+                    HostHolder<ByteBuf, ByteBuf> second = hosts.get(pos2);
+
+                    int w1 = ((HttpClientListenerImpl) first.getEventListener()).getWeight();
+                    int w2 = ((HttpClientListenerImpl) second.getEventListener()).getWeight();
+
+                    if (w1 > w2) {
+                        return first;
+                    } else if (w1 < w2) {
+                        return second;
+                    } else if (((HttpClientListenerImpl) first.getEventListener()).isUnusable(w1)) {
+                        clientMetrics.foundTwoUnusableHosts();
+                    } else {
+                        return first;
+                    }
+                }
+                return null;
+            }
+        };
+    }
+
+    @Override
+    public HostHolder<ByteBuf, ByteBuf> toHolder(HostConnector<ByteBuf, ByteBuf> connector) {
+        return new HostHolder<>(connector, new HttpClientListenerImpl());
+    }
+
+    public static class UnitTest {
+
+        @Rule
+        public final StrategyRule rule = new StrategyRule();
+
+        @Test
+        public void testNoHosts() {
+            ConnectionProvider<ByteBuf, ByteBuf> cp = rule.strategy.newStrategy(Collections.emptyList());
+            TestSubscriber<Connection<ByteBuf, ByteBuf>> sub = new TestSubscriber<>();
+            cp.newConnectionRequest().subscribe(sub);
+
+            sub.awaitTerminalEvent();
+            sub.assertError(NoHostsAvailableException.class);
+            Assert.assertEquals("Unexpected number of hosts in the pool.", 0, rule.clientMetrics.getHostsInPool().get());
+            Assert.assertEquals("Unexpected number of no usable hosts count.", 1,
+                                rule.clientMetrics.getNoUsableHosts().count());
+        }
+
+        @Test
+        public void testSingleUnusableHost() {
+            ConnectionProvider<ByteBuf, ByteBuf> cp = rule.strategy.newStrategy(rule.newHostStream(MIN_VALUE));
+            TestSubscriber<Connection<ByteBuf, ByteBuf>> sub = new TestSubscriber<>();
+            cp.newConnectionRequest().subscribe(sub);
+
+            sub.awaitTerminalEvent();
+            sub.assertError(NoHostsAvailableException.class);
+
+            Assert.assertEquals("Unexpected number of hosts in the pool.", 1, rule.clientMetrics.getHostsInPool().get());
+            Assert.assertEquals("Unexpected number of Unusable hosts found count.", 0,
+                                rule.clientMetrics.getFoundUnusableHosts().count());
+            Assert.assertEquals("Unexpected number of no usable hosts count.", 1,
+                                rule.clientMetrics.getNoUsableHosts().count());
+        }
+
+        @Test
+        public void testMultipleUnusableHost() {
+            ConnectionProvider<ByteBuf, ByteBuf> cp = rule.strategy.newStrategy(rule.newHostStream(MIN_VALUE,
+                                                                                                   MIN_VALUE));
+            TestSubscriber<Connection<ByteBuf, ByteBuf>> sub = new TestSubscriber<>();
+            cp.newConnectionRequest().subscribe(sub);
+
+            sub.awaitTerminalEvent();
+            sub.assertError(NoHostsAvailableException.class);
+
+            Assert.assertEquals("Unexpected number of hosts in the pool.", 2, rule.clientMetrics.getHostsInPool().get());
+            Assert.assertEquals("Unexpected number of Unusable hosts found count.", 3,
+                                rule.clientMetrics.getFoundUnusableHosts().count());
+            Assert.assertEquals("Unexpected number of no usable hosts count.", 1,
+                                rule.clientMetrics.getNoUsableHosts().count());
+        }
+
+        @Test
+        public void testUsableAndUnusable() {
+            ConnectionProvider<ByteBuf, ByteBuf> cp = rule.strategy.newStrategy(rule.newHostStream(10,
+                                                                                                   MIN_VALUE));
+            TestSubscriber<Connection<ByteBuf, ByteBuf>> sub = new TestSubscriber<>();
+            cp.newConnectionRequest().subscribe(sub);
+
+            sub.awaitTerminalEvent();
+            sub.assertNoErrors();
+
+            Assert.assertEquals("Unexpected number of hosts in the pool.", 2, rule.clientMetrics.getHostsInPool().get());
+            Assert.assertEquals("Unexpected number of Unusable hosts found count.", 0,
+                                rule.clientMetrics.getFoundUnusableHosts().count());
+            Assert.assertEquals("Unexpected number of no usable hosts count.", 0,
+                                rule.clientMetrics.getNoUsableHosts().count());
+        }
+
+        public static class StrategyRule extends ExternalResource {
+
+            private PowerOfTwoChoices strategy;
+            private HttpClientMetrics clientMetrics;
+
+            @Override
+            public Statement apply(final Statement base, Description description) {
+                return new Statement() {
+                    @Override
+                    public void evaluate() throws Throwable {
+                        clientMetrics = new HttpClientMetrics("");
+                        strategy = new PowerOfTwoChoices(clientMetrics);
+                        base.evaluate();
+                    }
+                };
+            }
+
+            public List<HostHolder<ByteBuf, ByteBuf>> newHostStream(int... weights) {
+                List<HostHolder<ByteBuf, ByteBuf>> toReturn = new ArrayList<>();
+                for (int weight : weights) {
+                    ConnectionProvider<ByteBuf, ByteBuf> dummy = Observable::empty;
+                    Host h = new Host(new InetSocketAddress(0));
+                    EventPublisher publisher = () -> false;
+                    HostConnector<ByteBuf, ByteBuf> connector = new HostConnector<>(h, dummy, null, publisher, null);
+                    toReturn.add(new HostHolder<>(connector, new HttpClientListenerImpl() {
+                        @Override
+                        public int getWeight() {
+                            return weight;
+                        }
+                    }));
+                }
+                return toReturn;
+            }
+        }
+
+    }
+}

--- a/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/RxNettyOriginManager.java
+++ b/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/RxNettyOriginManager.java
@@ -21,12 +21,11 @@ import com.netflix.config.DynamicStringMapProperty;
 import com.netflix.governator.annotations.WarmUp;
 import com.netflix.zuul.origins.Origin;
 import com.netflix.zuul.origins.OriginManager;
-import netflix.ocelli.Instance;
+import io.reactivex.netty.client.Host;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
 
-import java.net.SocketAddress;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -87,7 +86,7 @@ public class RxNettyOriginManager implements OriginManager
 
     private void initOrigin(String originName, String vip)
     {
-        Observable<Instance<SocketAddress>> hosts = hostSourceFactory.call(vip);
+        Observable<Host> hosts = hostSourceFactory.call(vip);
         this.origins.put(originName, RxNettyOrigin.newOrigin(originName, vip, hosts));
     }
 

--- a/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/SnapshotHostSourceAdapter.java
+++ b/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/SnapshotHostSourceAdapter.java
@@ -1,0 +1,218 @@
+package com.netflix.zuul.rxnetty;
+
+import io.reactivex.netty.client.Host;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import rx.Observable;
+import rx.Scheduler;
+import rx.functions.Func0;
+import rx.observers.TestSubscriber;
+import rx.schedulers.Schedulers;
+import rx.schedulers.TestScheduler;
+import rx.subjects.PublishSubject;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class SnapshotHostSourceAdapter {
+
+    public static Observable<Host> toHostStream(Func0<List<SocketAddress>> sourceFactory,
+                                                Observable<Long> pollingSource) {
+        return pollingSource.onBackpressureDrop()
+                            .scan(new HashMap<SocketAddress, Host>(), (lifecycles, tick) -> lifecycles)
+                            .skip(1) /*Scan sends the initial value first, which isn't required for us*/
+                            .flatMap(lifecycles -> {
+                                List<SocketAddress> hosts = sourceFactory.call();
+
+                                final Set<SocketAddress> hostsToRemove = new HashSet<>(lifecycles.keySet());
+                                final Set<Host> hostsAdded = new HashSet<>();
+
+                                for (SocketAddress host : hosts) {
+                                    hostsToRemove.remove(host);
+
+                                    Host lastSeen = lifecycles.get(host);
+                                    if (null == lastSeen) {
+                                        Host h = new Host(host, PublishSubject.create());
+                                        hostsAdded.add(h);
+                                        lifecycles.put(host, h);
+                                    }
+                                }
+
+                                for (SocketAddress socketAddress : hostsToRemove) {
+                                    Host removed = lifecycles.remove(socketAddress);
+                                    ((PublishSubject) removed.getCloseNotifier()).onCompleted();
+                                }
+
+                                return Observable.from(hostsAdded);
+
+                            }, 1 /*Have at most one pending calculation*/);
+    }
+
+    public static Observable<Host> toHostStream(Func0<List<SocketAddress>> sourceFactory) {
+        return toHostStream(sourceFactory, Observable.interval(30, TimeUnit.SECONDS));
+    }
+
+    public static class UnitTest {
+
+        @Rule
+        public AdapterRule rule = new AdapterRule();
+
+        @Test(timeout = 60000)
+        public void testAdd() {
+            rule.setNextHostsToEmit(Arrays.asList(1000, 1001));
+            rule.subscribeToStream();
+
+            rule.nextTick();
+
+            List<Host> hosts = rule.getHosts(2);
+            rule.assertNoHostsCompleted(hosts);
+        }
+
+        @Test(timeout = 60000)
+        public void testRemove() {
+            rule.setNextHostsToEmit(Collections.singletonList(1000));
+            rule.subscribeToStream();
+
+            rule.nextTick();
+
+            List<Host> hosts = rule.getHosts(1);
+            rule.assertNoHostsCompleted(hosts);
+
+            rule.setNextHostsToEmit(Collections.emptyList());
+            rule.nextTick();
+
+            rule.assertAllHostsCompleted(hosts);
+        }
+
+        @Test(timeout = 60000)
+        public void testMultiSnapshotsAllInstancesChanged() {
+            rule.setNextHostsToEmit(Arrays.asList(1000, 1001));
+            rule.subscribeToStream();
+
+            rule.nextTick();
+
+            List<Host> hosts = rule.getHosts(2);
+            rule.assertNoHostsCompleted(hosts);
+
+            rule.setNextHostsToEmit(Arrays.asList(1002, 1003));
+            rule.nextTick();
+
+            rule.assertAllHostsCompleted(hosts);
+            List<Host> hosts2 = rule.getHosts(4);
+            hosts2.removeAll(hosts);
+
+            rule.assertNoHostsCompleted(hosts2);
+        }
+
+        @Test(timeout = 60000)
+        public void testMultiSnapshotsSomeInstancesChanged() {
+            rule.setNextHostsToEmit(Arrays.asList(1000, 1001));
+            rule.subscribeToStream();
+
+            rule.nextTick();
+
+            List<Host> hosts = rule.getHosts(2);
+            rule.assertNoHostsCompleted(hosts);
+
+            rule.setNextHostsToEmit(Arrays.asList(1001, 1003));
+            rule.nextTick();
+
+            List<Host> removed = rule.assertHostsCompleted(hosts, 1000);
+            List<Host> hosts2 = rule.getHosts(3);
+            hosts2.removeAll(removed);
+
+            rule.assertNoHostsCompleted(hosts2);
+        }
+
+
+        public static class AdapterRule extends ExternalResource {
+
+            private TestSubscriber<Host> subscriber;
+            private TestScheduler scheduler;
+            private List<SocketAddress> nextHostsToEmit;
+
+            @Override
+            public Statement apply(final Statement base, Description description) {
+                return new Statement() {
+                    @Override
+                    public void evaluate() throws Throwable {
+                        subscriber = new TestSubscriber<>();
+                        scheduler = Schedulers.test();
+                        nextHostsToEmit = new ArrayList<>();
+                        base.evaluate();
+                    }
+                };
+            }
+
+            public void nextTick() {
+                scheduler.advanceTimeBy(1, TimeUnit.DAYS);
+            }
+
+            public void setNextHostsToEmit(List<Integer> ports) {
+                List<SocketAddress> newVal = ports.stream().map(InetSocketAddress::new).collect(Collectors.toList());
+                nextHostsToEmit.clear();
+                nextHostsToEmit.addAll(newVal);
+            }
+
+            public void subscribeToStream() {
+                SnapshotHostSourceAdapter.toHostStream(() -> nextHostsToEmit,
+                                                       Observable.interval(1, TimeUnit.DAYS, scheduler))
+                                         .subscribe(subscriber);
+            }
+
+            public List<Host> getHosts(int expectedCount) {
+                subscriber.assertNoErrors();
+                subscriber.assertValueCount(expectedCount);
+                return new ArrayList<>(subscriber.getOnNextEvents());
+            }
+
+            public void assertNoHostsCompleted(List<Host> hosts) {
+                for (Host host : hosts) {
+                    TestSubscriber<Void> s = new TestSubscriber<>();
+                    host.getCloseNotifier().subscribe(s);
+                    s.assertNoTerminalEvent();
+                }
+            }
+
+            public void assertAllHostsCompleted(List<Host> hosts) {
+                for (Host host : hosts) {
+                    assertHostCompleted(host);
+                }
+            }
+
+            protected void assertHostCompleted(Host host) {
+                TestSubscriber<Void> s = new TestSubscriber<>();
+                host.getCloseNotifier().subscribe(s);
+                s.assertCompleted();
+            }
+
+            public List<Host> assertHostsCompleted(List<Host> hosts, int... completedPorts) {
+                List<Host> toReturn = new ArrayList<>();
+
+                for (int completedPort : completedPorts) {
+                    for (Host host : hosts) {
+                        if (((InetSocketAddress) host.getHost()).getPort() == completedPort) {
+                            assertHostCompleted(host);
+                            toReturn.add(host);
+                        }
+                    }
+                }
+
+                return toReturn;
+            }
+        }
+
+    }
+}

--- a/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/StaticCompositeHostSourceFactory.java
+++ b/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/StaticCompositeHostSourceFactory.java
@@ -1,9 +1,8 @@
 package com.netflix.zuul.rxnetty;
 
-import netflix.ocelli.Instance;
+import io.reactivex.netty.client.Host;
 import rx.Observable;
 
-import java.net.SocketAddress;
 import java.util.Map;
 
 public class StaticCompositeHostSourceFactory implements HostSourceFactory {
@@ -15,7 +14,7 @@ public class StaticCompositeHostSourceFactory implements HostSourceFactory {
     }
 
     @Override
-    public Observable<Instance<SocketAddress>> call(String vip) {
+    public Observable<Host> call(String vip) {
         StaticHostSourceFactory f = vipVsFactory.get(vip);
         if (null == f) {
             return Observable.error(new IllegalArgumentException("VIP " + vip + " is not registered"));

--- a/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/StaticHostSourceFactory.java
+++ b/zuul-netty/src/main/java/com/netflix/zuul/rxnetty/StaticHostSourceFactory.java
@@ -1,45 +1,20 @@
 package com.netflix.zuul.rxnetty;
 
-import netflix.ocelli.Instance;
+import io.reactivex.netty.client.Host;
 import rx.Observable;
 
 import java.net.SocketAddress;
 
 public class StaticHostSourceFactory implements HostSourceFactory {
 
-    private final Observable<Instance<SocketAddress>> source;
+    private final Observable<Host> source;
 
     public StaticHostSourceFactory(SocketAddress host) {
-        this.source = Observable.just(new Instance<SocketAddress>() {
-            @Override
-            public Observable<Void> getLifecycle() {
-                return Observable.never();
-            }
-
-            @Override
-            public SocketAddress getValue() {
-                return host;
-            }
-        });
-    }
-
-    public StaticHostSourceFactory(SocketAddress... hosts) {
-        this.source = Observable.from(hosts)
-                                .map(host -> new Instance<SocketAddress>() {
-                                    @Override
-                                    public Observable<Void> getLifecycle() {
-                                        return Observable.never();
-                                    }
-
-                                    @Override
-                                    public SocketAddress getValue() {
-                                        return host;
-                                    }
-                                });
+        this.source = Observable.just(new Host(host));
     }
 
     @Override
-    public Observable<Instance<SocketAddress>> call(String s) {
+    public Observable<Host> call(String s) {
         return source;
     }
 }


### PR DESCRIPTION
Upgrading to 0.5.2-SNAPSHOT for rxnetty. Removed ocelli usage.