### PR TITLE
zuul-core: add initial header benchmarks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'nebula.netflixoss' version '8.0.0'
     id 'nebula.dependency-lock' version '8.0.0'
     id "com.google.osdetector" version "1.6.2"
+    id "me.champeau.gradle.jmh" version "0.5.0"
 }
 
 ext.githubProjectName = rootProject.name
@@ -19,16 +20,18 @@ configurations.all {
     exclude group: 'asm', module: 'asm-all'
 }
 
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
+
 subprojects {
     apply plugin: 'nebula.netflixoss'
     apply plugin: 'java'
     apply plugin: 'nebula.javadoc-jar'
     apply plugin: 'nebula.dependency-lock'
-
-    repositories {
-        jcenter()
-        mavenLocal()
-    }
+    apply plugin: 'me.champeau.gradle.jmh'
 
     license {
         ignoreFailures = false

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,3 +1,40 @@
 {
-    
+    "jmh": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21"
+        }
+    },
+    "jmhCompileClasspath": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        }
+    },
+    "jmhRuntime": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        }
+    },
+    "jmhRuntimeClasspath": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        }
+    }
 }

--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -55,3 +55,13 @@ test {
         showStandardStreams = false
     }
 }
+
+// ./gradlew --no-daemon clean :zuul-core:jmh --stacktrace
+jmh {
+    timeOnIteration = "1s"
+    warmup = "1s"
+    fork = 1
+    warmupIterations = 10
+    // Not sure why duplicate classes are aon the path.  Something Nebula related I think.
+    duplicateClassesStrategy = 'EXCLUDE'
+}

--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -63,6 +63,7 @@ jmh {
     warmup = "1s"
     fork = 1
     warmupIterations = 10
+    iterations 5
     // Not sure why duplicate classes are aon the path.  Something Nebula related I think.
     duplicateClassesStrategy = 'EXCLUDE'
 }

--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -58,6 +58,7 @@ test {
 
 // ./gradlew --no-daemon clean :zuul-core:jmh --stacktrace
 jmh {
+    profilers = ["gc"]
     timeOnIteration = "1s"
     warmup = "1s"
     fork = 1

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -389,6 +389,516 @@
             "requested": "1.7.25"
         }
     },
+    "jmh": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21"
+        }
+    },
+    "jmhCompileClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "locked": "0.7.5",
+            "requested": "0.7.5"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "locked": "1.9.18",
+            "requested": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.governator:governator-core": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "locked": "0.3.0",
+            "requested": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "locked": "0.7.2",
+            "requested": "0.7.2"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "0.103.0",
+            "requested": "0.103.0"
+        },
+        "commons-configuration:commons-configuration": {
+            "locked": "1.8",
+            "requested": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "locked": "0.21.0",
+            "requested": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "locked": "1.2.1",
+            "requested": "1.2.1"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "locked": "1.64",
+            "requested": "1.+"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "locked": "2.4.4",
+            "requested": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.25",
+            "requested": "1.7.25"
+        }
+    },
+    "jmhRuntime": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.truth:truth": {
+            "locked": "1.0.1",
+            "requested": "1.0.1"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "locked": "0.7.6",
+            "requested": "0.7.5"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "locked": "1.9.18",
+            "requested": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.governator:governator-core": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.governator:governator-test-junit": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "locked": "0.3.0",
+            "requested": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "locked": "0.12.21",
+            "requested": "0.7.2"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "0.103.0",
+            "requested": "0.103.0"
+        },
+        "commons-configuration:commons-configuration": {
+            "locked": "1.8",
+            "requested": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "locked": "2.0.30.Final",
+            "requested": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "locked": "0.21.0",
+            "requested": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "locked": "1.2.1",
+            "requested": "1.2.1"
+        },
+        "junit:junit": {
+            "locked": "4.13",
+            "requested": "4.13"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "locked": "1.64",
+            "requested": "1.+"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "locked": "2.4.4",
+            "requested": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.30",
+            "requested": "1.7.25"
+        },
+        "org.slf4j:slf4j-simple": {
+            "locked": "1.7.29",
+            "requested": "1.7.29"
+        }
+    },
+    "jmhRuntimeClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.9.8",
+            "requested": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.truth:truth": {
+            "locked": "1.0.1",
+            "requested": "1.0.1"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "locked": "0.7.6",
+            "requested": "0.7.5"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "locked": "1.9.18",
+            "requested": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.governator:governator-core": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.governator:governator-test-junit": {
+            "locked": "1.17.10",
+            "requested": "1.+"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "locked": "0.3.0",
+            "requested": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "locked": "2.7.17",
+            "requested": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "locked": "0.12.21",
+            "requested": "0.7.2"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "0.103.0",
+            "requested": "0.103.0"
+        },
+        "commons-configuration:commons-configuration": {
+            "locked": "1.8",
+            "requested": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "locked": "2.0.30.Final",
+            "requested": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "locked": "4.1.48.Final",
+            "requested": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "locked": "0.21.0",
+            "requested": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "locked": "1.2.1",
+            "requested": "1.2.1"
+        },
+        "junit:junit": {
+            "locked": "4.13",
+            "requested": "4.13"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "locked": "1.64",
+            "requested": "1.+"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "locked": "2.4.4",
+            "requested": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.30",
+            "requested": "1.7.25"
+        },
+        "org.slf4j:slf4j-simple": {
+            "locked": "1.7.29",
+            "requested": "1.7.29"
+        }
+    },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-core": {
             "locked": "2.9.8",

