### PR TITLE
all: test with both openjdk11 and openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
-- openjdk8
+  - openjdk8
+  - openjdk11
 install: "./installViaTravis.sh"
 script: "./buildViaTravis.sh"
 cache:


### PR DESCRIPTION
I think this should be okay.    We still compile against the Java 8 API in our gradle file.