### PR TITLE
correcting FilterType to valid enums

### DIFF
--- a/zuul-servletapi-sample/src/main/filters/inbound/BufferingInbound.groovy
+++ b/zuul-servletapi-sample/src/main/filters/inbound/BufferingInbound.groovy
@@ -35,6 +35,6 @@ class BufferingInbound extends MessageBodyBufferFilter
 
     @Override
     FilterType filterType() {
-        return "in"
+        return FilterType.INBOUND
     }
 }

--- a/zuul-servletapi-sample/src/main/filters/outbound/BufferingOutbound.groovy
+++ b/zuul-servletapi-sample/src/main/filters/outbound/BufferingOutbound.groovy
@@ -35,6 +35,6 @@ class BufferingOutbound extends MessageBodyBufferFilter
 
     @Override
     FilterType filterType() {
-        return "out"
+        return FilterType.OUTBOUND
     }
 }


### PR DESCRIPTION
This is addressing the issue reported in https://github.com/Netflix/zuul/issues/294 so that the BufferingOutbound.groovy and BufferingInbound.groovy filters return correct enum for the filterType() method. 