### PR TITLE
Ensures jar file is included in publishToMavenLocal

### DIFF
--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -1,6 +1,13 @@
 apply plugin: "groovy"
 apply plugin: "com.google.osdetector"
 
+// Otherwise publishToMavenLocal won't produce a jar in ~/.m2/repository
+publishing.publications {
+    mavenJava(MavenPublication) {
+        from components.java
+    }
+}
+
 dependencies {
 
     compile "log4j:log4j:1.2.17"


### PR DESCRIPTION
The goal here is to be able to run `./gradlew publishToMavenLocal`, which will enable the possibility of not having `includeBuild` in the internal edgezuul build.

I'll try to follow up with EngTools on why it's needed at all.