### PR TITLE
Proxy protocol encodes dest port info on actual client request.

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -252,8 +252,8 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
         final String clientIp = channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get();
 
         // This is the only way I found to get the port of the request with netty...
-        final int port = channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).get();
-        final String serverName = channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_ADDRESS).get();
+        final String serverName = channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get();
+        final int port = channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_PORT).get();
 
         // Store info about the SSL handshake if applicable, and choose the http scheme.
         String scheme = SCHEME_HTTP;


### PR DESCRIPTION
We override these attributes [based on the proxy protocol channel config](https://github.com/Netflix/zuul/blob/b46bf5a736cb0e4feb1f5a07c3b80755010e13dc/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java#L93-L94), and it makes sense to reference these instead of the local server address and port that `zuul` is listening on.