### PR TITLE
Fixing issue of cleaning expired connections in Zuul-simple-webapp

### DIFF
--- a/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRoutingFilter.groovy
+++ b/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRoutingFilter.groovy
@@ -80,13 +80,9 @@ class SimpleHostRoutingFilter extends ZuulFilter {
             @Override
             void run() {
                 try {
-                    final CloseableHttpClient hc = CLIENT.get();
-
-                    if (hc == null) {
-                        return;
-                    }
-
-                    hc.close();
+                    final HttpClient hc = CLIENT.get();
+                    if (hc == null) return;
+                    hc.getConnectionManager().closeExpiredConnections();
                 } catch (Throwable t) {
                     LOG.error("error closing expired connections", t);
                 }

--- a/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRoutingFilter.groovy
+++ b/zuul-simple-webapp/src/main/groovy/filters/route/SimpleHostRoutingFilter.groovy
@@ -90,7 +90,9 @@ class SimpleHostRoutingFilter extends ZuulFilter {
         }, 30000, 5000)
     }
 
-    public SimpleHostRoutingFilter() {}
+    public SimpleHostRoutingFilter() {
+        super();
+    }
 
     private static final HttpClientConnectionManager newConnectionManager() {
         SSLContext sslContext = SSLContexts.createSystemDefault();
@@ -161,7 +163,7 @@ class SimpleHostRoutingFilter extends ZuulFilter {
         HttpServletRequest request = RequestContext.getCurrentContext().getRequest();
         Header[] headers = buildZuulRequestHeaders(request)
         String verb = getVerb(request);
-        InputStream requestEntity = getRequestBody(request)
+        InputStream requestEntity = request.getInputStream();
         CloseableHttpClient httpclient = CLIENT.get()
 
         String uri = request.getRequestURI()
@@ -222,7 +224,7 @@ class SimpleHostRoutingFilter extends ZuulFilter {
         switch (verb) {
             case 'POST':
                 httpRequest = new HttpPost(uri + getQueryString())
-                InputStreamEntity entity = new InputStreamEntity(requestEntity, request.getContentLength())
+                InputStreamEntity entity = new InputStreamEntity(requestEntity)
                 httpRequest.setEntity(entity)
                 break
             case 'PUT':


### PR DESCRIPTION
With the current implementation Zuul-Simple-Webapp Connection pool is shut down[1] when cleaning the expired connection. After that requests not getting routed anymore. By changing clean code as[2] will fix the issue.

[1].
ZUUL_DEBUG::Invoking {route} type filters
ZUUL_DEBUG::Filter route 100 SimpleHostRoutingFilter
ZUUL_DEBUG::Running Filter failed SimpleHostRoutingFilter type:route order:100 Connection pool shut down
ZUUL_DEBUG::Invoking {error} type filters
ZUUL_DEBUG::Invoking {post} type filters
ZUUL_DEBUG::Filter post 1000 SendResponseFilter
ZUUL_DEBUG::Filter post 2000 Stats

[2].
```java
                try {
                    final HttpClient hc = CLIENT.get();
                    if (hc == null) return;
                    hc.getConnectionManager().closeExpiredConnections();
                } catch (Throwable t) {
                    LOG.error("error closing expired connections", t);
                }
```