### PR TITLE
zuul-core:  Make BaseServerStartup prefer using socket addresses

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
@@ -43,6 +43,7 @@ import io.netty.util.concurrent.DefaultEventExecutorChooserFactory;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorChooserFactory;
 import io.netty.util.concurrent.ThreadPerTaskExecutor;
+import java.util.LinkedHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,6 +101,11 @@ public class Server
     private final Map<? extends SocketAddress, ? extends ChannelInitializer<?>> addressesToInitializers;
     private final EventLoopConfig eventLoopConfig;
 
+    /**
+     * Use {@link #Server(ServerStatusManager, Map, ClientConnectionsShutdown, EventLoopGroupMetrics, EventLoopConfig)}
+     * instead.
+     */
+    @Deprecated
     public Server(Map<Integer, ChannelInitializer> portsToChannelInitializers, ServerStatusManager serverStatusManager,
                   ClientConnectionsShutdown clientConnectionsShutdown, EventLoopGroupMetrics eventLoopGroupMetrics)
     {
@@ -107,7 +113,12 @@ public class Server
                 new DefaultEventLoopConfig());
     }
 
+    /**
+     * Use {@link #Server(ServerStatusManager, Map, ClientConnectionsShutdown, EventLoopGroupMetrics, EventLoopConfig)}
+     * instead.
+     */
     @SuppressWarnings("unchecked") // Channel init map has the wrong generics and we can't fix without api breakage.
+    @Deprecated
     public Server(Map<Integer, ChannelInitializer> portsToChannelInitializers, ServerStatusManager serverStatusManager,
                   ClientConnectionsShutdown clientConnectionsShutdown, EventLoopGroupMetrics eventLoopGroupMetrics,
                   EventLoopConfig eventLoopConfig) {
@@ -116,11 +127,11 @@ public class Server
                 clientConnectionsShutdown, eventLoopGroupMetrics, eventLoopConfig);
     }
 
-    Server(ServerStatusManager serverStatusManager,
+    protected Server(ServerStatusManager serverStatusManager,
            Map<? extends SocketAddress, ? extends ChannelInitializer<?>> addressesToInitializers,
            ClientConnectionsShutdown clientConnectionsShutdown, EventLoopGroupMetrics eventLoopGroupMetrics,
            EventLoopConfig eventLoopConfig) {
-        this.addressesToInitializers = Collections.unmodifiableMap(new HashMap<>(addressesToInitializers));
+        this.addressesToInitializers = Collections.unmodifiableMap(new LinkedHashMap<>(addressesToInitializers));
         this.serverStatusManager = checkNotNull(serverStatusManager, "serverStatusManager");
         this.clientConnectionsShutdown = checkNotNull(clientConnectionsShutdown, "clientConnectionsShutdown");
         this.eventLoopConfig = checkNotNull(eventLoopConfig, "eventLoopConfig");
@@ -361,10 +372,10 @@ public class Server
         }
     }
 
