### PR TITLE
remove duplicated filter execution summary

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/FilterProcessor.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/FilterProcessor.java
@@ -225,7 +225,6 @@ public class FilterProcessor {
                 throw (ZuulException) e;
             } else {
                 ZuulException ex = new ZuulException(e, "Filter threw Exception", 500, filter.filterType() + ":" + filterName);
-                ctx.addFilterExecutionSummary(filterName, ExecutionStatus.FAILED.name(), execTime);
                 throw ex;
             }
         }


### PR DESCRIPTION
When the `ZuulFilterResult` is failed, `FilterProcessor` will add filter execution summary into the context twice.