### PR TITLE
Use daemon threads for filter pollers

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/FilterFileManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/FilterFileManager.java
@@ -112,6 +112,7 @@ public class FilterFileManager {
                 }
             }
         };
+        poller.setDaemon(true);
         poller.start();
     }
 

--- a/zuul-netflix/src/main/java/com/netflix/zuul/scriptManager/ZuulFilterPoller.java
+++ b/zuul-netflix/src/main/java/com/netflix/zuul/scriptManager/ZuulFilterPoller.java
@@ -65,6 +65,7 @@ public class ZuulFilterPoller {
      */
     public ZuulFilterPoller(ZuulFilterDAO dao) {
         this.dao = dao;
+        checkerThread.setDaemon(true);
         checkerThread.start();
 
     }


### PR DESCRIPTION
The filter poller threads are not daemon which has the potential to delay shutdown.

```
"GroovyFilterFileManagerPoller" #47 prio=5 os_prio=0 tid=0x00007f9ab1549000 nid=0x45dc waiting on condition [0x00007f9a54c77000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(Native Method)
	at com.netflix.zuul.FilterFileManager$1.run(FilterFileManager.java:107)

"ZuulFilterPoller" #46 prio=5 os_prio=0 tid=0x00007f9ab0fd4000 nid=0x45da waiting on condition [0x00007f9a552b8000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(Native Method)
	at com.netflix.zuul.scriptManager.ZuulFilterPoller$1.run(ZuulFilterPoller.java:119)

"ThreadCpuStatsCollector" #44 daemon prio=5 os_prio=0 tid=0x00007f9ab0f10800 nid=0x45d8 waiting on condition [0x00007f9a5533a000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
	at java.lang.Thread.sleep(Native Method)
	at com.netflix.servo.util.ThreadCpuStats$CpuStatRunnable.run(ThreadCpuStats.java:425)
	at java.lang.Thread.run(Thread.java:745)
```