### PR TITLE
Add Cause of SSL Handshake Error from Origin

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/OriginResponseReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/OriginResponseReceiver.java
@@ -194,6 +194,7 @@ public class OriginResponseReceiver extends ChannelDuplexHandler {
                         // Set the specific SSL handshake error if the handlers have already caught them
                         ctx.channel().attr(SSL_HANDSHAKE_UNSUCCESS_FROM_ORIGIN_THROWABLE).set(null);
                         fireWriteError("request headers", cause, ctx);
+                        LOG.debug("SSLException is overridden by SSLHandshakeException caught in handler level. Original SSL exception message: ", future.cause());
                     } else {
                         fireWriteError("request headers", future.cause(), ctx);
                     }

--- a/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempt.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempt.java
@@ -41,6 +41,7 @@ public class RequestAttempt
     private int attempt;
     private int status;
     private long duration;
+    private String cause;
     private String error;
     private String exceptionType;
     private String app;
@@ -325,6 +326,9 @@ public class RequestAttempt
                 error = t.getMessage();
                 exceptionType = t.getClass().getSimpleName();
             }
+            if (t.getCause() != null) {
+                cause = t.getCause().toString();
+            }
         }
     }
 
@@ -352,6 +356,7 @@ public class RequestAttempt
         root.put("attempt", attempt);
 
         putNullableAttribute(root, "error", error);
+        putNullableAttribute(root, "cause", cause);
         putNullableAttribute(root, "exceptionType", exceptionType);
         putNullableAttribute(root, "region", region);
         putNullableAttribute(root, "asg", asg);

--- a/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempt.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempt.java
@@ -19,6 +19,7 @@ package com.netflix.zuul.niws;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Throwables;
 import com.netflix.appinfo.AmazonInfo;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.client.config.IClientConfig;
@@ -28,6 +29,8 @@ import com.netflix.niws.loadbalancer.DiscoveryEnabledServer;
 import com.netflix.zuul.exception.OutboundException;
 import com.netflix.zuul.netty.connectionpool.OriginConnectException;
 import io.netty.handler.timeout.ReadTimeoutException;
+
+import javax.net.ssl.SSLHandshakeException;
 
 /**
  * User: michaels@netflix.com
@@ -322,12 +325,15 @@ public class RequestAttempt
                 error = obe.getOutboundErrorType().toString();
                 exceptionType = OutboundException.class.getSimpleName();
             }
+            else if (t instanceof SSLHandshakeException) {
+                error = t.getMessage();
+                exceptionType = t.getClass().getSimpleName();
+                cause = t.getCause().getMessage();
+            }
             else {
                 error = t.getMessage();
                 exceptionType = t.getClass().getSimpleName();
-            }
-            if (t.getCause() != null) {
-                cause = t.getCause().toString();
+                cause = Throwables.getStackTraceAsString(t);
             }
         }
     }


### PR DESCRIPTION
When SSL handler reads the message that the handshake failed (for example, because peer certificates are not verified), it populates the through handlers and eventually the failure message goes away. When ProxyEndpoint later tries to talk to origin it usually gets the error of SSLEngine Closed already, which does not display the actual reason why it was closed. This change catches the detailed failure cause and adds it to proxy attempt so client can know what went wrong:

"error":"General OpenSslEngine problem","cause":"java.security.cert.CertificateException: Certificate application name (applicationname) does not match expected name: expectedname","exceptionType":"SSLHandshakeException"