### PR TITLE
core: add initial unit tests for BaseZuulChannelInitializer

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/channel/config/ChannelConfig.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/channel/config/ChannelConfig.java
@@ -42,7 +42,7 @@ public class ChannelConfig implements Cloneable
         this.parameters.put(param.key(), param);
     }
 
-    public <T> void set(ChannelConfigKey key, T value)
+    public <T> void set(ChannelConfigKey<T> key, T value)
     {
         this.parameters.put(key, new ChannelConfigValue<>(key, value));
     }

--- a/zuul-core/src/main/java/com/netflix/netty/common/channel/config/CommonChannelConfigKeys.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/channel/config/CommonChannelConfigKeys.java
@@ -33,10 +33,14 @@ public class CommonChannelConfigKeys
             new ChannelConfigKey<>("allowProxyHeadersWhen", StripUntrustedProxyHeadersHandler.AllowWhen.ALWAYS);
     public static final ChannelConfigKey<Boolean> preferProxyProtocolForClientIp = new ChannelConfigKey<>("preferProxyProtocolForClientIp", true);
 
-    public static final ChannelConfigKey<Integer> idleTimeout = new ChannelConfigKey<>("idleTimeout");
+    /** The Idle timeout of a connection, in milliseconds */
+    public static final ChannelConfigKey<Integer> idleTimeout = new ChannelConfigKey<>("idleTimeout", 65000);
     public static final ChannelConfigKey<ServerTimeout> serverTimeout = new ChannelConfigKey<>("serverTimeout");
-    public static final ChannelConfigKey<Integer> httpRequestReadTimeout = new ChannelConfigKey<>("httpRequestReadTimeout");
-    public static final ChannelConfigKey<Integer> maxConnections = new ChannelConfigKey<>("maxConnections");
+    /** The HTTP request read timeout, in milliseconds */
+    public static final ChannelConfigKey<Integer> httpRequestReadTimeout =
+            new ChannelConfigKey<>("httpRequestReadTimeout", 5000);
+    /** The maximum number of inbound connections to proxy. */
+    public static final ChannelConfigKey<Integer> maxConnections = new ChannelConfigKey<>("maxConnections", 20000);
     public static final ChannelConfigKey<Integer> maxRequestsPerConnection = new ChannelConfigKey<>("maxRequestsPerConnection", 4000);
     public static final ChannelConfigKey<Integer> maxRequestsPerConnectionInBrownout = new ChannelConfigKey<>("maxRequestsPerConnectionInBrownout", 100);
     public static final ChannelConfigKey<Integer> connectionExpiry = new ChannelConfigKey<>("connectionExpiry", 20 * 60 * 1000);
@@ -49,7 +53,8 @@ public class CommonChannelConfigKeys
     // HTTP/2 specific:
     public static final ChannelConfigKey<Integer> maxConcurrentStreams = new ChannelConfigKey<>("maxConcurrentStreams", 100);
     public static final ChannelConfigKey<Integer> initialWindowSize = new ChannelConfigKey<>("initialWindowSize", 5242880);  // 5MB
-    public static final ChannelConfigKey<Integer> connCloseDelay = new ChannelConfigKey<>("connCloseDelay");
+    /* The amount of time to wait before closing a connection that has the `Connection: Close` header, in seconds */
+    public static final ChannelConfigKey<Integer> connCloseDelay = new ChannelConfigKey<>("connCloseDelay", 10);
     public static final ChannelConfigKey<Integer> maxHttp2HeaderTableSize = new ChannelConfigKey<>("maxHttp2HeaderTableSize", 4096);
     public static final ChannelConfigKey<Integer> maxHttp2HeaderListSize = new ChannelConfigKey<>("maxHttp2HeaderListSize");
     public static final ChannelConfigKey<Boolean> http2AllowGracefulDelayed = new ChannelConfigKey<>("http2AllowGracefulDelayed", true);

--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/OptionalHAProxyMessageDecoder.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/OptionalHAProxyMessageDecoder.java
@@ -17,9 +17,7 @@
 package com.netflix.netty.common.proxyprotocol;
 
 import com.netflix.config.CachedDynamicBooleanProperty;
-import com.netflix.config.DynamicStringProperty;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.ProtocolDetectionResult;
@@ -38,11 +36,14 @@ import org.slf4j.LoggerFactory;
  * Date: 3/24/16
  * Time: 3:13 PM
  */
