### PR TITLE
Use server cookie decoder

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/Cookies.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/Cookies.java
@@ -16,12 +16,19 @@
 
 package com.netflix.zuul.message.http;
 
+import com.netflix.config.CachedDynamicBooleanProperty;
+import com.netflix.config.DynamicStringProperty;
+import com.netflix.zuul.message.Headers;
 import io.netty.handler.codec.http.Cookie;
+import io.netty.handler.codec.http.DefaultCookie;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * User: Mike Smith
@@ -30,6 +37,23 @@ import java.util.Map;
  */
 public class Cookies
 {
+    private static final Logger LOG = LoggerFactory.getLogger(Cookies.class);
+
+    private static final CachedDynamicBooleanProperty CLEAN_COOKIES = new CachedDynamicBooleanProperty(
+            "zuul.HttpRequestMessage.cookies.clean", false);
+
+    private static final List<Pattern> RE_STRIP;
+    /** ":::"-delimited list of regexes to strip out of the cookie headers. */
+    private static final DynamicStringProperty REGEX_PTNS_TO_STRIP_PROP =
+            new DynamicStringProperty("zuul.request.cookie.cleaner.strip", " Secure,");
+
+    static {
+        RE_STRIP = new ArrayList<>();
+        for (String ptn : REGEX_PTNS_TO_STRIP_PROP.get().split(":::")) {
+            RE_STRIP.add(Pattern.compile(ptn));
+        }
+    }
+
     private Map<String, List<Cookie>> map = new HashMap<>();
     private List<Cookie> all = new ArrayList<>();
 
@@ -73,5 +97,38 @@ public class Cookies
             value = null;
         }
         return value;
