### PR TITLE
Copy error reason phrase if netty HttpResponse have

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -746,7 +746,8 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
         // Translate the netty HttpResponse into a zuul HttpResponseMessage.
         final SessionContext zuulCtx = context;
         final int respStatus = httpResponse.status().code();
-        final HttpResponseMessage zuulResponse = new HttpResponseMessageImpl(zuulCtx, zuulRequest, respStatus);
+        final String respReasonPhrase = httpResponse.status().reasonPhrase();
+        final HttpResponseMessage zuulResponse = new HttpResponseMessageImpl(zuulCtx, zuulRequest, respStatus, respReasonPhrase);
 
         final Headers respHeaders = zuulResponse.getHeaders();
         for (Map.Entry<String, String> entry : httpResponse.headers()) {

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseInfo.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseInfo.java
@@ -27,6 +27,8 @@ public interface HttpResponseInfo extends ZuulMessage
 {
     int getStatus();
 
+    String getReasonPhrase();
+
     /** The immutable request that was originally received from client. */
     HttpRequestInfo getInboundRequest();
 

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessage.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessage.java
@@ -27,6 +27,8 @@ public interface HttpResponseMessage extends HttpResponseInfo
 {
     void setStatus(int status);
 
+    void setReasonPhrase(String reasonPhrase);
+
     @Override
     int getMaxBodySize();
 

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessageImpl.java
@@ -54,14 +54,25 @@ public class HttpResponseMessageImpl implements HttpResponseMessage
     private ZuulMessage message;
     private HttpRequestMessage outboundRequest;
     private int status;
+    private String reasonPhrase = null;
     private HttpResponseInfo inboundResponse = null;
 
     public HttpResponseMessageImpl(SessionContext context, HttpRequestMessage request, int status)
     {
-        this(context, new Headers(), request, status);
+        this(context, new Headers(), request, status, null);
     }
 
     public HttpResponseMessageImpl(SessionContext context, Headers headers, HttpRequestMessage request, int status)
+    {
+        this(context, headers, request, status, null);
+    }
+
+    public HttpResponseMessageImpl(SessionContext context, HttpRequestMessage request, int status, String reasonPhrase)
+    {
+        this(context, new Headers(), request, status, reasonPhrase);
+    }
+
+    public HttpResponseMessageImpl(SessionContext context, Headers headers, HttpRequestMessage request, int status, String reasonPhrase)
     {
         this.message = new ZuulMessageImpl(context, headers);
         this.outboundRequest = request;
@@ -71,6 +82,7 @@ public class HttpResponseMessageImpl implements HttpResponseMessage
                     new RuntimeException("Invalid HttpRequestMessage"));
         }
         this.status = status;
+        this.reasonPhrase = reasonPhrase;
     }
 
     public static HttpResponseMessage defaultErrorResponse(HttpRequestMessage request)
@@ -180,6 +192,15 @@ public class HttpResponseMessageImpl implements HttpResponseMessage
     @Override
     public void setStatus(int status) {
         this.status = status;
+    }
+
+    @Override
+    public String getReasonPhrase() {
+        return reasonPhrase;
+    }
+    @Override
+    public void setReasonPhrase(String reasonPhrase) {
+        this.reasonPhrase = reasonPhrase;
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
@@ -181,8 +181,14 @@ public class ClientResponseWriter extends ChannelInboundHandlerAdapter {
         }
 
         // Create the main http response to send, with body.
-        final DefaultHttpResponse nativeResponse = new DefaultHttpResponse(responseHttpVersion,
-                HttpResponseStatus.valueOf(zuulResp.getStatus()), false, false);
+        HttpResponseStatus responseStatus;
+        if (zuulResp.getReasonPhrase() != null) {
+            responseStatus = HttpResponseStatus.valueOf(zuulResp.getStatus(), zuulResp.getReasonPhrase());
+        }
+        else {
+            responseStatus = HttpResponseStatus.valueOf(zuulResp.getStatus());
+        }
+        final DefaultHttpResponse nativeResponse = new DefaultHttpResponse(responseHttpVersion, responseStatus, false, false);
 
         // Now set all of the response headers - note this is a multi-set in keeping with HTTP semantics
         final HttpHeaders nativeHeaders = nativeResponse.headers();


### PR DESCRIPTION
My origin service and client are using custom reason phrase (https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html). I think that many service use this.
But Zuul 2.0 do not use the reason phrase which is from netty HttpResponse. 

So I add the reason phrase to HttpResponseInfo of Zuul.