--- a/zuul-core/src/jmh/java/com/netflix/zuul/message/HeadersBenchmark.java
+++ b/zuul-core/src/jmh/java/com/netflix/zuul/message/HeadersBenchmark.java
@@ -33,16 +33,11 @@ public class HeadersBenchmark {
 
     @State(Scope.Thread)
     public static class AddHeaders {
-        private Headers headers = new Headers();
-
         @Param({"0", "1", "5", "10", "30"})
         public int count;
 
         @Param({"10"})
         public int nameLength;
-
-        @Param({"true"})
-        public boolean commonNames;
 
         private String[] stringNames;
         private HeaderName[] names;
@@ -68,6 +63,7 @@ public class HeadersBenchmark {
         @BenchmarkMode(Mode.AverageTime)
         @OutputTimeUnit(TimeUnit.NANOSECONDS)
         public Headers addHeaders_string() {
+            Headers headers = new Headers();
             for (int i = 0; i < count; i++) {
                 headers.add(stringNames[i], values[i]);
             }
@@ -78,6 +74,7 @@ public class HeadersBenchmark {
         @BenchmarkMode(Mode.AverageTime)
         @OutputTimeUnit(TimeUnit.NANOSECONDS)
         public Headers addHeaders_headerName() {
+            Headers headers = new Headers();
             for (int i = 0; i < count; i++) {
                 headers.add(names[i], values[i]);
             }

--- a/zuul-core/src/jmh/java/com/netflix/zuul/message/HeadersBenchmark.java
+++ b/zuul-core/src/jmh/java/com/netflix/zuul/message/HeadersBenchmark.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.zuul.message;
+
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+
+@State(Scope.Thread)
+public class HeadersBenchmark {
+
+    @State(Scope.Thread)
+    public static class AddHeaders {
+        private Headers headers = new Headers();
+
+        @Param({"0", "1", "5", "10", "30"})
+        public int count;
+
+        @Param({"10"})
+        public int nameLength;
+
+        @Param({"true"})
+        public boolean commonNames;
+
+        private String[] stringNames;
+        private HeaderName[] names;
+        private String[] values;
+
+        @Setup
+        public void setUp() {
+            stringNames = new String[count];
+            names = new HeaderName[stringNames.length];
+            values = new String[stringNames.length];
+            for (int i = 0; i < stringNames.length; i++) {
+                UUID uuid = new UUID(ThreadLocalRandom.current().nextLong(), ThreadLocalRandom.current().nextLong());
+                String name = uuid.toString();
+                assert name.length() >= nameLength;
+                name = name.substring(0, nameLength);
+                names[i] = new HeaderName(name);
+                stringNames[i] = name;
+                values[i] = name;
+            }
+        }
+
+        @Benchmark
+        @BenchmarkMode(Mode.AverageTime)
+        @OutputTimeUnit(TimeUnit.NANOSECONDS)
+        public Headers addHeaders_string() {
+            for (int i = 0; i < count; i++) {
+                headers.add(stringNames[i], values[i]);
+            }
+            return headers;
+        }
+
+        @Benchmark
+        @BenchmarkMode(Mode.AverageTime)
+        @OutputTimeUnit(TimeUnit.NANOSECONDS)
+        public Headers addHeaders_headerName() {
+            for (int i = 0; i < count; i++) {
+                headers.add(names[i], values[i]);
+            }
+            return headers;
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public Headers newHeaders() {
+        return new Headers();
+    }
+
+}

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -454,6 +454,717 @@
             "locked": "1.7.30"
         }
     },
+    "jmh": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21"
+        }
+    },
+    "jmhCompileClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.5"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.2"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.25"
+        }
+    },
+    "jmhRuntime": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.truth:truth": {
+            "locked": "1.0.1",
+            "requested": "1.0.1"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.6"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.12.21"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "junit:junit": {
+            "locked": "4.13",
+            "requested": "4.13"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.64"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.30"
+        }
+    },
+    "jmhRuntimeClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre",
+            "requested": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.truth:truth": {
+            "locked": "1.0.1",
+            "requested": "1.0.1"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.6"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.12.21"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "junit:junit": {
+            "locked": "4.13",
+            "requested": "4.13"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.64"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.30"
+        }
+    },
     "runtime": {
         "com.google.inject.extensions:guice-assistedinject": {
             "locked": "4.2.2",

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -904,6 +904,711 @@
             "locked": "1.7.30"
         }
     },
