### PR TITLE
core: adjust release count

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java
@@ -108,7 +108,8 @@ public class ElbProxyProtocolChannelHandler extends ChannelInboundHandlerAdapter
                     }
                 }
                 stillRead = false;
-                if (hapm.refCnt() > 0) {
+                if (hapm.refCnt() > 1) {
+                    // TODO(carl-mastrangelo): test to see if this is still needed.
                     hapm.release();
                 } else {
                     logger.warn("Unexpected ref count on HAProxyMessage");


### PR DESCRIPTION
Occasionally a message falls of the end of the event loop causing a
crash.  Add in some safety releases and logging to aid in debugging.

@artgon FYI