### PR TITLE
remove manageFiles() from init(), in case it throws exception.

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/FilterFileManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/FilterFileManager.java
@@ -78,7 +78,6 @@ public class FilterFileManager {
 
         INSTANCE.aDirectories = directories;
         INSTANCE.pollingIntervalSeconds = pollingIntervalSeconds;
-        INSTANCE.manageFiles();
         INSTANCE.startPoller();
 
     }
@@ -104,8 +103,8 @@ public class FilterFileManager {
             public void run() {
                 while (bRunning) {
                     try {
-                        sleep(pollingIntervalSeconds * 1000);
                         manageFiles();
+                        sleep(pollingIntervalSeconds * 1000);
                     } catch (Exception e) {
                         e.printStackTrace();
                     }


### PR DESCRIPTION
manageFiles() will throw exceptions, which will make the init function crash. Let startPoller() do all things will be fine.