### PR TITLE
runtime tunable concurrency for async filters

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/exception/ZuulFilterConcurrencyExceededException.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/exception/ZuulFilterConcurrencyExceededException.java
@@ -1,0 +1,10 @@
+package com.netflix.zuul.exception;
+
+import com.netflix.zuul.filters.ZuulFilter;
+
+public class ZuulFilterConcurrencyExceededException extends ZuulException {
+
+    public ZuulFilterConcurrencyExceededException(ZuulFilter filter, int concurrencyLimit) {
+        super(filter.filterName() + " exceeded concurrency limit of " + concurrencyLimit, true);
+    }
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/SyncZuulFilterAdapter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/SyncZuulFilterAdapter.java
@@ -16,6 +16,7 @@
 
 package com.netflix.zuul.filters;
 
+import com.netflix.zuul.exception.ZuulFilterConcurrencyExceededException;
 import com.netflix.zuul.message.ZuulMessage;
 import io.netty.handler.codec.http.HttpContent;
 import rx.Observable;
@@ -86,4 +87,13 @@ public abstract class SyncZuulFilterAdapter<I extends ZuulMessage, O extends Zuu
         return chunk;
     }
 
+    @Override
+    public void incrementConcurrency() {
+        //NOOP for sync filters
+    }
+
+    @Override
+    public void decrementConcurrency() {
+        //NOOP for sync filters
+    }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.zuul.filters;
 
+import com.netflix.zuul.exception.ZuulFilterConcurrencyExceededException;
 import com.netflix.zuul.message.ZuulMessage;
 import io.netty.handler.codec.http.HttpContent;
 import rx.Observable;
@@ -57,9 +58,22 @@ public interface ZuulFilter<I extends ZuulMessage, O extends ZuulMessage> extend
     boolean overrideStopFilterProcessing();
 
     /**
+     * Called by zuul filter runner before sending request through this filter. The filter can throw
+     * ZuulFilterConcurrencyExceededException if it has reached its concurrent requests limit and does
+     * not wish to process the request. Generally only useful for async filters.
+     */
+    void incrementConcurrency() throws ZuulFilterConcurrencyExceededException;
+
+    /**
      * if shouldFilter() is true, this method will be invoked. this method is the core method of a ZuulFilter
      */
     Observable<O> applyAsync(I input);
+
+    /**
+     * Called by zuul filter after request is processed by this filter.
+     *
+     */
+    void decrementConcurrency();
 
     FilterSyncType getSyncType();
 

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/http/HttpSyncEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/http/HttpSyncEndpoint.java
@@ -17,6 +17,7 @@
 package com.netflix.zuul.filters.http;
 
 import com.netflix.config.CachedDynamicBooleanProperty;
+import com.netflix.zuul.exception.ZuulFilterConcurrencyExceededException;
 import com.netflix.zuul.filters.Endpoint;
 import com.netflix.zuul.filters.SyncZuulFilter;
 import com.netflix.zuul.message.ZuulMessage;
@@ -76,6 +77,16 @@ public abstract class HttpSyncEndpoint extends Endpoint<HttpRequestMessage, Http
             }
         }
         return super.processContentChunk(zuulMessage, chunk);
+    }
+
+    @Override
+    public void incrementConcurrency() {
+        //NOOP, since this is supposed to be a SYNC filter in spirit
+    }
+
+    @Override
+    public void decrementConcurrency() {
+        //NOOP, since this is supposed to be a SYNC filter in spirit
     }
 
     private static class ResponseState


### PR DESCRIPTION
A slow running async filter can cause high number of concurrent requests to be piled up on frontend. This PR introduces FP controlled concurrency limit that can be tuned for individual filters + single FP to disable filter concurrency limits altogether if we find a bug/leak in the implementation.