### PR TITLE
Logssl

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
@@ -401,7 +401,7 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
 
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-            if (msg instanceof ByteBuf && handshakeBuf.readableBytes() < 1024) {
+            if (msg instanceof ByteBuf && handshakeBuf.readableBytes() < 256) {
                 ByteBuf buf = (ByteBuf) msg;
                 handshakeBuf.addComponent(buf.retainedSlice());
             }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/Http1MutualSslChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/Http1MutualSslChannelInitializer.java
@@ -17,7 +17,12 @@
 package com.netflix.zuul.netty.server;
 
 import com.netflix.zuul.netty.ssl.SslContextFactory;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.handler.ssl.SslContext;
@@ -25,7 +30,10 @@ import io.netty.handler.ssl.SslHandler;
 import com.netflix.netty.common.channel.config.ChannelConfig;
 import com.netflix.netty.common.channel.config.CommonChannelConfigKeys;
 
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import javax.net.ssl.SSLException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * User: michaels@netflix.com
@@ -87,7 +95,7 @@ public class Http1MutualSslChannelInitializer extends BaseZuulChannelInitializer
         addTimeoutHandlers(pipeline);
         addPassportHandler(pipeline);
         addTcpRelatedHandlers(pipeline);
-        pipeline.addLast("ssl", sslHandler);
+        addLastSslHandler(pipeline, "ssl", sslHandler);
         addSslInfoHandlers(pipeline, isSSlFromIntermediary);
         addSslClientCertChecks(pipeline);
         addHttp1Handlers(pipeline);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2SslChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2SslChannelInitializer.java
@@ -106,7 +106,7 @@ public final class Http2SslChannelInitializer extends BaseZuulChannelInitializer
         addPassportHandler(pipeline);
         addTcpRelatedHandlers(pipeline);
         pipeline.addLast(new Http2FrameLoggingPerClientIpHandler());
-        pipeline.addLast("ssl", sslHandler);
+        addLastSslHandler(pipeline, "ssl", sslHandler);
         addSslInfoHandlers(pipeline, isSSlFromIntermediary);
         addSslClientCertChecks(pipeline);
 


### PR DESCRIPTION
Optional follow on: make this enabled via an FP.  I don't know how often these connection errors occur, but it seems like failures are hard to debug without seeing the bytes, and we might forget that this exists.    