### PR TITLE
[issue-424]fix connection never be release error caused by wrong PASSPORT_STATE_…

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
@@ -90,7 +90,7 @@ public class DefaultClientChannelManager implements ClientChannelManager {
     private NettyClientConnectionFactory clientConnFactory;
     private OriginChannelInitializer channelInitializer;
 
-    public static final String IDLE_STATE_HANDLER_NAME = "idleStateHandler";
+    public static final String IDLE_STATE_HANDLER_NAME = "idleStateHandler#0";
 
     public DefaultClientChannelManager(String originName, String vip, IClientConfig clientConfig, Registry spectatorRegistry) {
         this.loadBalancer = createLoadBalancer(clientConfig);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/insights/PassportStateHttpClientHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/insights/PassportStateHttpClientHandler.java
@@ -35,7 +35,7 @@ import io.netty.handler.codec.http.LastHttpContent;
  */
 public class PassportStateHttpClientHandler extends CombinedChannelDuplexHandler
 {
-    public static final String PASSPORT_STATE_HTTP_CLIENT_HANDLER_NAME = "PassportStateHttpClientHandler";
+    public static final String PASSPORT_STATE_HTTP_CLIENT_HANDLER_NAME = "PassportStateHttpClientHandler#0";
 
     public PassportStateHttpClientHandler()
     {


### PR DESCRIPTION
The rule of netty to generate name for handler is  StringUtil.simpleClassName(handlerType) + "#0", but the name given for PassportStateHttpClientHandler is PassportStateHttpClientHandler.

When adding idleStateHandler  after passportStateHttpClientHandler to ChannelPipeline in DefaultClientChannelManager.release(PooledConnection),  ChannelPipeline cannot find a context named "passportStateHttpClientHandler" so a _java.util.NoSuchElementException: PassportStateHttpClientHandler_ is thrown.  

Netty doesn't catch this exception so the release of connection will be stopped here.

the reason for losing this exception is:
in AbstractChannelHandlerContext#invokeUserEventTriggered(), this exception is caught but when invoking notifyHandlerException(), this method won't log this exception.

change "PassportStateHttpClientHandler" to "PassportStateHttpClientHandler#0" could fix this bug.
the name of  "idleStateHandler" doesn't matter here but better be changed to meet netty's rule


