### PR TITLE
zuul-core: refactor Filter loading into mutable and immutable parts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ subprojects {
 
     repositories {
         jcenter()
+        mavenCentral()
         mavenLocal()
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ subprojects {
 
     repositories {
         jcenter()
-        mavenCentral()
         mavenLocal()
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/FilterRegistry.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/FilterRegistry.java
@@ -15,35 +15,37 @@
  */
 package com.netflix.zuul.filters;
 
-
-import javax.inject.Singleton;
 import java.util.Collection;
-import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
 
-/**
- * @author mhawthorne
- */
-@Singleton
-public class FilterRegistry {
-    private final ConcurrentHashMap<String, ZuulFilter<?, ?>> filters = new ConcurrentHashMap<>();
+public interface FilterRegistry {
+    @Nullable
+    ZuulFilter<?, ?> get(String key);
 
-    public ZuulFilter<?, ?> remove(String key) {
-        return filters.remove(key);
-    }
+    int size();
 
-    public ZuulFilter<?, ?> get(String key) {
-        return filters.get(key);
-    }
+    Collection<ZuulFilter<?, ?>> getAllFilters();
 
-    public void put(String key, ZuulFilter<?, ?> filter) {
-        filters.putIfAbsent(key, filter);
-    }
+    /**
+     * Indicates if this registry can be modified.  Implementations should not change the return;
+     * they return the same value each time.
+     */
+    boolean isMutable();
 
-    public int size() {
-        return filters.size();
-    }
+    /**
+     * Removes the filter from the registry, and returns it.   Returns {@code null} no such filter
+     * was found.  Callers should check {@link #isMutable()} before calling this method.
+     *
+     * @throws IllegalStateException if this registry is not mutable.
+     */
+    @Nullable
+    ZuulFilter<?, ?> remove(String key);
 
-    public Collection<ZuulFilter<?, ?>> getAllFilters() {
-        return filters.values();
-    }
+    /**
+     * Stores the filter into the registry.  If an existing filter was present with the same key,
+     * it is removed.  Callers should check {@link #isMutable()} before calling this method.
+     *
+     * @throws IllegalStateException if this registry is not mutable.
+     */
+    void put(String key, ZuulFilter<?, ?> filter);
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/MutableFilterRegistry.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/MutableFilterRegistry.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.zuul.filters;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+import javax.inject.Singleton;
+
+@Singleton
+public final class MutableFilterRegistry implements FilterRegistry {
+    private final ConcurrentHashMap<String, ZuulFilter<?, ?>> filters = new ConcurrentHashMap<>();
+
+    @Nullable
+    @Override
+    public ZuulFilter<?, ?> remove(String key) {
+        return filters.remove(requireNonNull(key, "key"));
+    }
+
+    @Override
+    @Nullable
+    public ZuulFilter<?, ?> get(String key) {
+        return filters.get(requireNonNull(key, "key"));
+    }
+
+    @Override
+    public void put(String key, ZuulFilter<?, ?> filter) {
+        filters.putIfAbsent(requireNonNull(key, "key"), requireNonNull(filter, "filter"));
+    }
+
+    @Override
+    public int size() {
+        return filters.size();
+    }
+
+    @Override
+    public Collection<ZuulFilter<?, ?>> getAllFilters() {
+        return Collections.unmodifiableList(new ArrayList<>(filters.values()));
+    }
+
+    @Override
+    public boolean isMutable() {
+        return true;
+    }
+}


### PR DESCRIPTION
This step is needed to support the construction of static filter registries.  While
dynamic loading will still be supported, Zuul will be moving towards a fixed filter
set model.   This lowers load on live running servers, avoids a dependency on doing
disk reads.   Wide deploying code to live running servers is a risky endeavor, and
Zuul did not develop the necessary safeguards to support this.

After this change, FilterFileManager will be optional, as its sole purpose is to
populate the loader/registry.