### PR TITLE
zuul-core: rework Cookie logic to use non-deprecated types

### DIFF
--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     testCompile "com.netflix.governator:governator-test-junit:1.+"
     testCompile 'junit:junit:4.13-rc-1'
     testRuntime 'org.slf4j:slf4j-simple:1.7.29'
+
+    testImplementation 'com.google.truth:truth:1.0'
 }
 
 jar {

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/Cookies.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/Cookies.java
@@ -16,55 +16,108 @@
 
 package com.netflix.zuul.message.http;
 
+import static java.util.Collections.unmodifiableList;
+import static java.util.stream.Collectors.toList;
+
 import io.netty.handler.codec.http.Cookie;
 
+import io.netty.handler.codec.http.DefaultCookie;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * User: Mike Smith
  * Date: 6/18/15
  * Time: 12:04 AM
  */
-public class Cookies
-{
-    private Map<String, List<Cookie>> map = new HashMap<>();
-    private List<Cookie> all = new ArrayList<>();
+public final class Cookies {
+    private final Map<String, List<io.netty.handler.codec.http.cookie.Cookie>> map = new LinkedHashMap<>();
+    private final List<io.netty.handler.codec.http.cookie.Cookie> all = new ArrayList<>();
 
-    public void add(Cookie cookie)
-    {
-        List<Cookie> existing = map.get(cookie.getName());
-        if (existing == null) {
-            existing = new ArrayList<>();
-            map.put(cookie.getName(), existing);
-        }
-        existing.add(cookie);
+    public void add(io.netty.handler.codec.http.cookie.Cookie cookie) {
+        Objects.requireNonNull(cookie, "cookie");
+        String name = Objects.requireNonNull(cookie.name(), "name");
+        map.computeIfAbsent(name, key -> new ArrayList<>()).add(cookie);
         all.add(cookie);
     }
 
-    public List<Cookie> getAll()
-    {
-        return all;
+    /**
+     * Use {@link #add(io.netty.handler.codec.http.cookie.Cookie)} instead.
+     */
+    @Deprecated
+    public void add(Cookie cookie) {
+        add((io.netty.handler.codec.http.cookie.Cookie) cookie);
     }
 
-    public List<Cookie> get(String name)
-    {
-        return map.get(name);
+    /**
+     * Use {@link #getAllCookies()} instead.
+     */
+    @Deprecated
+    public List<Cookie> getAll() {
+        return unmodifiableList(getAllCookies().stream().map(Cookies::convert).collect(toList()));
     }
 
-    public Cookie getFirst(String name)
-    {
-        List<Cookie> found = map.get(name);
-        if (found == null || found.size() == 0) {
+    /**
+     * Returns all cookies.
+     */
+    public List<io.netty.handler.codec.http.cookie.Cookie> getAllCookies() {
+        return unmodifiableList(new ArrayList<>(all));
+    }
+
+    /**
+     * Returns all cookies for a given name, or an empty list if there are none..
+     */
+    public List<io.netty.handler.codec.http.cookie.Cookie> getCookies(String name) {
+        Objects.requireNonNull(name, "name");
+        return unmodifiableList(new ArrayList<>(map.computeIfAbsent(name, key -> Collections.emptyList())));
+    }
+
+    /**
+     * Returns all cookies for the given name, or {@code null} if absent.  Use {@link #getCookies(String)} instead.
+     */
+    @Deprecated
+    @Nullable
+    public List<Cookie> get(String name) {
+        List<io.netty.handler.codec.http.cookie.Cookie> cookies = getCookies(name);
+        if (!cookies.isEmpty()) {
+            return unmodifiableList(cookies.stream().map(Cookies::convert).collect(toList()));
+        }
+        return null;
+    }
+
+    /**
+     * Returns the first cookie value set for the given name, or {@code null} if absent.
+     */
+    @Nullable
+    public io.netty.handler.codec.http.cookie.Cookie getFirstCookie(String name) {
+        Objects.requireNonNull(name, "name");
+        List<io.netty.handler.codec.http.cookie.Cookie> cookies = map.get(name);
+        if (cookies == null || cookies.isEmpty()) {
             return null;
         }
-        return found.get(0);
+        return cookies.get(0);
     }
 
-    public String getFirstValue(String name)
-    {
+    /**
+     * Use {@link #getFirstCookie(String)} instead.
+     */
+    @Deprecated
+    @Nullable
+    public Cookie getFirst(String name) {
+        io.netty.handler.codec.http.cookie.Cookie cookie = getFirstCookie(name);
+        if (cookie != null) {
+            return convert(cookie);
+        }
+        return null;
+    }
+
+    public String getFirstValue(String name) {
         Cookie c = getFirst(name);
         String value;
         if (c != null) {
@@ -73,5 +126,17 @@ public class Cookies
             value = null;
         }
         return value;
+    }
+
+    @SuppressWarnings("deprecation")
+    private static final Cookie convert(io.netty.handler.codec.http.cookie.Cookie cookie) {
+        if (cookie instanceof Cookie) {
+            return (Cookie) cookie;
+        }
+        Cookie c = new DefaultCookie(cookie.name(), cookie.value());
+        c.setHttpOnly(cookie.isHttpOnly());
+        c.setDomain(cookie.domain());
+        return c;
+
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushAuthHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushAuthHandler.java
@@ -19,6 +19,7 @@ import com.google.common.base.Strings;
 import com.netflix.zuul.message.http.Cookies;
 import io.netty.channel.*;
 import io.netty.handler.codec.http.*;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,6 +103,7 @@ public abstract class PushAuthHandler extends SimpleChannelInboundHandler<FullHt
         final Cookies cookies = new Cookies();
         final String cookieStr = req.headers().get(HttpHeaderNames.COOKIE);
         if (!Strings.isNullOrEmpty(cookieStr)) {
+            Set<io.netty.handler.codec.http.cookie.Cookie> res = ServerCookieDecoder.LAX.decode(cookieStr);
             final Set<Cookie> decoded = CookieDecoder.decode(cookieStr, false);
             decoded.forEach(cookie -> cookies.add(cookie));
         }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushAuthHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushAuthHandler.java
@@ -103,9 +103,8 @@ public abstract class PushAuthHandler extends SimpleChannelInboundHandler<FullHt
         final Cookies cookies = new Cookies();
         final String cookieStr = req.headers().get(HttpHeaderNames.COOKIE);
         if (!Strings.isNullOrEmpty(cookieStr)) {
-            Set<io.netty.handler.codec.http.cookie.Cookie> res = ServerCookieDecoder.LAX.decode(cookieStr);
-            final Set<Cookie> decoded = CookieDecoder.decode(cookieStr, false);
-            decoded.forEach(cookie -> cookies.add(cookie));
+            Set<io.netty.handler.codec.http.cookie.Cookie> decoded = ServerCookieDecoder.LAX.decode(cookieStr);
+            decoded.forEach(cookies::add);
         }
         return cookies;
     }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/CookiesTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/CookiesTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.message.http;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CookiesTest {
+    @Test
+    public void getAll_returnsAllValues() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        List<Cookie> allCookies = cookies.getAllCookies();
+
+        assertThat(allCookies).containsExactly(
+                new DefaultCookie("robots", "humans"), new DefaultCookie("robots", "cyborgs"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void getAll_returnsAllValues_deprecated() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        List<io.netty.handler.codec.http.Cookie> allCookies = cookies.getAll();
+
+        assertThat(allCookies).containsExactly(
+                new io.netty.handler.codec.http.DefaultCookie("robots", "humans"),
+                new io.netty.handler.codec.http.DefaultCookie("robots", "cyborgs"));
+    }
+
+    @Test
+    public void getAll_returnsEmpty() {
+        Cookies cookies = new Cookies();
+
+        List<Cookie> allCookies = cookies.getAllCookies();
+
+        assertThat(allCookies).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void getAll_returnsEmpty_deprecated() {
+        Cookies cookies = new Cookies();
+
+        List<io.netty.handler.codec.http.Cookie> allCookies = cookies.getAll();
+
+        assertThat(allCookies).isEmpty();
+    }
+
+    @Test
+    public void getCookies_present() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("aliens", "predators"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+
+        List<Cookie> allCookies = cookies.getCookies("robots");
+
+        assertThat(allCookies).containsExactly(
+                new DefaultCookie("robots", "humans"), new DefaultCookie("robots", "cyborgs"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void getCookies_present_deprecated() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("aliens", "predators"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        List<io.netty.handler.codec.http.Cookie> allCookies = cookies.get("robots");
+
+        assertThat(allCookies).containsExactly(
+                new io.netty.handler.codec.http.DefaultCookie("robots", "humans"),
+                new io.netty.handler.codec.http.DefaultCookie("robots", "cyborgs"));
+    }
+
+    @Test
+    public void getCookies_absentReturnsEmpty() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        List<Cookie> allCookies = cookies.getCookies("aliens");
+
+        assertThat(allCookies).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void getCookies_absentReturnsNull_deprecated() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        List<io.netty.handler.codec.http.Cookie> allCookies = cookies.get("aliens");
+
+        assertThat(allCookies).isNull();
+    }
+
+    @Test
+    public void getFirstCookie_present() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        Cookie cookie = cookies.getFirstCookie("robots");
+
+        assertThat(cookie).isEqualTo(new DefaultCookie("robots", "humans"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void getFirstCookie_present_deprecated() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        io.netty.handler.codec.http.Cookie cookie = cookies.getFirst("robots");
+
+        assertThat(cookie).isEqualTo(new io.netty.handler.codec.http.DefaultCookie("robots", "humans"));
+    }
+
+    @Test
+    public void getFirstCookie_absentReturnsNull() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        Cookie cookie = cookies.getFirstCookie("aliens");
+
+        assertThat(cookie).isNull();
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void getFirstCookie_absentReturnsNull_deprecated() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        io.netty.handler.codec.http.Cookie cookie = cookies.getFirst("aliens");
+
+        assertThat(cookie).isNull();
+    }
+
+    @Test
+    public void getFirstValue_present() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        String value = cookies.getFirstValue("robots");
+
+        assertThat(value).isEqualTo("humans");
+    }
+
+    @Test
+    public void getFirstValue_absentReturnsNull() {
+        Cookies cookies = new Cookies();
+        cookies.add(new DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        String value = cookies.getFirstValue("aliens");
+
+        assertThat(value).isNull();
+    }
+
+    // This checks that mixed cookie types can convert
+    @Test
+    @SuppressWarnings("deprecation")
+    public void addMixedDeprecated() {
+        Cookies cookies = new Cookies();
+        cookies.add(new io.netty.handler.codec.http.DefaultCookie("robots", "humans"));
+        cookies.add(new DefaultCookie("robots", "cyborgs"));
+
+        List<Cookie> allCookies = cookies.getAllCookies();
+
+        assertThat(allCookies).containsExactly(
+                new DefaultCookie("robots", "humans"),
+                new io.netty.handler.codec.http.DefaultCookie("robots", "cyborgs"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void convertImplOtherThanDefaultCookie() {
+        Cookie cookie = mock(Cookie.class);
+        when(cookie.name()).thenReturn("robots");
+        when(cookie.value()).thenReturn("humans");
+        when(cookie.domain()).thenReturn("domain");
+        when(cookie.isHttpOnly()).thenReturn(true);
+        when(cookie.isSecure()).thenReturn(true);
+        when(cookie.path()).thenReturn("/path");
+
+        io.netty.handler.codec.http.Cookie oldCookie = Cookies.convert(cookie);
+
+        assertThat(oldCookie.name()).isEqualTo("robots");
+        assertThat(oldCookie.value()).isEqualTo("humans");
+        assertThat(oldCookie.domain()).isEqualTo("domain");
+        assertThat(oldCookie.isSecure()).isEqualTo(true);
+        assertThat(oldCookie.isHttpOnly()).isEqualTo(true);
+        assertThat(oldCookie.path()).isEqualTo("/path");
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushAuthHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushAuthHandlerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.netty.server.push;
+
+import com.google.common.truth.Truth;
+import com.netflix.zuul.message.http.Cookies;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link PushAuthHandler}.
+ */
+@RunWith(JUnit4.class)
+public class PushAuthHandlerTest {
+
+    @Test
+    public void parseCookie() {
+        PushAuthHandler handler = new PushAuthHandler("pushConnectionPath", "originDomain"){
+            @Override
+            protected boolean isDelayedAuth(FullHttpRequest req, ChannelHandlerContext ctx) {
+                return false;
+            }
+
+            @Override
+            protected PushUserAuth doAuth(FullHttpRequest req) {
+                return null;
+            }
+        };
+
+        DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        req.headers().set(HttpHeaderNames.COOKIE, "robots=people");
+        Cookies cookies = handler.parseCookies(req);
+
+        Truth.assertWithMessage(cookies.toString()).that(cookies.getFirstValue("robots")).isEqualTo("people");
+    }
+}


### PR DESCRIPTION
This does a few things:

* Deprecates most of the cookie methods on the `Cookie` class
* Adds test for the Cookie class
* Updates the PushAuthHandler to use non-deprecated types
* adds tests for push.