### PR TITLE
Add generic type and protected getters to RibbonCommand

### DIFF
--- a/zuul-netflix-webapp/src/main/groovy/filters/route/ZuulNFRequest.groovy
+++ b/zuul-netflix-webapp/src/main/groovy/filters/route/ZuulNFRequest.groovy
@@ -15,6 +15,7 @@
  */
 package filters.route
 
+import com.netflix.client.AbstractLoadBalancerAwareClient
 import com.netflix.client.ClientException
 import com.netflix.client.ClientFactory
 import com.netflix.client.IClient
@@ -144,7 +145,7 @@ class ZuulNFRequest extends ZuulFilter {
         route = route.replace("/", "_")
 
 
-        RibbonCommand command = new RibbonCommand(restClient, verb, uri, headers, params, requestEntity);
+        RibbonCommand<AbstractLoadBalancerAwareClient<HttpRequest, HttpResponse>> command = new RibbonCommand<>(restClient, verb, uri, headers, params, requestEntity);
         try {
             HttpResponse response = command.execute();
             return response

--- a/zuul-netflix/src/main/java/com/netflix/zuul/dependency/ribbon/hystrix/RibbonCommand.java
+++ b/zuul-netflix/src/main/java/com/netflix/zuul/dependency/ribbon/hystrix/RibbonCommand.java
@@ -33,12 +33,12 @@ import static com.netflix.client.http.HttpRequest.Verb;
  */
 public class RibbonCommand<T extends AbstractLoadBalancerAwareClient<HttpRequest, HttpResponse>> extends HystrixCommand<HttpResponse> {
 
-    T restClient;
-    Verb verb;
-    URI uri;
-    MultivaluedMap<String, String> headers;
-    MultivaluedMap<String, String> params;
-    InputStream requestEntity;
+    private final T restClient;
+    private final Verb verb;
+    private final URI uri;
+    private final MultivaluedMap<String, String> headers;
+    private final MultivaluedMap<String, String> params;
+    private final InputStream requestEntity;
 
 
     public RibbonCommand(T restClient,
@@ -171,21 +171,24 @@ public class RibbonCommand<T extends AbstractLoadBalancerAwareClient<HttpRequest
         
         @Test
         public void testConstruction() throws URISyntaxException {
-            RibbonCommand rc = new RibbonCommand(null, null, localhost, null, null, null);
+            RibbonCommand<AbstractLoadBalancerAwareClient<HttpRequest, HttpResponse>> rc
+                = new RibbonCommand<>(null, null, localhost, null, null, null);
             Assert.assertEquals("default", rc.getCommandGroup().name());
             Assert.assertEquals(RibbonCommand.class.getSimpleName(), rc.getCommandKey().name());
         }
         
         @Test
         public void testConstructionWithCommandKey() throws URISyntaxException {
-            RibbonCommand rc = new RibbonCommand("myCommand", null, null, localhost, null, null, null);
+            RibbonCommand<AbstractLoadBalancerAwareClient<HttpRequest, HttpResponse>> rc
+                = new RibbonCommand<>("myCommand", null, null, localhost, null, null, null);
             Assert.assertEquals("myCommand", rc.getCommandGroup().name());
             Assert.assertEquals(RibbonCommand.class.getSimpleName(), rc.getCommandKey().name());
         }
         
         @Test
         public void testConstructionWithGroupKeyAndCommandKey() throws URISyntaxException {
-            RibbonCommand rc = new RibbonCommand("myGroup", "myCommand", null, null, localhost, null, null, null);
+            RibbonCommand<AbstractLoadBalancerAwareClient<HttpRequest, HttpResponse>> rc
+                = new RibbonCommand<>("myGroup", "myCommand", null, null, localhost, null, null, null);
             Assert.assertEquals("myGroup", rc.getCommandGroup().name());
             Assert.assertEquals("myCommand", rc.getCommandKey().name());
         }


### PR DESCRIPTION
I have a use case in which I want to use RibbonCommand but I don't want to execute with the load balancer. Default implementation if left unchanged.

- Changed class signature to accept a generic to indicate the type of the client. Due to type erasure this is a passive change
- Added protected methods for member fields
- Added protected method to delegate client execution when overridden