### PR TITLE
Proxy protocol encodes dest port info on actual client request. Prefer that over Zuul's local server port.

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestInfo.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestInfo.java
@@ -58,6 +58,10 @@ public interface HttpRequestInfo extends ZuulMessage
 
     int getOriginalPort();
 
+    default int getClientDestinationPort() {
+        return getOriginalPort();
+    }
+
     String reconstructURI();
 
     /** Parse and lazily cache the request cookies. */

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
@@ -30,6 +30,8 @@ import com.netflix.zuul.util.HttpUtils;
 import io.netty.handler.codec.http.Cookie;
 import io.netty.handler.codec.http.CookieDecoder;
 import io.netty.handler.codec.http.HttpContent;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,6 +85,7 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
     private String scheme;
     private int port;
     private String serverName;
+    private SocketAddress clientRemoteAddress;
 
     private HttpRequestInfo inboundRequest = null;
     private Cookies parsedCookies = null;
@@ -95,14 +98,14 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
 
     public HttpRequestMessageImpl(SessionContext context, String protocol, String method, String path,
                                   HttpQueryParams queryParams, Headers headers, String clientIp, String scheme,
-                                  int port, String serverName)
+                                  int port, String serverName, SocketAddress clientRemoteAddress)
     {
-        this(context, protocol, method, path, queryParams, headers, clientIp, scheme, port, serverName, false);
+        this(context, protocol, method, path, queryParams, headers, clientIp, scheme, port, serverName, clientRemoteAddress, false);
     }
 
     public HttpRequestMessageImpl(SessionContext context, String protocol, String method, String path,
                                   HttpQueryParams queryParams, Headers headers, String clientIp, String scheme,
-                                  int port, String serverName,
+                                  int port, String serverName, SocketAddress clientRemoteAddress,
                                   boolean immutable)
     {
         this.immutable = immutable;
@@ -123,6 +126,7 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
         this.scheme = scheme;
         this.port = port;
         this.serverName = serverName;
+        this.clientRemoteAddress = clientRemoteAddress;
     }
 
     private void immutableCheck()
@@ -392,7 +396,7 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
         HttpRequestMessageImpl clone = new HttpRequestMessageImpl(message.getContext().clone(),
                 protocol, method, path,
                 queryParams.clone(), message.getHeaders().clone(), clientIp, scheme,
-                port, serverName);
+                port, serverName, clientRemoteAddress);
         if (getInboundRequest() != null) {
             clone.inboundRequest = (HttpRequestInfo) getInboundRequest().clone();
         }
@@ -405,7 +409,7 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
         HttpRequestMessageImpl req = new HttpRequestMessageImpl(message.getContext(),
                 protocol, method, path,
                 queryParams.immutableCopy(), message.getHeaders().immutableCopy(), clientIp, scheme,
-                port, serverName, true);
+                port, serverName, clientRemoteAddress, true);
         req.setHasBody(hasBody());
         return req;
     }
@@ -526,6 +530,15 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
             port = Integer.parseInt(portStr);
         }
         return port;
