### PR TITLE
Prepare BasicNettyOrigin for subclassing

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOriginManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOriginManager.java
@@ -49,6 +49,8 @@ public class BasicNettyOriginManager implements OriginManager<BasicNettyOrigin> 
 
     @Override
     public BasicNettyOrigin createOrigin(String name, String vip, String uri, boolean useFullVipName, SessionContext ctx) {
-        return new BasicNettyOrigin(name, vip, registry);
+        BasicNettyOrigin origin = new BasicNettyOrigin(name, vip, registry);
+        origin.init();
+        return origin;
     }
 }


### PR DESCRIPTION
BasicNettyOrigin contains some valuable logic like status recording and concurrency protection. Therefore it would be an ideal base class for more complex NettyOrigin implementations. This PR introduces the following changes:

1. Make relevant fields protected
2. Separate construction from initializing the downstream objects like `IClientConfig` and `ClientChannelManager` by introducing a post-construct method`init()`
3. Introduce method to selectively override `ClientChannelManager` construction
4. Protected method to obtain an LB server selection key based on the Zuul request object