-public class OptionalHAProxyMessageDecoder extends ChannelInboundHandlerAdapter
+public final class OptionalHAProxyMessageDecoder extends ChannelInboundHandlerAdapter
 {
     public static final String NAME = "OptionalHAProxyMessageDecoder";
     private static final Logger logger = LoggerFactory.getLogger("OptionalHAProxyMessageDecoder");
-    private static final CachedDynamicBooleanProperty dumpHAProxyByteBuf = new CachedDynamicBooleanProperty("zuul.haproxy.dump.bytebuf", false);
+    private static final CachedDynamicBooleanProperty dumpHAProxyByteBuf =
+            new CachedDynamicBooleanProperty("zuul.haproxy.dump.bytebuf", false);
+
+    OptionalHAProxyMessageDecoder() {}
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
@@ -185,52 +185,61 @@ public abstract class BaseServerStartup
     {
         ChannelConfig config = new ChannelConfig();
 
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.maxConnections,
-                chooseIntChannelProperty(portName, "connection.max", 20000)));
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.maxRequestsPerConnection,
+        config.add(new ChannelConfigValue<>(
+                CommonChannelConfigKeys.maxConnections,
+                chooseIntChannelProperty(
+                        portName, "connection.max", CommonChannelConfigKeys.maxConnections.defaultValue())));
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.maxRequestsPerConnection,
                 chooseIntChannelProperty(portName, "connection.max.requests", 20000)));
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.maxRequestsPerConnectionInBrownout,
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.maxRequestsPerConnectionInBrownout,
                 chooseIntChannelProperty(portName, "connection.max.requests.brownout", CommonChannelConfigKeys.maxRequestsPerConnectionInBrownout.defaultValue())));
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.connectionExpiry,
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.connectionExpiry,
                 chooseIntChannelProperty(portName, "connection.expiry", CommonChannelConfigKeys.connectionExpiry.defaultValue())));
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.httpRequestReadTimeout,
-                chooseIntChannelProperty(portName, "http.request.read.timeout", 5000)));
+        config.add(new ChannelConfigValue<>(
+                CommonChannelConfigKeys.httpRequestReadTimeout,
+                chooseIntChannelProperty(
+                        portName,
+                        "http.request.read.timeout",
+                        CommonChannelConfigKeys.httpRequestReadTimeout.defaultValue())));
 
-        int connectionIdleTimeout = chooseIntChannelProperty(portName, "connection.idle.timeout", 65000);
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.idleTimeout, connectionIdleTimeout));
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.serverTimeout, new ServerTimeout(connectionIdleTimeout)));
+        int connectionIdleTimeout = chooseIntChannelProperty(
+                portName, "connection.idle.timeout",
+                CommonChannelConfigKeys.idleTimeout.defaultValue());
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.idleTimeout, connectionIdleTimeout));
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.serverTimeout, new ServerTimeout(connectionIdleTimeout)));
 
         // For security, default to NEVER allowing XFF/Proxy headers from client.
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.allowProxyHeadersWhen, StripUntrustedProxyHeadersHandler.AllowWhen.NEVER));
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.allowProxyHeadersWhen, StripUntrustedProxyHeadersHandler.AllowWhen.NEVER));
 
         config.set(CommonChannelConfigKeys.withProxyProtocol, true);
         config.set(CommonChannelConfigKeys.preferProxyProtocolForClientIp, true);
 
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.connCloseDelay,
-                chooseIntChannelProperty(portName, "connection.close.delay", 10)));
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.connCloseDelay,
+                chooseIntChannelProperty(
+                        portName, "connection.close.delay", CommonChannelConfigKeys.connCloseDelay.defaultValue())));
 
         return config;
     }
 
     public static void addHttp2DefaultConfig(ChannelConfig config, String portName)
     {
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.maxConcurrentStreams,
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.maxConcurrentStreams,
                 chooseIntChannelProperty(portName, "http2.max.concurrent.streams", CommonChannelConfigKeys.maxConcurrentStreams.defaultValue())));
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.initialWindowSize,
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.initialWindowSize,
                 chooseIntChannelProperty(portName, "http2.initialwindowsize", CommonChannelConfigKeys.initialWindowSize.defaultValue())));
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.maxHttp2HeaderTableSize,
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.maxHttp2HeaderTableSize,
                 chooseIntChannelProperty(portName, "http2.maxheadertablesize", 65536)));
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.maxHttp2HeaderListSize,
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.maxHttp2HeaderListSize,
                 chooseIntChannelProperty(portName, "http2.maxheaderlistsize", 32768)));
 
         // Override this to a lower value, as we'll be using ELB TCP listeners for h2, and therefore the connection
         // is direct from each device rather than shared in an ELB pool.
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.maxRequestsPerConnection,
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.maxRequestsPerConnection,
                 chooseIntChannelProperty(portName, "connection.max.requests", 4000)));
 
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.http2AllowGracefulDelayed,
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.http2AllowGracefulDelayed,
                 chooseBooleanChannelProperty(portName, "connection.close.graceful.delayed.allow", true)));
