### PR TITLE
core: raise generic bounds for DiscoverClient

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ZuulDependencyKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ZuulDependencyKeys.java
@@ -17,7 +17,7 @@
 package com.netflix.zuul.netty.server;
 
 import com.netflix.appinfo.ApplicationInfoManager;
-import com.netflix.discovery.DiscoveryClient;
+import com.netflix.discovery.EurekaClient;
 import com.netflix.netty.common.accesslog.AccessLogPublisher;
 import com.netflix.netty.common.channel.config.ChannelConfigKey;
 import com.netflix.netty.common.metrics.EventLoopGroupMetrics;
@@ -48,7 +48,7 @@ public class ZuulDependencyKeys {
     public static final ChannelConfigKey<BasicCounter> httpRequestReadTimeoutCounter = new ChannelConfigKey<>("httpRequestReadTimeoutCounter");
     public static final ChannelConfigKey<FilterLoader> filterLoader = new ChannelConfigKey<>("filterLoader");
     public static final ChannelConfigKey<FilterUsageNotifier> filterUsageNotifier = new ChannelConfigKey<>("filterUsageNotifier");
-    public static final ChannelConfigKey<DiscoveryClient> discoveryClient = new ChannelConfigKey<>("discoveryClient");
+    public static final ChannelConfigKey<EurekaClient> discoveryClient = new ChannelConfigKey<>("discoveryClient");
     public static final ChannelConfigKey<ApplicationInfoManager> applicationInfoManager = new ChannelConfigKey<>("applicationInfoManager");
     public static final ChannelConfigKey<ServerStatusManager> serverStatusManager = new ChannelConfigKey<>("serverStatusManager");
     public static final ChannelConfigKey<Boolean> SSL_CLIENT_CERT_CHECK_REQUIRED = new ChannelConfigKey<>("requiresSslClientCertCheck", false);


### PR DESCRIPTION
As exposed by #620 the bounds on the discovery client should be EurekaClient rather than DiscoveryClient.