+    "jmh": {
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21"
+        }
+    },
+    "jmhCompileClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.5"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.2"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.25"
+        }
+    },
+    "jmhRuntime": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.6"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.12.21"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.13.1",
+            "requested": "2.13.1"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.13.1",
+            "requested": "2.13.1"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.64"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.30"
+        }
+    },
+    "jmhRuntimeClasspath": {
+        "com.fasterxml.jackson.core:jackson-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.9.8"
+        },
+        "com.google.guava:guava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "28.1-jre"
+        },
+        "com.google.inject.extensions:guice-assistedinject": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-grapher": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-multibindings": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-servlet": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject.extensions:guice-throwingproviders": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.google.inject:guice": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.2.2",
+            "requested": "4.2.2"
+        },
+        "com.netflix.archaius:archaius-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.7.6"
+        },
+        "com.netflix.eureka:eureka-client": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.9.18"
+        },
+        "com.netflix.governator:governator": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.governator:governator-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.17.10"
+        },
+        "com.netflix.netflix-commons:netflix-commons-util": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.3.0"
+        },
+        "com.netflix.ribbon:ribbon-archaius": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-eureka": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-httpclient": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.ribbon:ribbon-loadbalancer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.7.17"
+        },
+        "com.netflix.servo:servo-core": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.12.21"
+        },
+        "com.netflix.spectator:spectator-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.103.0"
+        },
+        "com.netflix.zuul:zuul-core": {
+            "project": true
+        },
+        "commons-configuration:commons-configuration": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.8"
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-haproxy": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-codec-http2": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-common": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-tcnative-boringssl-static": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.0.30.Final"
+        },
+        "io.netty:netty-transport": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.netty:netty-transport-native-kqueue": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "4.1.48.Final"
+        },
+        "io.perfmark:perfmark-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "0.21.0"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.2.1"
+        },
+        "org.apache.logging.log4j:log4j-core": {
+            "locked": "2.13.1",
+            "requested": "2.13.1"
+        },
+        "org.apache.logging.log4j:log4j-slf4j-impl": {
+            "locked": "2.13.1",
+            "requested": "2.13.1"
+        },
+        "org.bouncycastle:bcprov-jdk15on": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.64"
+        },
+        "org.codehaus.groovy:groovy-all": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "2.4.4"
+        },
+        "org.openjdk.jmh:jmh-core": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.openjdk.jmh:jmh-generator-bytecode": {
+            "locked": "1.21",
+            "requested": "1.21"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.7.30"
+        }
+    },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [


### PR DESCRIPTION
```
Benchmark                                          (commonNames)  (count)  (nameLength)  Mode  Cnt      Score        Error  Units
HeadersBenchmark.AddHeaders.addHeaders_headerName           true        0            10  avgt    5      2.129 ±      0.030  ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName           true        1            10  avgt    3     16.533 ±      2.216  ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName           true        5            10  avgt    5    221.283 ±   1227.752  ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName           true       10            10  avgt    5  20193.151 ± 172558.089  ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName           true       30            10  avgt    5    949.597 ±   4048.503  ns/op
HeadersBenchmark.AddHeaders.addHeaders_string               true        0            10  avgt    5      2.114 ±      0.045  ns/op
HeadersBenchmark.AddHeaders.addHeaders_string               true        1            10  avgt    5    204.636 ±     94.494  ns/op
HeadersBenchmark.AddHeaders.addHeaders_string               true        5            10  avgt    5   1020.070 ±    349.082  ns/op
HeadersBenchmark.AddHeaders.addHeaders_string               true       10            10  avgt    5   4717.763 ±  23825.930  ns/op
HeadersBenchmark.AddHeaders.addHeaders_string               true       30            10  avgt    5  34264.173 ± 242825.116  ns/op
HeadersBenchmark.newHeaders                                  N/A      N/A           N/A  avgt    5     12.881 ±      0.395  ns/op
```