### PR TITLE
zuul-core: make all HttpSyncEndpoints return SYNC

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/http/HttpSyncEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/http/HttpSyncEndpoint.java
@@ -17,8 +17,8 @@
 package com.netflix.zuul.filters.http;
 
 import com.netflix.config.CachedDynamicBooleanProperty;
-import com.netflix.zuul.exception.ZuulFilterConcurrencyExceededException;
 import com.netflix.zuul.filters.Endpoint;
+import com.netflix.zuul.filters.FilterSyncType;
 import com.netflix.zuul.filters.SyncZuulFilter;
 import com.netflix.zuul.message.ZuulMessage;
 import com.netflix.zuul.message.http.HttpRequestMessage;
@@ -47,6 +47,9 @@ public abstract class HttpSyncEndpoint extends Endpoint<HttpRequestMessage, Http
         return HttpResponseMessageImpl.defaultErrorResponse(request);
     }
 
+    /**
+     * If you override this class, make sure to override {@link #getSyncType()} as well.
+     */
     @Override
     public Observable<HttpResponseMessage> applyAsync(HttpRequestMessage input)
     {
@@ -62,6 +65,11 @@ public abstract class HttpSyncEndpoint extends Endpoint<HttpRequestMessage, Http
         else {
             return Observable.just(this.apply(input));
         }
+    }
+
+    @Override
+    public FilterSyncType getSyncType() {
+        return FilterSyncType.SYNC;
     }
 
     @Override

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/http/HttpSyncEndpointTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/http/HttpSyncEndpointTest.java
@@ -1,5 +1,41 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
 package com.netflix.zuul.filters.http;
 
+import static org.junit.Assert.assertEquals;
+
+import com.netflix.zuul.filters.FilterSyncType;
+import com.netflix.zuul.message.http.HttpRequestMessage;
+import com.netflix.zuul.message.http.HttpResponseMessage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
 public class HttpSyncEndpointTest {
 
+    @Test
+    public void blah() {
+        HttpSyncEndpoint endpoint = new HttpSyncEndpoint() {
+            @Override
+            public HttpResponseMessage apply(HttpRequestMessage input) {
+                return null;
+            }
+        };
+
+        assertEquals(FilterSyncType.SYNC, endpoint.getSyncType());
+    }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/http/HttpSyncEndpointTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/http/HttpSyncEndpointTest.java
@@ -1,0 +1,5 @@
+package com.netflix.zuul.filters.http;
+
+public class HttpSyncEndpointTest {
+
+}


### PR DESCRIPTION
When the BaseZuulFilterRunner runs the endpoints, it always results in a thread hop, even for the ErrorResponse endpoint.  Return the correct type so it's easier to follow through the code.