### PR TITLE
fix problem when filterLoader.jsp returned 500 error.

### DIFF
--- a/zuul-netflix-webapp/build.gradle
+++ b/zuul-netflix-webapp/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile 'com.sun.jersey:jersey-client:1.19'
     compile 'com.sun.jersey:jersey-servlet:1.19'
 
-    compile "org.codehaus.groovy:groovy-all:2.2.2"
+    compile "org.codehaus.groovy:groovy-all:2.3.10"
     providedCompile 'junit:junit-dep:4.10'
 }
 

--- a/zuul-netflix-webapp/src/main/webapp/admin/filterLoader.jsp
+++ b/zuul-netflix-webapp/src/main/webapp/admin/filterLoader.jsp
@@ -2,6 +2,7 @@
 <%@ page import="com.netflix.zuul.scriptManager.FilterInfo" %>
 <%@ page import="com.netflix.zuul.scriptManager.ZuulFilterDAO" %>
 <%@ page import="com.netflix.zuul.scriptManager.ZuulFilterDAOCassandra" %>
+<%@ page import="com.netflix.zuul.dependency.cassandra.CassandraHelper" %>
 <%@ page import="com.netflix.zuul.util.AdminFilterUtil" %>
 <%@ page import="org.slf4j.Logger" %>
 <%@ page import="org.slf4j.LoggerFactory" %>
@@ -18,7 +19,7 @@
 
     ZuulFilterDAO scriptDAO = null;
     try {
-        scriptDAO = new ZuulFilterDAOCassandra(StartServer.getZuulCassKeyspace());
+        scriptDAO = new ZuulFilterDAOCassandra(CassandraHelper.getInstance().getZuulCassKeyspace());
     } catch (Exception e) {
         LOG.error(e.getMessage(), e);
     }


### PR DESCRIPTION
When I got page admin/filterLoader.jsp in zuul-netflix-webapp example, I got 500 error like this:

<pre>HTTP ERROR 500

Problem accessing /admin/filterLoader.jsp. Reason:

    PWC6033: Unable to compile class for JSP

PWC6197: An error occurred at line: 16 in the jsp file: /admin/filterLoader.jsp
PWC6199: Generated servlet error:
The method getZuulCassKeyspace() is undefined for the type StartServer

Caused by:

org.apache.jasper.JasperException: PWC6033: Unable to compile class for JSP

PWC6197: An error occurred at line: 16 in the jsp file: /admin/filterLoader.jsp
PWC6199: Generated servlet error:
The method getZuulCassKeyspace() is undefined for the type StartServer


	at org.apache.jasper.compiler.DefaultErrorHandler.javacError(DefaultErrorHandler.java:123)
	at org.apache.jasper.compiler.ErrorDispatcher.javacError(ErrorDispatcher.java:296)
	at org.apache.jasper.compiler.Compiler.generateClass(Compiler.java:376)
	at org.apache.jasper.compiler.Compiler.compile(Compiler.java:437)
	at org.apache.jasper.JspCompilationContext.compile(JspCompilationContext.java:608)
	at org.apache.jasper.servlet.JspServletWrapper.service(JspServletWrapper.java:360)
	at org.apache.jasper.servlet.JspServlet.serviceJspFile(JspServlet.java:486)
	at org.apache.jasper.servlet.JspServlet.service(JspServlet.java:380)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
	at org.mortbay.jetty.servlet.ServletHolder.handle(ServletHolder.java:511)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1166)
	at com.google.inject.servlet.DefaultFilterPipeline.dispatch(DefaultFilterPipeline.java:43)
	at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:113)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
	at com.netflix.zuul.context.ContextLifecycleFilter.doFilter(ContextLifecycleFilter.java:40)
	at org.mortbay.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1157)
	at org.mortbay.jetty.servlet.ServletHandler.handle(ServletHandler.java:388)
	at org.mortbay.jetty.security.SecurityHandler.handle(SecurityHandler.java:216)
	at org.mortbay.jetty.servlet.SessionHandler.handle(SessionHandler.java:182)
	at org.mortbay.jetty.handler.ContextHandler.handle(ContextHandler.java:765)
	at org.mortbay.jetty.webapp.WebAppContext.handle(WebAppContext.java:440)
	at org.mortbay.jetty.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:230)
	at org.mortbay.jetty.handler.HandlerCollection.handle(HandlerCollection.java:114)
	at org.mortbay.jetty.handler.HandlerWrapper.handle(HandlerWrapper.java:152)
	at org.mortbay.jetty.Server.handle(Server.java:326)
	at org.mortbay.jetty.HttpConnection.handleRequest(HttpConnection.java:542)
	at org.mortbay.jetty.HttpConnection$RequestHandler.headerComplete(HttpConnection.java:926)
	at org.mortbay.jetty.HttpParser.parseNext(HttpParser.java:549)
	at org.mortbay.jetty.HttpParser.parseAvailable(HttpParser.java:212)
	at org.mortbay.jetty.HttpConnection.handle(HttpConnection.java:404)
	at org.mortbay.io.nio.SelectChannelEndPoint.run(SelectChannelEndPoint.java:410)
	at org.mortbay.thread.QueuedThreadPool$PoolThread.run(QueuedThreadPool.java:582)<
</pre>