### PR TITLE
Allow consumers to use jersey2 compatible components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ Thumbs.db
 /build
 */build
 .m2
+/bin
+*/bin
 
 # IntelliJ specific files/directories
 out

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulServletFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulServletFilter.java
@@ -69,7 +69,13 @@ public class ZuulServletFilter implements Filter {
                 postRouting();
                 return;
             }
-            filterChain.doFilter(servletRequest, servletResponse);
+            
+            // Only forward onto to the chain if a zuul response is not being sent
+            if (!RequestContext.getCurrentContext().sendZuulResponse()) {
+                filterChain.doFilter(servletRequest, servletResponse);
+                return;
+            }
+            
             try {
                 routing();
             } catch (ZuulException e) {

--- a/zuul-netflix/src/main/java/com/netflix/zuul/dependency/ribbon/hystrix/RibbonCommand.java
+++ b/zuul-netflix/src/main/java/com/netflix/zuul/dependency/ribbon/hystrix/RibbonCommand.java
@@ -7,7 +7,7 @@ import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandKey;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandProperties;
-import com.netflix.niws.client.http.RestClient;
+import com.netflix.client.AbstractLoadBalancerAwareClient;
 import com.netflix.zuul.constants.ZuulConstants;
 import com.netflix.zuul.context.NFRequestContext;
 import com.netflix.zuul.dependency.httpclient.hystrix.HostCommand;
@@ -35,7 +35,7 @@ import static com.netflix.client.http.HttpRequest.Verb;
  */
 public class RibbonCommand extends HystrixCommand<HttpResponse> {
 
-    RestClient restClient;
+    AbstractLoadBalancerAwareClient<HttpRequest, HttpResponse> restClient;
     Verb verb;
     URI uri;
     MultivaluedMap<String, String> headers;
@@ -43,7 +43,7 @@ public class RibbonCommand extends HystrixCommand<HttpResponse> {
     InputStream requestEntity;
 
 
-    public RibbonCommand(RestClient restClient,
+    public RibbonCommand(AbstractLoadBalancerAwareClient<HttpRequest, HttpResponse> restClient,
                          Verb verb,
                          String uri,
                          MultivaluedMap<String, String> headers,
@@ -54,7 +54,7 @@ public class RibbonCommand extends HystrixCommand<HttpResponse> {
 
 
     public RibbonCommand(String commandKey,
-                         RestClient restClient,
+                         AbstractLoadBalancerAwareClient<HttpRequest, HttpResponse> restClient,
                          Verb verb,
                          String uri,
                          MultivaluedMap<String, String> headers,
@@ -67,7 +67,7 @@ public class RibbonCommand extends HystrixCommand<HttpResponse> {
     
     public RibbonCommand(String groupKey, 
                     String commandKey,
-                    RestClient restClient,
+                    AbstractLoadBalancerAwareClient<HttpRequest, HttpResponse> restClient,
                     Verb verb,
                     String uri,
                     MultivaluedMap<String, String> headers,


### PR DESCRIPTION
As part of the work to support jersey2 with eureka(https://github.com/Netflix/eureka/pull/821)

I discovered two issues with zuul. The `RibbonCommand` contract it too restrictive on the ribbon implementation and the `ZuulServletFilter` attempts to reuse the output stream when a zuul response is being sent.