### PR TITLE
Fix: parseRequest lose form-field when value empty

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/http/HttpServletRequestWrapper.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/http/HttpServletRequestWrapper.java
@@ -514,6 +514,18 @@ public class HttpServletRequestWrapper extends javax.servlet.http.HttpServletReq
         }
 
         @Test
+        public void parsesParamsFromFormBodyIncludeEmptyValue() throws Exception {
+            method("POST");
+            body("one=1&two=".getBytes());
+            contentType("application/x-www-form-urlencoded");
+
+            final HttpServletRequestWrapper wrapper = new HttpServletRequestWrapper(request);
+            final Map params = wrapper.getParameterMap();
+            assertTrue(params.containsKey("one"));
+            assertTrue(params.containsKey("two"));
+        }
+
+        @Test
         public void ignoresParamsInBodyForNonPosts() throws Exception {
             method("PUT");
             body("one=1&two=2".getBytes());

--- a/zuul-core/src/main/java/com/netflix/zuul/http/HttpServletRequestWrapper.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/http/HttpServletRequestWrapper.java
@@ -189,7 +189,7 @@ public class HttpServletRequestWrapper extends javax.servlet.http.HttpServletReq
                 while (st.hasMoreTokens()) {
                     s = st.nextToken();
                     i = s.indexOf("=");
-                    if (i > 0) {
+                    if (i > 0 && s.length() > i + 1) {
                         name = s.substring(0, i);
                         value = s.substring(i + 1);
                         if (decode) {

--- a/zuul-core/src/main/java/com/netflix/zuul/http/HttpServletRequestWrapper.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/http/HttpServletRequestWrapper.java
@@ -189,7 +189,7 @@ public class HttpServletRequestWrapper extends javax.servlet.http.HttpServletReq
                 while (st.hasMoreTokens()) {
                     s = st.nextToken();
                     i = s.indexOf("=");
-                    if (i > 0 && s.length() > i + 1) {
+                    if (i > 0) {
                         name = s.substring(0, i);
                         value = s.substring(i + 1);
                         if (decode) {


### PR DESCRIPTION
We use local-forward in product.

curl -X POST -d 'foo=1&bar='   http://host:port/forward/xxxx

That will lose request parameter  `bar`