### PR TITLE
zuul-core: make client connection shutdown depend on the channel

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientConnectionsShutdown.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientConnectionsShutdown.java
@@ -122,7 +122,8 @@ public class ClientConnectionsShutdown
 
                 ChannelPromise closePromise = channel.pipeline().newPromise();
                 channel.attr(ConnectionCloseChannelAttributes.CLOSE_AFTER_RESPONSE).set(closePromise);
-                closeAfterPromises.add((Future<Void>) closePromise);
+                // TODO(carl-mastrangelo): remove closePromise, since I don't think it's needed.  Need to verify.
+                closeAfterPromises.add(channel.closeFuture());
             }
 
             // Wait for all of the attempts to close connections gracefully, or max of 30 secs each.


### PR DESCRIPTION
Rather than wait for a request to come in to finish off a channel, just wait on the channel closeFuture instead.