+    }
+
+    public static Cookies fromHeaders(Headers headers) {
+        Cookies cookies = new Cookies();
+        for (String aCookieHeader : headers.get(HttpHeaderNames.COOKIE)) {
+            try {
+                if (CLEAN_COOKIES.get()) {
+                    aCookieHeader = cleanCookieHeader(aCookieHeader);
+                }
+                List<io.netty.handler.codec.http.cookie.Cookie> decodedCookies =
+                        ServerCookieDecoder.LAX.decodeAll(aCookieHeader);
+                // Temporarily map to the deprecated objects until Zuul moves to the new interfaces.
+                List<Cookie> mappedCookies = decodedCookies.stream()
+                        .map(cookie -> new DefaultCookie(cookie.name(), cookie.value()))
+                        .collect(Collectors.toList());
+                for (Cookie cookie : mappedCookies) {
+                    cookies.add(cookie);
+                }
+            } catch (Exception e) {
+                LOG.error(String.format("Error parsing request Cookie header. cookie=%s", aCookieHeader));
+            }
+        }
+        return cookies;
+    }
+
+    static String cleanCookieHeader(String cookie) {
+        for (Pattern stripPtn : RE_STRIP) {
+            Matcher matcher = stripPtn.matcher(cookie);
+            if (matcher.find()) {
+                cookie = matcher.replaceAll("");
+            }
+        }
+        return cookie;
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/Cookies.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/Cookies.java
@@ -17,94 +17,37 @@
 package com.netflix.zuul.message.http;
 
 import com.netflix.config.CachedDynamicBooleanProperty;
-import com.netflix.config.DynamicStringProperty;
 import com.netflix.zuul.message.Headers;
 import io.netty.handler.codec.http.Cookie;
 import io.netty.handler.codec.http.DefaultCookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 /**
- * User: Mike Smith
- * Date: 6/18/15
- * Time: 12:04 AM
+ * User: Mike Smith Date: 6/18/15 Time: 12:04 AM
  */
-public class Cookies
-{
+public class Cookies {
+
     private static final Logger LOG = LoggerFactory.getLogger(Cookies.class);
 
     private static final CachedDynamicBooleanProperty CLEAN_COOKIES = new CachedDynamicBooleanProperty(
             "zuul.HttpRequestMessage.cookies.clean", false);
 
-    private static final List<Pattern> RE_STRIP;
-    /** ":::"-delimited list of regexes to strip out of the cookie headers. */
-    private static final DynamicStringProperty REGEX_PTNS_TO_STRIP_PROP =
-            new DynamicStringProperty("zuul.request.cookie.cleaner.strip", " Secure,");
-
-    static {
-        RE_STRIP = new ArrayList<>();
-        for (String ptn : REGEX_PTNS_TO_STRIP_PROP.get().split(":::")) {
-            RE_STRIP.add(Pattern.compile(ptn));
-        }
-    }
-
     private Map<String, List<Cookie>> map = new HashMap<>();
     private List<Cookie> all = new ArrayList<>();
-
-    public void add(Cookie cookie)
-    {
-        List<Cookie> existing = map.get(cookie.getName());
-        if (existing == null) {
-            existing = new ArrayList<>();
-            map.put(cookie.getName(), existing);
-        }
-        existing.add(cookie);
-        all.add(cookie);
-    }
-
-    public List<Cookie> getAll()
-    {
-        return all;
-    }
-
-    public List<Cookie> get(String name)
-    {
-        return map.get(name);
-    }
-
-    public Cookie getFirst(String name)
-    {
-        List<Cookie> found = map.get(name);
-        if (found == null || found.size() == 0) {
-            return null;
-        }
-        return found.get(0);
-    }
-
-    public String getFirstValue(String name)
-    {
-        Cookie c = getFirst(name);
-        String value;
-        if (c != null) {
-            value = c.getValue();
-        } else {
-            value = null;
-        }
-        return value;
-    }
 
     public static Cookies fromHeaders(Headers headers) {
         Cookies cookies = new Cookies();
         for (String aCookieHeader : headers.get(HttpHeaderNames.COOKIE)) {
             try {
                 if (CLEAN_COOKIES.get()) {
-                    aCookieHeader = cleanCookieHeader(aCookieHeader);
+                    aCookieHeader = CookiesSanitizer.cleanCookieHeader(aCookieHeader);
                 }
                 List<io.netty.handler.codec.http.cookie.Cookie> decodedCookies =
                         ServerCookieDecoder.LAX.decodeAll(aCookieHeader);
@@ -122,13 +65,40 @@ public class Cookies
         return cookies;
     }
 
-    static String cleanCookieHeader(String cookie) {
-        for (Pattern stripPtn : RE_STRIP) {
-            Matcher matcher = stripPtn.matcher(cookie);
-            if (matcher.find()) {
-                cookie = matcher.replaceAll("");
-            }
+    public void add(Cookie cookie) {
+        List<Cookie> existing = map.get(cookie.getName());
+        if (existing == null) {
+            existing = new ArrayList<>();
+            map.put(cookie.getName(), existing);
         }
-        return cookie;
+        existing.add(cookie);
+        all.add(cookie);
+    }
+
+    public List<Cookie> getAll() {
+        return all;
+    }
+
+    public List<Cookie> get(String name) {
+        return map.get(name);
+    }
+
+    public Cookie getFirst(String name) {
+        List<Cookie> found = map.get(name);
+        if (found == null || found.size() == 0) {
+            return null;
+        }
+        return found.get(0);
+    }
+
+    public String getFirstValue(String name) {
+        Cookie c = getFirst(name);
+        String value;
+        if (c != null) {
+            value = c.getValue();
+        } else {
+            value = null;
+        }
+        return value;
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/CookiesSanitizer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/CookiesSanitizer.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
  * Performs a simple cleanup of the cookie headers by removing values which shouldn't be part of a cookie header.
  * Note: It's a temporary hack put in place to clean cookie headers which will removed in future releases.
  */
+@Deprecated
 class CookiesSanitizer {
     private static final CachedDynamicBooleanProperty CLEAN_COOKIES = new CachedDynamicBooleanProperty(
             "zuul.HttpRequestMessage.cookies.clean", false);

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/CookiesSanitizer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/CookiesSanitizer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.zuul.message.http;
+
+import com.netflix.config.CachedDynamicBooleanProperty;
+import com.netflix.config.DynamicStringProperty;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Performs a simple cleanup of the cookie headers by removing values which shouldn't be part of a cookie header.
+ * Note: It's a temporary hack put in place to clean cookie headers which will removed in future releases.
+ */
+class CookiesSanitizer {
+    private static final CachedDynamicBooleanProperty CLEAN_COOKIES = new CachedDynamicBooleanProperty(
+            "zuul.HttpRequestMessage.cookies.clean", false);
+
+    private static final List<Pattern> RE_STRIP;
+    /**
+     * ":::"-delimited list of regexes to strip out of the cookie headers.
+     */
+    private static final DynamicStringProperty REGEX_PTNS_TO_STRIP_PROP =
+            new DynamicStringProperty("zuul.request.cookie.cleaner.strip", " Secure,");
+
+    static {
+        RE_STRIP = new ArrayList<>();
+        for (String ptn : REGEX_PTNS_TO_STRIP_PROP.get().split(":::")) {
+            RE_STRIP.add(Pattern.compile(ptn));
+        }
+    }
+
+    public static String cleanCookieHeader(String cookie) {
+        for (Pattern stripPtn : RE_STRIP) {
+            Matcher matcher = stripPtn.matcher(cookie);
+            if (matcher.find()) {
+                cookie = matcher.replaceAll("");
+            }
+        }
+        return cookie;
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/CookieSanitizerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/CookieSanitizerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.zuul.message.http;
+
+import static com.netflix.zuul.message.http.CookiesSanitizer.cleanCookieHeader;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CookieSanitizerTest {
+
+    @Test
+    public void testCleanCookieHeaders() {
+        assertEquals("BlahId=12345; something=67890;",
+                cleanCookieHeader("BlahId=12345; Secure, something=67890;"));
+        assertEquals("BlahId=12345; something=67890;",
+                cleanCookieHeader("BlahId=12345; something=67890;"));
+        assertEquals(" BlahId=12345; something=67890;",
+                cleanCookieHeader(" Secure, BlahId=12345; Secure, something=67890;"));
+        assertEquals("", cleanCookieHeader(""));
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/CookiesTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/CookiesTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.zuul.message.http;
+
+import com.netflix.zuul.message.Headers;
+import io.netty.handler.codec.http.Cookie;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static com.netflix.zuul.message.http.Cookies.cleanCookieHeader;
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CookiesTest {
+
+    @Test
+    public void testFromHeaders() {
+
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.COOKIE, "a=1; b=2");
+
+        Cookies cookies = Cookies.fromHeaders(headers);
+        List<Cookie> decodedCookies = cookies.getAll();
+
+        assertEquals(2, decodedCookies.size());
+        assertTrue("Decoded cookies have a=1 cookie", hasCookie(decodedCookies, "a", "1"));
+        assertTrue("Decoded cookies have b=1 cookie", hasCookie(decodedCookies, "b", "2"));
+    }
+
+    @Test
+    public void testFromHeadersDuplicateNames() {
+
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.COOKIE, "a=1; a=2");
+
+        Cookies cookies = Cookies.fromHeaders(headers);
+        List<Cookie> decodedCookies = cookies.getAll();
+
+        assertEquals(2, decodedCookies.size());
+        assertTrue("Decoded cookies have a=1 cookie", hasCookie(decodedCookies, "a", "1"));
+        assertTrue("Decoded cookies have a=2 cookie", hasCookie(decodedCookies, "a", "2"));
+    }
+
+    @Test
+    public void testFromHeadersEmptyValue() {
+
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.COOKIE, "a=1; a=");
+
+        Cookies cookies = Cookies.fromHeaders(headers);
+        List<Cookie> decodedCookies = cookies.getAll();
+
+        assertEquals(2, decodedCookies.size());
+        assertTrue("Decoded cookies have a=1 cookie", hasCookie(decodedCookies, "a", "1"));
+        assertTrue("Decoded cookies have a= cookie", hasCookie(decodedCookies, "a", ""));
+    }
+
+    @Test
+    public void testGetFirst() {
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.COOKIE, "a=1; a=2");
+        Cookies cookies = Cookies.fromHeaders(headers);
+
+        Cookie firstCookie = cookies.getFirst("a");
+
+        assertNotNull(firstCookie);
+        assertEquals("1", firstCookie.value());
+    }
+
+    @Test
+    public void testGetFirstValue() {
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.COOKIE, "a=1; a=2");
+        Cookies cookies = Cookies.fromHeaders(headers);
+
+        String firstValue = cookies.getFirstValue("a");
+
+        assertEquals("1", firstValue);
+    }
+
+    @Test
+    public void testGet() {
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.COOKIE, "a=1; a=2");
+        Cookies cookies = Cookies.fromHeaders(headers);
+
+        List<Cookie> decodedCookies = cookies.get("a");
+
+        assertEquals(2, decodedCookies.size());
+        assertTrue("Decoded cookies have a=1 cookie", hasCookie(decodedCookies, "a", "1"));
+        assertTrue("Decoded cookies have a=2 cookie", hasCookie(decodedCookies, "a", "2"));
+    }
+
+    @Test
+    public void testGetAll() {
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.COOKIE, "a=1; a=2; b=; c=3");
+        Cookies cookies = Cookies.fromHeaders(headers);
+
+        List<Cookie> decodedCookies = cookies.getAll();
+
+        assertEquals(4, decodedCookies.size());
+        assertTrue("Decoded cookies have a=1 cookie", hasCookie(decodedCookies, "a", "1"));
+        assertTrue("Decoded cookies have a=2 cookie", hasCookie(decodedCookies, "a", "2"));
+        assertTrue("Decoded cookies have b= cookie", hasCookie(decodedCookies, "b", ""));
+        assertTrue("Decoded cookies have c=3 cookie", hasCookie(decodedCookies, "c", "3"));
+    }
+
+
+    @Test
+    public void testCleanCookieHeaders() {
+        assertEquals("BlahId=12345; something=67890;",
+                cleanCookieHeader("BlahId=12345; Secure, something=67890;"));
+        assertEquals("BlahId=12345; something=67890;",
+                cleanCookieHeader("BlahId=12345; something=67890;"));
+        assertEquals(" BlahId=12345; something=67890;",
+                cleanCookieHeader(" Secure, BlahId=12345; Secure, something=67890;"));
+        assertEquals("", cleanCookieHeader(""));
+    }
+
+    private boolean hasCookie(List<Cookie> cookies, String name, String value) {
+        for (Cookie cookie : cookies) {
+            if (cookie.name().equals(name) && cookie.value().equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/CookiesTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/CookiesTest.java
@@ -15,16 +15,15 @@
  */
 package com.netflix.zuul.message.http;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import com.netflix.zuul.message.Headers;
 import io.netty.handler.codec.http.Cookie;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.List;
-
-import static com.netflix.zuul.message.http.Cookies.cleanCookieHeader;
-import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CookiesTest {
@@ -120,18 +119,6 @@ public class CookiesTest {
         assertTrue("Decoded cookies have a=2 cookie", hasCookie(decodedCookies, "a", "2"));
         assertTrue("Decoded cookies have b= cookie", hasCookie(decodedCookies, "b", ""));
         assertTrue("Decoded cookies have c=3 cookie", hasCookie(decodedCookies, "c", "3"));
-    }
-
-
-    @Test
-    public void testCleanCookieHeaders() {
-        assertEquals("BlahId=12345; something=67890;",
-                cleanCookieHeader("BlahId=12345; Secure, something=67890;"));
-        assertEquals("BlahId=12345; something=67890;",
-                cleanCookieHeader("BlahId=12345; something=67890;"));
-        assertEquals(" BlahId=12345; something=67890;",
-                cleanCookieHeader(" Secure, BlahId=12345; Secure, something=67890;"));
-        assertEquals("", cleanCookieHeader(""));
     }
 
     private boolean hasCookie(List<Cookie> cookies, String name, String value) {

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
@@ -256,17 +256,6 @@ public class HttpRequestMessageImplTest {
     }
 
     @Test
-    public void testCleanCookieHeaders() {
-        assertEquals("BlahId=12345; something=67890;",
-                HttpRequestMessageImpl.cleanCookieHeader("BlahId=12345; Secure, something=67890;"));
-        assertEquals("BlahId=12345; something=67890;",
-                HttpRequestMessageImpl.cleanCookieHeader("BlahId=12345; something=67890;"));
-        assertEquals(" BlahId=12345; something=67890;",
-                HttpRequestMessageImpl.cleanCookieHeader(" Secure, BlahId=12345; Secure, something=67890;"));
-        assertEquals("", HttpRequestMessageImpl.cleanCookieHeader(""));
-    }
-
-    @Test
     public void shouldPreferClientDestPortWhenInitialized() {
         HttpRequestMessageImpl message = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST",
                 "/some/where", new HttpQueryParams(), new Headers(),


### PR DESCRIPTION
* Restructure the code to move the parsing logic from headers into the Cookies class. This will make us not refer to the request class for parsing cookies from the headers.
* Use ServerCookieDecoder which now handles multiple cookies with the same name.
* Add tests to make sure that the methods in Cookies class work as expected.