+    }
+
+    @Override
+    public int getClientDestinationPort() {
+        if (clientRemoteAddress instanceof InetSocketAddress) {
+            return ((InetSocketAddress) clientRemoteAddress).getPort();
+        } else {
+            return getOriginalPort();
+        }
     }
 
     /**

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -48,6 +48,7 @@ import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.netty.common.ssl.SslHandshakeInfo;
+import java.net.SocketAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -254,6 +255,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
         // This is the only way I found to get the port of the request with netty...
         final int port = channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).get();
         final String serverName = channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_ADDRESS).get();
+        final SocketAddress clientDestinationAddress = channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get();
 
         // Store info about the SSL handshake if applicable, and choose the http scheme.
         String scheme = SCHEME_HTTP;
@@ -287,7 +289,8 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
                 clientIp,
                 scheme,
                 port,
-                serverName
+                serverName,
+                clientDestinationAddress
         );
 
         // Try to decide if this request has a body or not based on the headers (as we won't yet have

--- a/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
@@ -33,6 +33,7 @@ import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpRequestMessageImpl;
 import com.netflix.zuul.message.http.HttpResponseMessage;
 import com.netflix.zuul.message.http.HttpResponseMessageImpl;
+import java.net.InetSocketAddress;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,7 +60,7 @@ public class DebugTest {
         params.add("k1", "v1");
 
         request = new HttpRequestMessageImpl(ctx, "HTTP/1.1", "post", "/some/where",
-            params, headers, "9.9.9.9", "https", 80, "localhost");
+            params, headers, "9.9.9.9", "https", 80, "localhost",new InetSocketAddress("api.netflix.com", 443));
         request.setBodyAsText("some text");
         request.storeInboundRequest();
 

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.when;
 
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.Headers;
+import io.netty.channel.local.LocalAddress;
+import java.net.InetSocketAddress;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,7 +45,7 @@ public class HttpRequestMessageImplTest {
         Headers headers = new Headers();
         headers.add("Host", "blah.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
 
         request.storeInboundRequest();
         HttpRequestInfo originalRequest = request.getInboundRequest();
@@ -71,7 +73,7 @@ public class HttpRequestMessageImplTest {
         Headers headers = new Headers();
         headers.add("Host", "blah.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals("https://blah.netflix.com:7002/some/where?flag=5", request.reconstructURI());
 
         queryParams = new HttpQueryParams();
@@ -79,7 +81,7 @@ public class HttpRequestMessageImplTest {
         headers.add("X-Forwarded-Host", "place.netflix.com");
         headers.add("X-Forwarded-Port", "80");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "http", 7002, "localhost");
+            "192.168.0.2", "http", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals("http://place.netflix.com/some/where", request.reconstructURI());
 
         queryParams = new HttpQueryParams();
@@ -88,13 +90,13 @@ public class HttpRequestMessageImplTest {
         headers.add("X-Forwarded-Proto", "https");
         headers.add("X-Forwarded-Port", "443");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "http", 7002, "localhost");
+            "192.168.0.2", "http", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals("https://place.netflix.com/some/where", request.reconstructURI());
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "http", 7002, "localhost");
+            "192.168.0.2", "http", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals("http://localhost:7002/some/where", request.reconstructURI());
 
         queryParams = new HttpQueryParams();
@@ -102,7 +104,7 @@ public class HttpRequestMessageImplTest {
         queryParams.add("flag B", "9");
         headers = new Headers();
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some%20where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals("https://localhost:7002/some%20where?flag=5&flag+B=9", request.reconstructURI());
     }
 
@@ -113,7 +115,7 @@ public class HttpRequestMessageImplTest {
         Headers headers = new Headers();
         headers.add("Host", "blah.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost", true);
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443), true);
 
         // Check it's the same value 2nd time.
         Assert.assertEquals("https://blah.netflix.com:7002/some/where?flag=5", request.reconstructURI());
@@ -121,7 +123,7 @@ public class HttpRequestMessageImplTest {
 
         // Check that cached on 1st usage.
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost", true);
+            "192.168.0.2", "https", 7002, "localhost",new InetSocketAddress("api.netflix.com", 443), true);
         request = spy(request);
         when(request._reconstructURI()).thenReturn("http://testhost/blah");
         verify(request, times(1))._reconstructURI();
@@ -143,7 +145,7 @@ public class HttpRequestMessageImplTest {
         HttpQueryParams queryParams = new HttpQueryParams();
         queryParams.add("flag", "5");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, new Headers(),
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
 
         // Check that value changes.
         Assert.assertEquals("/some/where?flag=5", request.getPathAndQuery());
@@ -158,7 +160,7 @@ public class HttpRequestMessageImplTest {
         HttpQueryParams queryParams = new HttpQueryParams();
         queryParams.add("flag", "5");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, new Headers(),
-            "192.168.0.2", "https", 7002, "localhost", true);
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443),true);
 
         // Check it's the same value 2nd time.
         Assert.assertEquals("/some/where?flag=5", request.getPathAndQuery());
@@ -166,7 +168,7 @@ public class HttpRequestMessageImplTest {
 
         // Check that cached on 1st usage.
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, new Headers(),
-            "192.168.0.2", "https", 7002, "localhost", true);
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443),true);
         request = spy(request);
         when(request.generatePathAndQuery()).thenReturn("/blah");
         verify(request, times(1)).generatePathAndQuery();
@@ -180,26 +182,26 @@ public class HttpRequestMessageImplTest {
         Headers headers = new Headers();
         headers.add("Host", "blah.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost",new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals("blah.netflix.com", request.getOriginalHost());
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com");
         headers.add("X-Forwarded-Host", "foo.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals("foo.netflix.com", request.getOriginalHost());
 
         headers = new Headers();
         headers.add("X-Forwarded-Host", "foo.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals("foo.netflix.com", request.getOriginalHost());
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com:8080");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals("blah.netflix.com", request.getOriginalHost());
     }
 
@@ -208,27 +210,27 @@ public class HttpRequestMessageImplTest {
         HttpQueryParams queryParams = new HttpQueryParams();
         Headers headers = new Headers();
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals(7002, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com");
         headers.add("X-Forwarded-Port", "443");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals(443, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com:443");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals(443, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com:443");
         headers.add("X-Forwarded-Port", "7005");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams, headers,
-            "192.168.0.2", "https", 7002, "localhost");
+            "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
         Assert.assertEquals(7005, request.getOriginalPort());
     }
 
@@ -238,5 +240,14 @@ public class HttpRequestMessageImplTest {
         assertEquals("BlahId=12345; something=67890;", HttpRequestMessageImpl.cleanCookieHeader("BlahId=12345; something=67890;"));
         assertEquals(" BlahId=12345; something=67890;", HttpRequestMessageImpl.cleanCookieHeader(" Secure, BlahId=12345; Secure, something=67890;"));
         assertEquals("", HttpRequestMessageImpl.cleanCookieHeader(""));
+    }
+
+    @Test
+    public void shouldPreferClientDestPortWhenInitialized() {
+        HttpRequestMessageImpl message = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST",
+                "/some/where", new HttpQueryParams(), new Headers(),
+                "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443));
+
+        assertEquals(message.getClientDestinationPort(), 443);
     }
 }


### PR DESCRIPTION
We override these attributes based on the [proxy protocol channel config](https://github.com/Netflix/zuul/blob/b46bf5a736cb0e4feb1f5a07c3b80755010e13dc/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java#L93-L94), and it makes sense to reference these instead of the local server address and port that zuul is listening on.

