### PR TITLE
zuul-core: add perfmark annotations

### DIFF
--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     compile "junit:junit:latest.release"
     compile "org.mockito:mockito-core:1.9.+"
 
+    compile 'io.perfmark:perfmark-api:0.17.0'
+
     testCompile "com.netflix.governator:governator-test-junit:1.+"
 }
 

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -153,11 +153,11 @@
             "requested": "3.4"
         },
         "org.bouncycastle:bcpg-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
@@ -314,6 +314,10 @@
             "locked": "4.1.42.Final",
             "requested": "4.1.42.Final"
         },
+        "io.perfmark:perfmark-api": {
+            "locked": "0.17.0",
+            "requested": "0.17.0"
+        },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
             "requested": "1.2.1"
@@ -331,11 +335,11 @@
             "requested": "3.4"
         },
         "org.bouncycastle:bcpg-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
@@ -496,6 +500,10 @@
             "locked": "4.1.42.Final",
             "requested": "4.1.42.Final"
         },
+        "io.perfmark:perfmark-api": {
+            "locked": "0.17.0",
+            "requested": "0.17.0"
+        },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
             "requested": "1.2.1"
@@ -513,11 +521,11 @@
             "requested": "3.4"
         },
         "org.bouncycastle:bcpg-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
@@ -695,11 +703,11 @@
             "requested": "3.4"
         },
         "org.bouncycastle:bcpg-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
@@ -860,6 +868,10 @@
             "locked": "4.1.42.Final",
             "requested": "4.1.42.Final"
         },
+        "io.perfmark:perfmark-api": {
+            "locked": "0.17.0",
+            "requested": "0.17.0"
+        },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
             "requested": "1.2.1"
@@ -877,11 +889,11 @@
             "requested": "3.4"
         },
         "org.bouncycastle:bcpg-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
@@ -1059,11 +1071,11 @@
             "requested": "3.4"
         },
         "org.bouncycastle:bcpg-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
@@ -1224,6 +1236,10 @@
             "locked": "4.1.42.Final",
             "requested": "4.1.42.Final"
         },
+        "io.perfmark:perfmark-api": {
+            "locked": "0.17.0",
+            "requested": "0.17.0"
+        },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
             "requested": "1.2.1"
@@ -1241,11 +1257,11 @@
             "requested": "3.4"
         },
         "org.bouncycastle:bcpg-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
@@ -1427,11 +1443,11 @@
             "requested": "3.4"
         },
         "org.bouncycastle:bcpg-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
@@ -1596,6 +1612,10 @@
             "locked": "4.1.42.Final",
             "requested": "4.1.42.Final"
         },
+        "io.perfmark:perfmark-api": {
+            "locked": "0.17.0",
+            "requested": "0.17.0"
+        },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
             "requested": "1.2.1"
@@ -1613,11 +1633,11 @@
             "requested": "3.4"
         },
         "org.bouncycastle:bcpg-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.63",
+            "locked": "1.64",
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/SyncZuulFilterAdapter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/SyncZuulFilterAdapter.java
@@ -19,6 +19,8 @@ package com.netflix.zuul.filters;
 import com.netflix.zuul.exception.ZuulFilterConcurrencyExceededException;
 import com.netflix.zuul.message.ZuulMessage;
 import io.netty.handler.codec.http.HttpContent;
+import io.perfmark.PerfMark;
+import io.perfmark.Tag;
 import rx.Observable;
 
 import static com.netflix.zuul.filters.FilterSyncType.SYNC;
@@ -40,6 +42,16 @@ import static com.netflix.zuul.filters.FilterType.ENDPOINT;
  * Created by saroskar on 6/8/17.
  */
 public abstract class SyncZuulFilterAdapter<I extends ZuulMessage, O extends ZuulMessage> implements SyncZuulFilter<I, O> {
+
+    private final Tag tag = PerfMark.createTag(getClass().getSimpleName() + "." + filterType());
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final Tag perfmarkTag() {
+        return tag;
+    }
 
     @Override
     public boolean isDisabled() {

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
@@ -18,6 +18,8 @@ package com.netflix.zuul.filters;
 import com.netflix.zuul.exception.ZuulFilterConcurrencyExceededException;
 import com.netflix.zuul.message.ZuulMessage;
 import io.netty.handler.codec.http.HttpContent;
+import io.perfmark.PerfMark;
+import io.perfmark.Tag;
 import rx.Observable;
 
 /**
@@ -98,4 +100,14 @@ public interface ZuulFilter<I extends ZuulMessage, O extends ZuulMessage> extend
      * @return
      */
     HttpContent processContentChunk(ZuulMessage zuulMessage, HttpContent chunk);
+
+    /**
+     * Returns the internal profiling tag for this filter.   This method is NOT API stable, and may be removed.
+     * This method is internal.
+     * @return
+     */
+    default Tag perfmarkTag() {
+        return PerfMark.createTag();
+    }
+
 }


### PR DESCRIPTION
I tried to keep this as clean as possible.  PerfMark does make things more verbose, but it should have almost no effect on the runtime performance.  The bridge between the async observable and observe is slightly annoying, but I believe works properly.   In particular, making the links available to the observer from the observable appears to have a happens-before relationship in the Rx implementation.  I used compareAndSet to make sure it is only set once, incase onNext is accidentally called twice.

Tested manually, it looks like it is working properly.