-        config.add(new ChannelConfigValue(CommonChannelConfigKeys.http2SwallowUnknownExceptionsOnConnClose,
+        config.add(new ChannelConfigValue<>(CommonChannelConfigKeys.http2SwallowUnknownExceptionsOnConnClose,
                 chooseBooleanChannelProperty(portName, "connection.close.swallow.unknown.exceptions", false)));
     }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializerTest.java
@@ -1,0 +1,89 @@
+package com.netflix.zuul.netty.server;
+
+import com.netflix.netty.common.SourceAddressChannelHandler;
+import com.netflix.netty.common.channel.config.ChannelConfig;
+import com.netflix.netty.common.channel.config.CommonChannelConfigKeys;
+import com.netflix.netty.common.metrics.PerEventLoopMetricsChannelHandler;
+import com.netflix.netty.common.metrics.ServerChannelMetrics;
+import com.netflix.netty.common.proxyprotocol.ElbProxyProtocolChannelHandler;
+import com.netflix.netty.common.proxyprotocol.OptionalHAProxyMessageDecoder;
+import com.netflix.netty.common.throttle.MaxInboundConnectionsHandler;
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.zuul.netty.ratelimiting.NullChannelHandlerProvider;
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.util.concurrent.GlobalEventExecutor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit tests for {@link BaseZuulChannelInitializer}.
+ */
+@RunWith(JUnit4.class)
+public class BaseZuulChannelInitializerTest {
+
+    @Test
+    public void tcpHandlersAdded() {
+        int port = 1234;
+        ChannelConfig channelConfig = new ChannelConfig();
+        ChannelConfig channelDependencies = new ChannelConfig();
+        channelDependencies.set(ZuulDependencyKeys.registry, new NoopRegistry());
+        channelDependencies.set(
+                ZuulDependencyKeys.rateLimitingChannelHandlerProvider, new NullChannelHandlerProvider());
+        channelDependencies.set(
+                ZuulDependencyKeys.sslClientCertCheckChannelHandlerProvider, new NullChannelHandlerProvider());
+        ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+        BaseZuulChannelInitializer init =
+                new BaseZuulChannelInitializer(port, channelConfig, channelDependencies, channelGroup) {
+
+            @Override
+            protected void initChannel(Channel ch) {}
+        };
+        EmbeddedChannel channel = new EmbeddedChannel();
+
+        init.addTcpRelatedHandlers(channel.pipeline());
+
+        assertNotNull(channel.pipeline().context(SourceAddressChannelHandler.class));
+        assertNotNull(channel.pipeline().context(ServerChannelMetrics.class));
+        assertNotNull(channel.pipeline().context(PerEventLoopMetricsChannelHandler.Connections.class));
+        assertNotNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
+        assertNull(channel.pipeline().context(OptionalHAProxyMessageDecoder.NAME));
+        assertNotNull(channel.pipeline().context(MaxInboundConnectionsHandler.class));
+    }
+
+    @Test
+    public void tcpHandlersAdded_withProxyProtocol() {
+        int port = 1234;
+        ChannelConfig channelConfig = new ChannelConfig();
+        channelConfig.set(CommonChannelConfigKeys.withProxyProtocol, true);
+        ChannelConfig channelDependencies = new ChannelConfig();
+        channelDependencies.set(ZuulDependencyKeys.registry, new NoopRegistry());
+        channelDependencies.set(
+                ZuulDependencyKeys.rateLimitingChannelHandlerProvider, new NullChannelHandlerProvider());
+        channelDependencies.set(
+                ZuulDependencyKeys.sslClientCertCheckChannelHandlerProvider, new NullChannelHandlerProvider());
+        ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+        BaseZuulChannelInitializer init =
+                new BaseZuulChannelInitializer(port, channelConfig, channelDependencies, channelGroup) {
+
+                    @Override
+                    protected void initChannel(Channel ch) {}
+                };
+        EmbeddedChannel channel = new EmbeddedChannel();
+
+        init.addTcpRelatedHandlers(channel.pipeline());
+
+        assertNotNull(channel.pipeline().context(SourceAddressChannelHandler.class));
+        assertNotNull(channel.pipeline().context(ServerChannelMetrics.class));
+        assertNotNull(channel.pipeline().context(PerEventLoopMetricsChannelHandler.Connections.class));
+        assertNotNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
+        assertNotNull(channel.pipeline().context(OptionalHAProxyMessageDecoder.NAME));
+        assertNotNull(channel.pipeline().context(MaxInboundConnectionsHandler.class));
+    }
+}


### PR DESCRIPTION
Changes:

* Fix generics on some call sites.   This is a breaking change, but needed for type safety.
* Move the default values for a few dynamic properties to the config key.   This avoids an NPE when unboxing the values in BaseZuulChannelInitializer.
    * Note that `connCloseDelay`  Does **not** have a default in the initializer, and picks the default of 0 in `ConnectionCloseChannelAttributes`.  This is a behavior change, but I think it's okay.
* Add some basic unit tests for the TCP handlers being added.   Some of the code is copied; we can deduplicate it later if there is enough overlap in future tests.