### PR TITLE
Make Zuul able to work with JDK 11.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 
 plugins {
-    id 'nebula.netflixoss' version '7.1.2'
-    id 'nebula.dependency-lock' version '7.3.0'
+    id 'nebula.netflixoss' version '8.0.0'
+    id 'nebula.dependency-lock' version '8.0.0'
     id "com.google.osdetector" version "1.6.2"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compile 'commons-collections:commons-collections:3.2.2'
     compile 'commons-configuration:commons-configuration:1.8'
     compile "org.apache.commons:commons-lang3:3.4"
+    compile "com.google.guava:guava:28.1-jre"
     compile "org.codehaus.groovy:groovy-all:${versions_groovy}"
     compile "org.slf4j:slf4j-api:1.7.25"
     compile "org.json:json:20090211"

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -8,6 +8,10 @@
             "locked": "2.9.8",
             "requested": "2.9.8"
         },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
         "com.google.inject.extensions:guice-assistedinject": {
             "locked": "4.1.0",
             "requested": "4.0"
@@ -182,6 +186,10 @@
             "locked": "2.9.8",
             "requested": "2.9.8"
         },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
         "com.google.inject.extensions:guice-assistedinject": {
             "locked": "4.1.0",
             "requested": "4.0"
@@ -355,6 +363,10 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.9.8",
             "requested": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
         },
         "com.google.inject.extensions:guice-assistedinject": {
             "locked": "4.1.0",
@@ -534,6 +546,10 @@
             "locked": "2.9.8",
             "requested": "2.9.8"
         },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
         "com.google.inject.extensions:guice-assistedinject": {
             "locked": "4.1.0",
             "requested": "4.0"
@@ -711,6 +727,10 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.9.8",
             "requested": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
         },
         "com.google.inject.extensions:guice-assistedinject": {
             "locked": "4.1.0",
@@ -890,6 +910,10 @@
             "locked": "2.9.8",
             "requested": "2.9.8"
         },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
         "com.google.inject.extensions:guice-assistedinject": {
             "locked": "4.1.0",
             "requested": "4.0"
@@ -1068,6 +1092,10 @@
             "locked": "2.9.8",
             "requested": "2.9.8"
         },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
         "com.google.inject.extensions:guice-assistedinject": {
             "locked": "4.1.0",
             "requested": "4.0"
@@ -1245,6 +1273,10 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.9.8",
             "requested": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
         },
         "com.google.inject.extensions:guice-assistedinject": {
             "locked": "4.1.0",
@@ -1427,6 +1459,10 @@
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.9.8",
             "requested": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
         },
         "com.google.inject.extensions:guice-assistedinject": {
             "locked": "4.1.0",

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -12,6 +12,12 @@
             ],
             "locked": "2.9.8"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
+        },
         "com.google.inject.extensions:guice-assistedinject": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -290,6 +296,12 @@
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
         },
         "com.google.inject.extensions:guice-assistedinject": {
             "firstLevelTransitive": [
@@ -570,6 +582,12 @@
             ],
             "locked": "2.9.8"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
+        },
         "com.google.inject.extensions:guice-assistedinject": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -848,6 +866,12 @@
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
         },
         "com.google.inject.extensions:guice-assistedinject": {
             "firstLevelTransitive": [
@@ -1128,6 +1152,12 @@
             ],
             "locked": "2.9.8"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
+        },
         "com.google.inject.extensions:guice-assistedinject": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -1406,6 +1436,12 @@
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
         },
         "com.google.inject.extensions:guice-assistedinject": {
             "firstLevelTransitive": [
@@ -1686,6 +1722,12 @@
             ],
             "locked": "2.9.8"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
+        },
         "com.google.inject.extensions:guice-assistedinject": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -1965,6 +2007,12 @@
             ],
             "locked": "2.9.8"
         },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
+        },
         "com.google.inject.extensions:guice-assistedinject": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -2243,6 +2291,12 @@
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
         },
         "com.google.inject.extensions:guice-assistedinject": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -161,61 +161,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-resolver": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.25.Final"
+            "locked": "2.0.26.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -245,13 +245,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [
@@ -440,61 +440,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-resolver": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.25.Final"
+            "locked": "2.0.26.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -524,13 +524,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [
@@ -719,61 +719,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-resolver": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.25.Final"
+            "locked": "2.0.26.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -803,13 +803,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [
@@ -998,61 +998,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-resolver": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.25.Final"
+            "locked": "2.0.26.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1082,13 +1082,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [
@@ -1277,61 +1277,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-resolver": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.25.Final"
+            "locked": "2.0.26.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1361,13 +1361,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [
@@ -1556,61 +1556,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-resolver": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.25.Final"
+            "locked": "2.0.26.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1640,13 +1640,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [
@@ -1835,61 +1835,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-resolver": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.25.Final"
+            "locked": "2.0.26.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1919,13 +1919,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [
@@ -2114,61 +2114,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-resolver": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.25.Final"
+            "locked": "2.0.26.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -2198,13 +2198,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [
@@ -2393,61 +2393,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-resolver": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.25.Final"
+            "locked": "2.0.26.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.39.Final"
+            "locked": "4.1.42.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -2477,13 +2477,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.62"
+            "locked": "1.63"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [


### PR DESCRIPTION
This change is split into multiple Commits, but is logically part of one single change to update Guava.   The `ZuulFiltersModule` class depends on Guava reflection utility to scan the classpath for filters.  This class does not work with OpenJDK 11, and thus needs to be updated to the latest Guava release.

This PR:

1.  Updates to the latest Gradle.  (this is needed to update to the latest Nebula, and to work with the JDK 11 'version string' parsing.
2.  Updates to the latest Nebula (this is needed to work with the latest Gradle)
3.  Updates the lock files to use the latest nebula
4.  Updates to Guava 28.1



This should be ~mostly~ okay.   If there are any problems, it should be okay to just rollback the commits that cause issue.   Along with the changes to `https://github.com/Netflix/governator/pull/397`, we should be able to work with JDK 11.

