### PR TITLE
Add MonitoringHelper.initMocks() to ZuulFilter TestUnit, otherwise it…

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/ZuulFilter.java
@@ -17,6 +17,7 @@ package com.netflix.zuul;
 
 import com.netflix.config.DynamicBooleanProperty;
 import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.zuul.monitoring.MonitoringHelper;
 import com.netflix.zuul.monitoring.Tracer;
 import com.netflix.zuul.monitoring.TracerFactory;
 import org.junit.Before;

--- a/zuul-core/src/main/java/com/netflix/zuul/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/ZuulFilter.java
@@ -153,6 +153,7 @@ public abstract class ZuulFilter implements IZuulFilter, Comparable<ZuulFilter> 
         @Before
         public void before() {
             MockitoAnnotations.initMocks(this);
+            MonitoringHelper.initMocks();
         }
 
         @Test


### PR DESCRIPTION
… causes the 'TracerFactory not initialized' error