### PR TITLE
zuul-core: depend on the correct kqueue jar

### DIFF
--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     compile "io.netty:netty-resolver:${versions_netty}"
     compile "io.netty:netty-transport:${versions_netty}"
     compile "io.netty:netty-transport-native-epoll:${versions_netty}:linux-x86_64"
-    compile "io.netty:netty-transport-native-kqueue:${versions_netty}"
+    compile "io.netty:netty-transport-native-kqueue:${versions_netty}:osx-x86_64"
     runtime "io.netty:netty-tcnative-boringssl-static:2.0.26.Final"
 
     // To ensure that zuul-netty gets this correct later version.


### PR DESCRIPTION
Testing manually shows the native deps are missing.