### PR TITLE
zuul-core: Use filter names in profiling calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ subprojects {
 
     repositories {
         jcenter()
+        mavenLocal()
     }
 
     license {

--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     compile "junit:junit:latest.release"
     compile "org.mockito:mockito-core:1.9.+"
 
-    compile 'io.perfmark:perfmark-api:0.17.0'
+    compile 'io.perfmark:perfmark-api:0.20.0'
 
     testCompile "com.netflix.governator:governator-test-junit:1.+"
     testCompile 'junit:junit:4.13-rc-1'

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -141,8 +141,8 @@
             "requested": "4.1.43.Final"
         },
         "io.perfmark:perfmark-api": {
-            "locked": "0.17.0",
-            "requested": "0.17.0"
+            "locked": "0.20.0",
+            "requested": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
@@ -327,8 +327,8 @@
             "requested": "4.1.43.Final"
         },
         "io.perfmark:perfmark-api": {
-            "locked": "0.17.0",
-            "requested": "0.17.0"
+            "locked": "0.20.0",
+            "requested": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
@@ -517,8 +517,8 @@
             "requested": "4.1.43.Final"
         },
         "io.perfmark:perfmark-api": {
-            "locked": "0.17.0",
-            "requested": "0.17.0"
+            "locked": "0.20.0",
+            "requested": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
@@ -707,8 +707,8 @@
             "requested": "4.1.43.Final"
         },
         "io.perfmark:perfmark-api": {
-            "locked": "0.17.0",
-            "requested": "0.17.0"
+            "locked": "0.20.0",
+            "requested": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
@@ -897,8 +897,8 @@
             "requested": "4.1.43.Final"
         },
         "io.perfmark:perfmark-api": {
-            "locked": "0.17.0",
-            "requested": "0.17.0"
+            "locked": "0.20.0",
+            "requested": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
@@ -1087,8 +1087,8 @@
             "requested": "4.1.43.Final"
         },
         "io.perfmark:perfmark-api": {
-            "locked": "0.17.0",
-            "requested": "0.17.0"
+            "locked": "0.20.0",
+            "requested": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
@@ -1277,8 +1277,8 @@
             "requested": "4.1.43.Final"
         },
         "io.perfmark:perfmark-api": {
-            "locked": "0.17.0",
-            "requested": "0.17.0"
+            "locked": "0.20.0",
+            "requested": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
@@ -1471,8 +1471,8 @@
             "requested": "4.1.43.Final"
         },
         "io.perfmark:perfmark-api": {
-            "locked": "0.17.0",
-            "requested": "0.17.0"
+            "locked": "0.20.0",
+            "requested": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",
@@ -1665,8 +1665,8 @@
             "requested": "4.1.43.Final"
         },
         "io.perfmark:perfmark-api": {
-            "locked": "0.17.0",
-            "requested": "0.17.0"
+            "locked": "0.20.0",
+            "requested": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "locked": "1.2.1",

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
@@ -18,8 +18,6 @@ package com.netflix.zuul.filters;
 import com.netflix.zuul.exception.ZuulFilterConcurrencyExceededException;
 import com.netflix.zuul.message.ZuulMessage;
 import io.netty.handler.codec.http.HttpContent;
-import io.perfmark.PerfMark;
-import io.perfmark.Tag;
 import rx.Observable;
 
 /**
@@ -99,15 +97,4 @@ public interface ZuulFilter<I extends ZuulMessage, O extends ZuulMessage> extend
      * @param chunk
      * @return
      */
-    HttpContent processContentChunk(ZuulMessage zuulMessage, HttpContent chunk);
-
-    /**
-     * Returns the internal profiling tag for this filter.   This method is NOT API stable, and may be removed.
-     * This method is internal.
-     * @return
-     */
-    default Tag perfmarkTag() {
-        return PerfMark.createTag(filterName());
-    }
-
-}
+    HttpContent processContentChunk(ZuulMessage zuulMessage, HttpContent chunk);}

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
@@ -138,26 +138,35 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
         }
     }
 
