### PR TITLE
ZuulFiltersModule now injects AbstractConfiguration.

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/init/ZuulFiltersModule.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/init/ZuulFiltersModule.java
@@ -19,7 +19,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.reflect.ClassPath;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.netflix.config.ConfigurationManager;
 import com.netflix.zuul.BasicFilterUsageNotifier;
 import com.netflix.zuul.DynamicCodeCompiler;
 import com.netflix.zuul.FilterFactory;
@@ -60,10 +59,8 @@ public class ZuulFiltersModule extends AbstractModule {
     }
 
     @Provides
-    FilterFileManagerConfig provideFilterFileManagerConfig() {
+    FilterFileManagerConfig provideFilterFileManagerConfig(AbstractConfiguration config) {
         // Get filter directories.
-        final AbstractConfiguration config = ConfigurationManager.getConfigInstance();
-
         String[] filterLocations = findFilterLocations(config);
         String[] filterClassNames = findClassNames(config);
 

--- a/zuul-core/src/test/java/com/netflix/zuul/init/InitTestModule.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/init/InitTestModule.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.init;
+
+import com.google.inject.AbstractModule;
+import com.netflix.config.ConfigurationManager;
+import org.apache.commons.configuration.AbstractConfiguration;
+
+public class InitTestModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(AbstractConfiguration.class).toInstance(ConfigurationManager.getConfigInstance());
+    }
+
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleIntegTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleIntegTest.java
@@ -30,7 +30,7 @@ import javax.inject.Inject;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(GovernatorJunit4ClassRunner.class)
-@ModulesForTesting({ZuulFiltersModule.class})
+@ModulesForTesting({InitTestModule.class, ZuulFiltersModule.class})
 public class ZuulFiltersModuleIntegTest {
     @Inject
     FilterFileManagerConfig filterFileManagerConfig;

--- a/zuul-sample/src/main/java/com/netflix/zuul/sample/Bootstrap.java
+++ b/zuul-sample/src/main/java/com/netflix/zuul/sample/Bootstrap.java
@@ -17,7 +17,6 @@
 package com.netflix.zuul.sample;
 
 import com.google.inject.Injector;
-import com.netflix.config.ConfigurationManager;
 import com.netflix.governator.InjectorBuilder;
 import com.netflix.zuul.netty.server.BaseServerStartup;
 import com.netflix.zuul.netty.server.Server;
@@ -42,7 +41,6 @@ public class Bootstrap {
         Server server = null;
 
         try {
-            ConfigurationManager.loadCascadedPropertiesFromResources("application");
             Injector injector = InjectorBuilder.fromModule(new ZuulSampleModule()).createInjector();
             BaseServerStartup serverStartup = injector.getInstance(BaseServerStartup.class);
             server = serverStartup.server();

--- a/zuul-sample/src/main/java/com/netflix/zuul/sample/ZuulSampleModule.java
+++ b/zuul-sample/src/main/java/com/netflix/zuul/sample/ZuulSampleModule.java
@@ -17,6 +17,7 @@
 package com.netflix.zuul.sample;
 
 import com.google.inject.AbstractModule;
+import com.netflix.config.ConfigurationManager;
 import com.netflix.discovery.AbstractDiscoveryClientOptionalArgs;
 import com.netflix.discovery.DiscoveryClient;
 import com.netflix.netty.common.accesslog.AccessLogPublisher;
@@ -35,6 +36,7 @@ import com.netflix.zuul.origins.BasicNettyOriginManager;
 import com.netflix.zuul.origins.OriginManager;
 import com.netflix.zuul.stats.BasicRequestMetricsPublisher;
 import com.netflix.zuul.stats.RequestMetricsPublisher;
+import org.apache.commons.configuration.AbstractConfiguration;
 
 /**
  * Zuul Sample Module
@@ -45,6 +47,14 @@ import com.netflix.zuul.stats.RequestMetricsPublisher;
 public class ZuulSampleModule extends AbstractModule {
     @Override
     protected void configure() {
+        try {
+          ConfigurationManager.loadCascadedPropertiesFromResources("application");
+        } catch (Exception ex) {
+          throw new RuntimeException("Error loading configuration: " + ex.getMessage(), ex);
+        }
+
+        bind(AbstractConfiguration.class).toInstance(ConfigurationManager.getConfigInstance());
+
         // sample specific bindings
         bind(BaseServerStartup.class).to(SampleServerStartup.class);
 


### PR DESCRIPTION
ZuulFiltersModule used to statically load AbstractConfiguration via
ConfigurationManager.getConfigInstance(). This limits the user's ability
to bind various configuration loading mechanisms via the injector.

This fixes #716