### PR TITLE
zuul-core: silence log spam during builds

### DIFF
--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -54,9 +54,16 @@ dependencies {
 
     testCompile "com.netflix.governator:governator-test-junit:1.+"
     testCompile 'junit:junit:4.13-rc-1'
+    testRuntime 'org.slf4j:slf4j-simple:1.7.29'
 }
 
 jar {
     from sourceSets.main.allGroovy
 }
 
+// Silences log statements during tests.   This still allows normal failures to be printed.
+test {
+    testLogging {
+        showStandardStreams = false
+    }
+}

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -1511,8 +1511,12 @@
             "requested": "1.9.+"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
+            "locked": "1.7.29",
             "requested": "1.7.25"
+        },
+        "org.slf4j:slf4j-simple": {
+            "locked": "1.7.29",
+            "requested": "1.7.29"
         }
     },
     "testRuntimeClasspath": {
@@ -1705,8 +1709,12 @@
             "requested": "1.9.+"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.25",
+            "locked": "1.7.29",
             "requested": "1.7.25"
+        },
+        "org.slf4j:slf4j-simple": {
+            "locked": "1.7.29",
+            "requested": "1.7.29"
         }
     }
 }


### PR DESCRIPTION
Adds a dummy log backend, and then silences it.