### PR TITLE
Fixed integer overflow in ZuulFilter.compareTo(..)

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/ZuulFilter.java
@@ -126,7 +126,7 @@ public abstract class ZuulFilter implements IZuulFilter, Comparable<ZuulFilter> 
     }
 
     public int compareTo(ZuulFilter filter) {
-        return this.filterOrder() - filter.filterOrder();
+        return Integer.compare(this.filterOrder(), filter.filterOrder());
     }
 
     public static class TestUnit {


### PR DESCRIPTION
the current implementation of `ZuulFilter.compareTo(..)` is vulnerable to Integer overflows:

```java
    public int compareTo(ZuulFilter filter) {
        return this.filterOrder() - filter.filterOrder();
    }
```

In the Javadoc of `filterOrder()` is no mention of valid values, so I assume that positive and negative values including `Integer.MAX_VALUE` and `Integer.MIN_VALUE` are supported.

the simple fix is to use `Integer.compare(int,int)` instead:

```java
    public int compareTo(ZuulFilter filter) {
        return Integer.compare(this.filterOrder(), filter.filterOrder());
    }
```