+    protected final void addPerfMarkTags(I inMesg) {
+      if (inMesg instanceof HttpRequestInfo) {
+        PerfMark.attachTag("path", ((HttpRequestInfo) inMesg).getPath());
+        PerfMark.attachTag("path", ((HttpRequestInfo) inMesg).getPath());
+      }
+      PerfMark.attachTag("uuid", inMesg.getContext().getUUID());
+    }
+
     protected final O filter(final ZuulFilter<I, O> filter, final I inMesg) {
         final long startTime = System.nanoTime();
         final ZuulMessage snapshot = inMesg.getContext().debugRouting() ? inMesg.clone() : null;
         FilterChainResumer resumer = null;
 
-        PerfMark.startTask("FilterRunner.filter", filter.perfmarkTag());
+        PerfMark.startTask(filter.filterName(), "filter");
         try {
+            addPerfMarkTags(inMesg);
             ExecutionStatus filterRunStatus = null;
             if (filter.filterType() == INBOUND && inMesg.getContext().shouldSendErrorResponse()) {
                 // Pass request down the pipeline, all the way to error endpoint if error response needs to be generated
                 filterRunStatus = SKIPPED;
             }
 
-            PerfMark.startTask("FilterRunner.shouldSkipFilter", filter.perfmarkTag());
+            PerfMark.startTask(filter.filterName(), "shouldSkipFilter");
             try {
                 if (shouldSkipFilter(inMesg, filter)) {
                     filterRunStatus = SKIPPED;
                 }
             } finally {
-                PerfMark.stopTask("FilterRunner.shouldSkipFilter", filter.perfmarkTag());
+              PerfMark.stopTask(filter.filterName(), "shouldSkipFilter");
             }
 
             if (filter.isDisabled()) {
@@ -186,29 +195,30 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
             if (filter.getSyncType() == FilterSyncType.SYNC) {
                 final SyncZuulFilter<I, O> syncFilter = (SyncZuulFilter) filter;
                 final O outMesg;
-                PerfMark.startTask("FilterRunner.applySync", filter.perfmarkTag());
+                PerfMark.startTask(filter.filterName(), "apply");
                 try {
+                    addPerfMarkTags(inMesg);
                     outMesg = syncFilter.apply(inMesg);
                 } finally {
-                    PerfMark.stopTask("FilterRunner.applySync", filter.perfmarkTag());
+                  PerfMark.stopTask(filter.filterName(), "apply");
                 }
                 recordFilterCompletion(SUCCESS, filter, startTime, inMesg, snapshot);
                 return (outMesg != null) ? outMesg : filter.getDefaultOutput(inMesg);
             }
 
             // async filter
-            PerfMark.startTask("FilterRunner.applyAsync", filter.perfmarkTag());
+            PerfMark.startTask(filter.filterName(), "applyAsync");
             try {
                 final Link nettyToSchedulerLink = PerfMark.linkOut();
                 filter.incrementConcurrency();
                 resumer = new FilterChainResumer(inMesg, filter, snapshot, startTime);
                 filter.applyAsync(inMesg)
                         .doOnSubscribe(() -> {
-                            PerfMark.startTask("FilterRunner.onSubscribeAsync", filter.perfmarkTag());
+                            PerfMark.startTask(filter.filterName(), "onSubscribeAsync");
                             try {
                                 PerfMark.linkIn(nettyToSchedulerLink);
                             } finally {
-                                PerfMark.stopTask("FilterRunner.onSubscribeAsync", filter.perfmarkTag());
+                              PerfMark.stopTask(filter.filterName(), "onSubscribeAsync");
                             }
                         })
                         .doOnNext(resumer.onNextStarted(nettyToSchedulerLink))
@@ -218,7 +228,7 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
                         .doOnUnsubscribe(resumer::decrementConcurrency)
                         .subscribe(resumer);
             } finally {
-                PerfMark.stopTask("FilterRunner.applyAsync", filter.perfmarkTag());
+              PerfMark.stopTask(filter.filterName(), "applyAsync");
             }
 
             return null;  //wait for the async filter to finish
@@ -232,7 +242,7 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
             recordFilterCompletion(FAILED, filter, startTime, inMesg, snapshot);
             return outMesg;
         } finally {
-            PerfMark.stopTask("FilterRunner.filter", filter.perfmarkTag());
+          PerfMark.stopTask(filter.filterName(), "filter");
         }
     }
 
@@ -383,29 +393,33 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
 
         @Override
         public void onNext(O outMesg) {
-            PerfMark.startTask("FilterChainResumer.onNext", filter.perfmarkTag());
+            boolean stopped = false;
+            PerfMark.startTask(filter.filterName(), "onNextAsync");
             try {
-                PerfMark.event("FilterChainResumer.resumeNext", PerfMark.createTag(inMesg.getContext().getUUID()));
                 PerfMark.linkIn(onNextLinkOut.get());
+                addPerfMarkTags(inMesg);
                 recordFilterCompletion(SUCCESS, filter, startTime, inMesg, snapshot);
                 if (outMesg == null) {
                     outMesg = filter.getDefaultOutput(inMesg);
                 }
+                stopped = true;
+                PerfMark.stopTask(filter.filterName(), "onNextAsync");
                 resumeInBindingContext(outMesg, filter.filterName());
             }
             catch (Exception e) {
                 decrementConcurrency();
                 handleException(inMesg, filter.filterName(), e);
             } finally {
-                PerfMark.stopTask("FilterChainResumer.onNext", filter.perfmarkTag());
+                if (!stopped) {
+                    PerfMark.stopTask(filter.filterName(), "onNextAsync");
+                }
             }
         }
 
         @Override
         public void onError(Throwable ex) {
-            PerfMark.startTask("FilterChainResumer.onError", filter.perfmarkTag());
+            PerfMark.startTask(filter.filterName(), "onErrorAsync");
             try {
-                PerfMark.event("FilterChainResumer.resumeError", PerfMark.createTag(inMesg.getContext().getUUID()));
                 PerfMark.linkIn(onErrorLinkOut.get());
                 decrementConcurrency();
                 recordFilterCompletion(FAILED, filter, startTime, inMesg, snapshot);
@@ -415,55 +429,50 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
             catch (Exception e) {
                 handleException(inMesg, filter.filterName(), e);
             } finally {
-                PerfMark.stopTask("FilterChainResumer.onError", filter.perfmarkTag());
-            }
+              PerfMark.stopTask(filter.filterName(), "onErrorAsync");            }
         }
 
         @Override
         public void onCompleted() {
-            PerfMark.startTask("FilterChainResumer.onCompleted", filter.perfmarkTag());
+            PerfMark.startTask(filter.filterName(), "onCompletedAsync");
             try {
                 PerfMark.linkIn(onCompletedLinkOut.get( ));
-                PerfMark.event("FilterChainResumer.resumeCompleted", PerfMark.createTag(inMesg.getContext().getUUID()));
                 decrementConcurrency();
             } finally {
-                PerfMark.stopTask("FilterChainResumer.onCompleted", filter.perfmarkTag());
+              PerfMark.stopTask(filter.filterName(), "onCompletedAsync");
             }
         }
 
         private Action1<O> onNextStarted(Link onNextLinkIn) {
             return o -> {
-                PerfMark.startTask("FilterRunner.onNextAsync", filter.perfmarkTag());
+                PerfMark.startTask(filter.filterName(), "onNext");
                 try {
                     PerfMark.linkIn(onNextLinkIn);
                     onNextLinkOut.compareAndSet(null, PerfMark.linkOut());
                 } finally {
-                    PerfMark.stopTask("FilterRunner.onNextAsync", filter.perfmarkTag());
-                }
+                    PerfMark.stopTask(filter.filterName(), "onNext");                }
             };
         }
 
         private Action1<Throwable> onErrorStarted(Link onErrorLinkIn) {
             return t -> {
-                PerfMark.startTask("FilterRunner.onErrorAsync", filter.perfmarkTag());
+                PerfMark.startTask(filter.filterName(), "onError");
                 try {
                     PerfMark.linkIn(onErrorLinkIn);
                     onErrorLinkOut.compareAndSet(null, PerfMark.linkOut());
                 } finally {
-                    PerfMark.stopTask("FilterRunner.onErrorAsync", filter.perfmarkTag());
-                }
+                    PerfMark.stopTask(filter.filterName(), "onError");                }
             };
         }
 
         private Action0 onCompletedStarted(Link onCompletedLinkIn) {
             return () -> {
-                PerfMark.startTask("FilterRunner.onCompletedAsync", filter.perfmarkTag());
+                PerfMark.startTask(filter.filterName(), "onCompleted");
                 try {
                     PerfMark.linkIn(onCompletedLinkIn);
                     onCompletedLinkOut.compareAndSet(null, PerfMark.linkOut());
                 } finally {
-                    PerfMark.stopTask("FilterRunner.onCompletedAsync", filter.perfmarkTag());
-                }
+                    PerfMark.stopTask(filter.filterName(), "onCompleted");                }
             };
         }
     }

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -80,19 +80,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-archaius": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.netflix-commons:netflix-commons-util": {
             "firstLevelTransitive": [
@@ -233,7 +233,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.17.0"
+            "locked": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -245,7 +245,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.13-beta-3"
+            "locked": "4.13-rc-1"
         },
         "log4j:log4j": {
             "firstLevelTransitive": [
@@ -377,19 +377,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-archaius": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.netflix-commons:netflix-commons-util": {
             "firstLevelTransitive": [
@@ -530,7 +530,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.17.0"
+            "locked": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -542,7 +542,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.13-beta-3"
+            "locked": "4.13-rc-1"
         },
         "log4j:log4j": {
             "firstLevelTransitive": [
@@ -674,19 +674,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-archaius": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.netflix-commons:netflix-commons-util": {
             "firstLevelTransitive": [
@@ -827,7 +827,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.17.0"
+            "locked": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -839,7 +839,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.13-beta-3"
+            "locked": "4.13-rc-1"
         },
         "log4j:log4j": {
             "firstLevelTransitive": [
@@ -971,19 +971,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-archaius": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.netflix-commons:netflix-commons-util": {
             "firstLevelTransitive": [
@@ -1124,7 +1124,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.17.0"
+            "locked": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1136,7 +1136,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.13-beta-3"
+            "locked": "4.13-rc-1"
         },
         "log4j:log4j": {
             "firstLevelTransitive": [
@@ -1268,19 +1268,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-archaius": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.netflix-commons:netflix-commons-util": {
             "firstLevelTransitive": [
@@ -1421,7 +1421,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.17.0"
+            "locked": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1433,7 +1433,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.13-beta-3"
+            "locked": "4.13-rc-1"
         },
         "log4j:log4j": {
             "firstLevelTransitive": [
@@ -1565,19 +1565,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-archaius": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.netflix-commons:netflix-commons-util": {
             "firstLevelTransitive": [
@@ -1718,7 +1718,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.17.0"
+            "locked": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1730,7 +1730,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.13-beta-3"
+            "locked": "4.13-rc-1"
         },
         "log4j:log4j": {
             "firstLevelTransitive": [
@@ -1862,19 +1862,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-archaius": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.netflix-commons:netflix-commons-util": {
             "firstLevelTransitive": [
@@ -2015,7 +2015,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.17.0"
+            "locked": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -2027,7 +2027,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.13-beta-3"
+            "locked": "4.13-rc-1"
         },
         "log4j:log4j": {
             "firstLevelTransitive": [
@@ -2159,19 +2159,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-archaius": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.netflix-commons:netflix-commons-util": {
             "firstLevelTransitive": [
@@ -2312,7 +2312,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.17.0"
+            "locked": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -2324,7 +2324,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.13-beta-3"
+            "locked": "4.13-rc-1"
         },
         "log4j:log4j": {
             "firstLevelTransitive": [
@@ -2456,19 +2456,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-archaius": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.governator:governator-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.17.8"
+            "locked": "1.17.9"
         },
         "com.netflix.netflix-commons:netflix-commons-util": {
             "firstLevelTransitive": [
@@ -2609,7 +2609,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.17.0"
+            "locked": "0.20.0"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -2621,7 +2621,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.13-beta-3"
+            "locked": "4.13-rc-1"
         },
         "log4j:log4j": {
             "firstLevelTransitive": [


### PR DESCRIPTION
Motivation:  Several of the tracing calls are not very useful, because they push the filter name into the tag, rather than the task.   This change makes filter runners put the filter name in the task, and apply per request tags instead.    This was not done originally, as PerfMark was not originally designed for the runtime-constant number of task (it was compile time constant only).

This should give dramatically better (and still very cheap) insight into what takes a long time in filter processing.