### PR TITLE
Dont cache perfmark tag

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/BaseFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/BaseFilter.java
@@ -47,7 +47,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class BaseFilter<I extends ZuulMessage, O extends ZuulMessage> implements ZuulFilter<I,O>
 {
     private final String baseName;
-    private final Tag tag;
     private final AtomicInteger concurrentCount;
     private final Counter concurrencyRejections;
 
@@ -58,7 +57,6 @@ public abstract class BaseFilter<I extends ZuulMessage, O extends ZuulMessage> i
 
     protected BaseFilter() {
         baseName = getClass().getSimpleName() + "." + filterType();
-        tag = PerfMark.createTag(baseName);
         concurrentCount = SpectatorUtils.newGauge("zuul.filter.concurrency.current", baseName, new AtomicInteger(0));
         concurrencyRejections = SpectatorUtils.newCounter("zuul.filter.concurrency.rejected", baseName);
         filterDisabled = new CachedDynamicBooleanProperty(disablePropertyName(), false);
@@ -67,7 +65,7 @@ public abstract class BaseFilter<I extends ZuulMessage, O extends ZuulMessage> i
 
     @Override
     public String filterName() {
-        return this.getClass().getName();
+        return getClass().getName();
     }
 
     @Override
@@ -145,13 +143,5 @@ public abstract class BaseFilter<I extends ZuulMessage, O extends ZuulMessage> i
     @Override
     public void decrementConcurrency() {
         concurrentCount.decrementAndGet();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public final Tag perfmarkTag() {
-        return tag;
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/SyncZuulFilterAdapter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/SyncZuulFilterAdapter.java
@@ -43,16 +43,6 @@ import static com.netflix.zuul.filters.FilterType.ENDPOINT;
  */
 public abstract class SyncZuulFilterAdapter<I extends ZuulMessage, O extends ZuulMessage> implements SyncZuulFilter<I, O> {
 
-    private final Tag tag = PerfMark.createTag(getClass().getSimpleName() + "." + filterType());
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public final Tag perfmarkTag() {
-        return tag;
-    }
-
     @Override
     public boolean isDisabled() {
         return false;

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
@@ -107,7 +107,7 @@ public interface ZuulFilter<I extends ZuulMessage, O extends ZuulMessage> extend
      * @return
      */
     default Tag perfmarkTag() {
-        return PerfMark.createTag();
+        return PerfMark.createTag(filterName());
     }
 
 }


### PR DESCRIPTION
I forgot that the tag is a noop impl depending on if it is enabled.   It doesn't make sense to cache the tag in the filter, since the filter instance isn't created for each request.