-    private static Map<SocketAddress, ChannelInitializer<?>> convertPortMap(
+    static Map<SocketAddress, ChannelInitializer<?>> convertPortMap(
             Map<Integer, ChannelInitializer<?>> portsToChannelInitializers) {
         Map<SocketAddress, ChannelInitializer<?>> addrsToInitializers =
-                new HashMap<>(portsToChannelInitializers.size());
+                new LinkedHashMap<>(portsToChannelInitializers.size());
         for (Map.Entry<Integer, ChannelInitializer<?>> portToInitializer : portsToChannelInitializers.entrySet()){
             addrsToInitializers.put(new InetSocketAddress(portToInitializer.getKey()), portToInitializer.getValue());
         }

--- a/zuul-sample/src/main/java/com/netflix/zuul/sample/SampleServerStartup.java
+++ b/zuul-sample/src/main/java/com/netflix/zuul/sample/SampleServerStartup.java
@@ -42,6 +42,8 @@ import com.netflix.netty.common.proxyprotocol.StripUntrustedProxyHeadersHandler;
 import com.netflix.netty.common.ssl.ServerSslConfig;
 import com.netflix.netty.common.status.ServerStatusManager;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
@@ -86,11 +88,12 @@ public class SampleServerStartup extends BaseServerStartup {
     }
 
     @Override
-    protected Map<Integer, ChannelInitializer> choosePortsAndChannels(ChannelGroup clientChannels) {
-        Map<Integer, ChannelInitializer> portsToChannels = new HashMap<>();
+    protected Map<SocketAddress, ChannelInitializer<?>> chooseAddrsAndChannels(ChannelGroup clientChannels) {
+        Map<SocketAddress, ChannelInitializer<?>> addrsToChannels = new HashMap<>();
 
         String mainPortName = "main";
         int port = new DynamicIntProperty("zuul.server.port.main", 7001).get();
+        SocketAddress sockAddr = new InetSocketAddress(port);
 
         ChannelConfig channelConfig = defaultChannelConfig(mainPortName);
         int pushPort = new DynamicIntProperty("zuul.server.port.http.push", 7008).get();
@@ -110,7 +113,9 @@ public class SampleServerStartup extends BaseServerStartup {
                 channelConfig.set(CommonChannelConfigKeys.isSSlFromIntermediary, false);
                 channelConfig.set(CommonChannelConfigKeys.withProxyProtocol, false);
 
-                portsToChannels.put(port, new ZuulServerChannelInitializer(port, channelConfig, channelDependencies, clientChannels));
+                addrsToChannels.put(
+                        sockAddr,
+                        new ZuulServerChannelInitializer(port, channelConfig, channelDependencies, clientChannels));
                 logPortConfigured(port);
                 break;
 
@@ -131,7 +136,9 @@ public class SampleServerStartup extends BaseServerStartup {
 
                 addHttp2DefaultConfig(channelConfig, mainPortName);
 
-                portsToChannels.put(port, new Http2SslChannelInitializer(port, channelConfig, channelDependencies, clientChannels));
+                addrsToChannels.put(
+                        sockAddr,
+                        new Http2SslChannelInitializer(port, channelConfig, channelDependencies, clientChannels));
                 logPortConfigured(port, sslConfig);
                 break;
 
@@ -160,7 +167,9 @@ public class SampleServerStartup extends BaseServerStartup {
                 channelConfig.set(CommonChannelConfigKeys.serverSslConfig, sslConfig);
                 channelConfig.set(CommonChannelConfigKeys.sslContextFactory, new BaseSslContextFactory(registry, sslConfig));
 
-                portsToChannels.put(port, new Http1MutualSslChannelInitializer(port, channelConfig, channelDependencies, clientChannels));
+                addrsToChannels.put(
+                        sockAddr,
+                        new Http1MutualSslChannelInitializer(port, channelConfig, channelDependencies, clientChannels));
                 logPortConfigured(port, sslConfig);
                 break;
 
@@ -174,11 +183,13 @@ public class SampleServerStartup extends BaseServerStartup {
 
                 channelDependencies.set(ZuulDependencyKeys.pushConnectionRegistry, pushConnectionRegistry);
 
-                portsToChannels.put(port, new SampleWebSocketPushChannelInitializer(port, channelConfig, channelDependencies, clientChannels));
+                addrsToChannels.put(
+                        sockAddr,
+                        new SampleWebSocketPushChannelInitializer(port, channelConfig, channelDependencies, clientChannels));
                 logPortConfigured(port);
 
                 // port to accept push message from the backend, should be accessible on internal network only.
-                portsToChannels.put(pushPort, pushSenderInitializer);
+                addrsToChannels.put(new InetSocketAddress(pushPort), pushSenderInitializer);
                 logPortConfigured(pushPort);
 
                 break;
@@ -193,17 +204,19 @@ public class SampleServerStartup extends BaseServerStartup {
 
                 channelDependencies.set(ZuulDependencyKeys.pushConnectionRegistry, pushConnectionRegistry);
 
-                portsToChannels.put(port, new SampleSSEPushChannelInitializer(port, channelConfig, channelDependencies, clientChannels));
+                addrsToChannels.put(
+                        sockAddr,
+                        new SampleSSEPushChannelInitializer(port, channelConfig, channelDependencies, clientChannels));
                 logPortConfigured(port);
 
                 // port to accept push message from the backend, should be accessible on internal network only.
-                portsToChannels.put(pushPort, pushSenderInitializer);
+                addrsToChannels.put(new InetSocketAddress(pushPort), pushSenderInitializer);
                 logPortConfigured(pushPort);
 
                 break;
         }
 
-        return portsToChannels;
+        return addrsToChannels;
     }
 
     private File loadFromResources(String s) {


### PR DESCRIPTION
This is an incremental change to allow existing code to slowly move over to socket addresses rather than ports.   Old clients can still override existing methods (but with a deprecation warning), while new clients can override the socket address methods.

Updates CGW-95