### PR TITLE
core:   Don't fire HAProxyMessage further up the pipeline

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java
@@ -101,22 +101,13 @@ public class ElbProxyProtocolChannelHandler extends ChannelInboundHandlerAdapter
                     channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_PORT).set(hapm.sourcePort());
                 }
 
-                // PPV2 passes dynamic fields in TLV format which
-                // HAProxyMessage decodes into bytebufs retaining
-                // refCounts..call release to avoid bytebuf leaks
-                List<HAProxyTLV> haProxyTLVList = hapm.tlvs();
-                if (haProxyTLVList != null) {
-                    logger.debug("Decoded PPV2 TLV list count: {}, List: {}", haProxyTLVList.size(), haProxyTLVList);
-                    for (int i = 0; i < haProxyTLVList.size(); i++) {
-                        HAProxyTLV haProxyTLV = haProxyTLVList.get(i);
-                        haProxyTLV.release();
-                    }
-                }
-
                 // TODO - fire an additional event to notify interested parties that we now know the IP?
 
                 // Remove ourselves (this handler) from the channel now, as no more work to do.
                 ctx.pipeline().remove(this);
+
+                // Do not continue propagating the message.
+                return;
             }
         }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/common/proxyprotocol/ElbProxyProtocolChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/common/proxyprotocol/ElbProxyProtocolChannelHandlerTest.java
@@ -31,8 +31,6 @@ public class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object dropped = channel.readInbound();
-
-        // TODO(carl-mastrangelo): this test should be inverted, but ensuring existing behavior at the moment.
         assertEquals(dropped, buf);
 
         // TODO(carl-mastrangelo): the handler should remove itself, but it currently doesn't.
@@ -55,10 +53,7 @@ public class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object dropped = channel.readInbound();
-
-        // TODO(carl-mastrangelo): this test should be inverted, but ensuring existing behavior at the moment.
-        assertNotNull(dropped);
-        assertTrue(dropped.toString(), dropped instanceof HAProxyMessage);
+        assertNull(dropped);
 
         // The handler should remove itself.
         assertNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
@@ -83,10 +78,7 @@ public class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object dropped = channel.readInbound();
-
-        // TODO(carl-mastrangelo): this test should be inverted, but ensuring existing behavior at the moment.
-        assertNotNull(dropped);
-        assertTrue(dropped.toString(), dropped instanceof HAProxyMessage);
+        assertNull(dropped);
 
         // The handler should remove itself.
         assertNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
@@ -114,10 +106,7 @@ public class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object dropped = channel.readInbound();
-
-        // TODO(carl-mastrangelo): this test should be inverted, but ensuring existing behavior at the moment.
-        assertNotNull(dropped);
-        assertTrue(dropped.toString(), dropped instanceof HAProxyMessage);
+        assertNull(dropped);
 
         // The handler should remove itself.
         assertNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));


### PR DESCRIPTION
Additionally, don't release the interior TLVs as the channel clode future takes care of that now