### PR TITLE
zuul-core: re-implement Headers with an array 

### DIFF
--- a/zuul-core/src/jmh/java/com/netflix/zuul/message/HeadersBenchmark.java
+++ b/zuul-core/src/jmh/java/com/netflix/zuul/message/HeadersBenchmark.java
@@ -134,14 +134,14 @@ public class HeadersBenchmark {
         @BenchmarkMode(Mode.AverageTime)
         @OutputTimeUnit(TimeUnit.NANOSECONDS)
         public List<String> getHeader_first() {
-            return headers.get(names[0]);
+            return headers.getAll(names[0]);
         }
 
         @Benchmark
         @BenchmarkMode(Mode.AverageTime)
         @OutputTimeUnit(TimeUnit.NANOSECONDS)
         public List<String> getHeader_last() {
-            return headers.get(names[count - 1]);
+            return headers.getAll(names[count - 1]);
         }
 
         @Benchmark

--- a/zuul-core/src/main/java/com/netflix/zuul/message/Header.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Header.java
@@ -17,12 +17,9 @@
 package com.netflix.zuul.message;
 
 /**
- * User: Mike Smith
- * Date: 7/29/15
- * Time: 1:06 PM
+ * Represents a single header from a {@link Headers} object.
  */
-public class Header implements Cloneable
-{
+public final class Header {
     private final HeaderName name;
     private final String value;
 
@@ -33,45 +30,44 @@ public class Header implements Cloneable
         this.value = value;
     }
 
-    public String getKey()
-    {
+    public String getKey() {
         return name.getName();
     }
 
-    public HeaderName getName()
-    {
+    public HeaderName getName() {
         return name;
     }
 
-    public String getValue()
-    {
+    public String getValue() {
         return value;
     }
 
     @Override
-    public boolean equals(Object o)
-    {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         Header header = (Header) o;
 
-        if (!name.equals(header.name)) return false;
+        if (!name.equals(header.name)) {
+            return false;
+        }
         return !(value != null ? !value.equals(header.value) : header.value != null);
-
     }
 
     @Override
-    public int hashCode()
-    {
+    public int hashCode() {
         int result = name.hashCode();
         result = 31 * result + (value != null ? value.hashCode() : 0);
         return result;
     }
 
     @Override
-    public String toString()
-    {
+    public String toString() {
         return String.format("%s: %s", name, value);
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/HeaderName.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/HeaderName.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.message;
 
-import com.netflix.config.DynamicPropertyFactory;
+import java.util.Locale;
 
 /**
  * Immutable, case-insensitive wrapper around Header name.
@@ -25,58 +25,47 @@ import com.netflix.config.DynamicPropertyFactory;
  * Date: 7/29/15
  * Time: 1:07 PM
  */
-public class HeaderName
-{
-    private static final boolean SHOULD_INTERN =
-            DynamicPropertyFactory.getInstance().getBooleanProperty(
-                    "com.netflix.zuul.message.HeaderName.shouldIntern", true).get();
-
+public final class HeaderName {
     private final String name;
     private final String normalised;
+    private final int hashCode;
 
-    public HeaderName(String name)
-    {
-        if (name == null) throw new NullPointerException("HeaderName cannot be null!");
-        this.name = SHOULD_INTERN ? name.intern() : name;
-        this.normalised = SHOULD_INTERN ? name.toLowerCase().intern() : name.toLowerCase();
+    public HeaderName(String name) {
+        if (name == null) {
+            throw new NullPointerException("HeaderName cannot be null!");
+        }
+        this.name = name;
+        this.normalised = name.toLowerCase(Locale.ROOT);
+        this.hashCode = this.normalised.hashCode();
     }
 
-    public String getName()
-    {
+    public String getName() {
         return name;
     }
 
-    public String getNormalised()
-    {
+    public String getNormalised() {
         return normalised;
     }
 
     @Override
-    public boolean equals(Object o)
-    {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HeaderName)) {
+            return false;
+        }
         HeaderName that = (HeaderName) o;
-
-        // Ignore case when comparing.
-        if (SHOULD_INTERN) {
-            return normalised == that.normalised;
-        }
-        else {
-            return normalised.equals(that.normalised);
-        }
+        return this.normalised.equals(that.normalised);
     }
 
     @Override
-    public int hashCode()
-    {
-        return normalised.hashCode();
+    public int hashCode() {
+        return hashCode;
     }
 
     @Override
-    public String toString()
-    {
+    public String toString() {
         return name;
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/HeaderName.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/HeaderName.java
@@ -35,16 +35,29 @@ public final class HeaderName {
             throw new NullPointerException("HeaderName cannot be null!");
         }
         this.name = name;
-        this.normalised = name.toLowerCase(Locale.ROOT);
+        this.normalised = normalize(name);
         this.hashCode = this.normalised.hashCode();
     }
 
+    HeaderName(String name, String normalised) {
+        this.name = name;
+        this.normalised = normalised;
+        this.hashCode = normalised.hashCode();
+    }
+
+    /**
+     * Gets the original, non-normalized name for this header.
+     */
     public String getName() {
         return name;
     }
 
     public String getNormalised() {
         return normalised;
+    }
+
+    static String normalize(String s) {
+        return s.toLowerCase(Locale.ROOT);
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
@@ -15,19 +15,20 @@
  */
 package com.netflix.zuul.message;
 
-import com.netflix.zuul.message.http.HttpHeaderNames;
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-
-import static com.netflix.zuul.util.HttpUtils.stripMaliciousHeaderChars;
-import static java.util.Objects.requireNonNull;
 
 /**
  * An abstraction over a collection of http headers. Allows multiple headers with same name, and header names are
@@ -35,13 +36,12 @@ import static java.util.Objects.requireNonNull;
  *
  * There are methods for getting and setting headers by String AND by HeaderName. When possible, use the HeaderName
  * variants and cache the HeaderName instances somewhere, to avoid case-insensitive String comparisons.
- *
- * User: michaels@netflix.com
- * Date: 2/20/15
- * Time: 3:13 PM
  */
 public final class Headers {
-    private final List<HeaderName> names;
+    private static final int ABSENT = -1;
+
+    private final List<String> originalNames;
+    private final List<String> names;
     private final List<String> values;
 
     public static Headers copyOf(Headers original) {
@@ -49,44 +49,42 @@ public final class Headers {
     }
 
     public Headers() {
+        originalNames = new ArrayList<>();
         names = new ArrayList<>();
         values = new ArrayList<>();
     }
 
     private Headers(Headers original) {
+        originalNames = new ArrayList<>(original.originalNames);
         names = new ArrayList<>(original.names);
         values = new ArrayList<>(original.values);
     }
 
-    private HeaderName getHeaderName(String name) {
-        return HttpHeaderNames.get(name);
-    }
-
-    private boolean set(HeaderName name, String value) {
-        return entries.put(hn, stripMaliciousHeaderChars(value));
-    }
-
-    private void delegatePutAll(Headers headers) {
-        // enforce using above delegatePut method, for stripping malicious characters
-        headers.delegate.entries().forEach(entry -> delegatePut(entry.getKey(), entry.getValue()));
+    /**
+     * Get the first value found for this key even if there are multiple. If none, then
+     * return {@code null}.
+     */
+    @Nullable
+    public String getFirst(String headerName) {
+        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        return getFirstNormal(normalName);
     }
 
     /**
      * Get the first value found for this key even if there are multiple. If none, then
-     * return null.
+     * return {@code null}.
      */
     @Nullable
-    public String getFirst(String name) {
-        HeaderName hn = getHeaderName(requireNonNull(name, "name"));
-        return getFirst(hn);
+    public String getFirst(HeaderName headerName) {
+        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        return getFirstNormal(normalName);
     }
 
     @Nullable
-    public String getFirst(HeaderName headerName) {
-        requireNonNull(headerName, "headerName");
-        for (int i = 0; i < names.size(); i++) {
-            if (names.get(i).equals(headerName)) {
-                return values.get(i);
+    private String getFirstNormal(String name) {
+        for (int i = 0; i < size(); i++) {
+            if (name(i).equals(name)) {
+                return value(i);
             }
         }
         return null;
@@ -96,38 +94,52 @@ public final class Headers {
      * Get the first value found for this key even if there are multiple. If none, then
      * return the specified defaultValue.
      */
-    public String getFirst(String name, String defaultValue) {
-        requireNonNull(defaultValue);
-        String value = getFirst(name);
+    public String getFirst(String headerName, String defaultValue) {
+        requireNonNull(defaultValue, "defaultValue");
+        String value = getFirst(headerName);
         if (value != null) {
             return value;
         }
         return defaultValue;
     }
 
-    public String getFirst(HeaderName name, String defaultValue) {
-        requireNonNull(defaultValue);
-        String value = getFirst(hn);
+    /**
+     * Get the first value found for this key even if there are multiple. If none, then
+     * return the specified defaultValue.
+     */
+    public String getFirst(HeaderName headerName, String defaultValue) {
+        requireNonNull(defaultValue, "defaultValue");
+        String value = getFirst(headerName);
         if (value != null) {
             return value;
         }
         return defaultValue;
     }
 
-    public List<String> getAll(String name) {
-        HeaderName hn = getHeaderName(requireNonNull(name, "name"));
-        return getAll(hn);
+    /**
+     * Returns all header values associated with the name.
+     */
+    public List<String> getAll(String headerName) {
+        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        return getAllNormal(normalName);
     }
 
-    public List<String> getAll(HeaderName name) {
-        requireNonNull(name, "name");
+    /**
+     * Returns all header values associated with the name.
+     */
+    public List<String> getAll(HeaderName headerName) {
+        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        return getAllNormal(normalName);
+    }
+
+    private List<String> getAllNormal(String normalName) {
         List<String> results = null;
-        for (int i = 0; i < names.size(); i++) {
-            if (names.get(i).equals(name)) {
+        for (int i = 0; i < size(); i++) {
+            if (name(i).equals(normalName)) {
                 if (results == null) {
                     results = new ArrayList<>(1);
                 }
-                results.add(values.get(i));
+                results.add(value(i));
             }
         }
         if (results == null) {
@@ -140,137 +152,339 @@ public final class Headers {
     /**
      * Replace any/all entries with this key, with this single entry.
      *
-     * If value is null, then not added, but any existing header of same name is removed.
+     * If value is {@code null}, then not added, but any existing header of same name is removed.
      */
-    public void set(String name, String value)
-    {
-        HeaderName hn = getHeaderName(name);
-        set(hn, value);
+    public void set(String headerName, @Nullable String value) {
+        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        setNormal(headerName, normalName, value);
     }
-    public void set(HeaderName hn, String value)
-    {
-        delegate.removeAll(hn);
+
+    /**
+     * Replace any/all entries with this key, with this single entry.
+     *
+     * If value is {@code null}, then not added, but any existing header of same name is removed.
+     */
+    public void set(HeaderName headerName, String value) {
+        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        setNormal(headerName.getName(), normalName, value);
+    }
+
+    private void setNormal(String originalName, String normalName, @Nullable String value) {
+        int i = findNormal(normalName);
+        if (i == ABSENT) {
+            if (value != null) {
+                addNormal(originalName, normalName, value);
+            }
+            return;
+        }
         if (value != null) {
-            delegatePut(hn, value);
+            value(i, value);
+            originalName(i, originalName);
+            i++;
         }
+        clearMatchingStartingAt(i, normalName, /* removed= */ null);
     }
 
-    public boolean setIfAbsent(String name, String value)
-    {
-        HeaderName hn = getHeaderName(name);
-        return setIfAbsent(hn, value);
-    }
-    public boolean setIfAbsent(HeaderName hn, String value)
-    {
-        boolean did = false;
-        if (! contains(hn)) {
-            set(hn, value);
-            did = true;
+    /**
+     * Returns the first index entry that has a matching name.  Returns {@link #ABSENT} if absent.
+     */
+    private int findNormal(String normalName) {
+        for (int i = 0; i < size(); i++) {
+            if (name(i).equals(normalName)) {
+                return i;
+            }
         }
-        return did;
+        return -1;
     }
 
-    public void add(String name, String value)
-    {
-        HeaderName hn = getHeaderName(name);
-        add(hn, value);
+    /**
+     * Removes entries that match the name, starting at the given index.
+     */
+    private void clearMatchingStartingAt(int i, String normalName, @Nullable Collection<? super String> removed) {
+        // This works by having separate read and write indexes, that iterate along the list.
+        // Values that don't match are moved to the front, leaving garbage values in place.
+        // At the end, all values at and values are garbage and are removed.
+        int w = i;
+        for (int r = i; r < size(); r++) {
+            if (!name(r).equals(normalName)) {
+                originalName(w, originalName(r));
+                name(w, name(r));
+                value(w, value(r));
+                w++;
+            } else if (removed != null) {
+                removed.add(value(r));
+            }
+        }
+        truncate(w);
     }
 
-
-    public void add(HeaderName name, String value) {
-        requireNonNull(name, "name");
+    /**
+     * Adds the name and value to the headers, except if the name is already present.  Unlike
+     * {@link #set(String, String)}, this method does not accept a {@code null} value.
+     *
+     * @return if the value was successfully added.
+     */
+    public boolean setIfAbsent(String headerName, String value) {
         requireNonNull(value, "value");
-        names.add(name);
-        values.add(value);
+        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        return setIfAbsentNormal(headerName, normalName, value);
     }
 
-    public void putAll(Headers headers)
-    {
-        delegatePutAll(headers);
+    /**
+     * Adds the name and value to the headers, except if the name is already present.  Unlike
+     * {@link #set(HeaderName, String)}, this method does not accept a {@code null} value.
+     *
+     * @return if the value was successfully added.
+     */
+    public boolean setIfAbsent(HeaderName headerName, String value) {
+        requireNonNull(value, "value");
+        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        return setIfAbsentNormal(headerName.getName(), normalName, value);
     }
 
-    public List<String> remove(String name)
-    {
-        HeaderName hn = getHeaderName(name);
-        return remove(hn);
-    }
-    public List<String> remove(HeaderName hn)
-    {
-        return delegate.removeAll(hn);
+    private boolean setIfAbsentNormal(String originalName, String normalName, String value) {
+        int i = findNormal(normalName);
+        if (i != ABSENT) {
+            return false;
+        }
+        addNormal(originalName, normalName, value);
+        return true;
     }
 
+    /**
+     * Adds the name and value to the headers.
+     */
+    public void add(String headerName, String value) {
+        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        requireNonNull(value, "value");
+        addNormal(headerName, normalName, value);
+    }
+
+    /**
+     * Adds the name and value to the headers.
+     */
+    public void add(HeaderName headerName, String value) {
+        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        requireNonNull(value, "value");
+        addNormal(headerName.getName(), normalName, value);
+    }
+
+    /**
+     * Adds all the headers into this headers object.
+     */
+    public void putAll(Headers headers) {
+        for (int i = 0; i < headers.size(); i++) {
+            addNormal(headers.originalName(i), headers.name(i), headers.value(i));
+        }
+    }
+
+    /**
+     * Removes the header entries that match the given header name, and returns them as a list.
+     */
+    public List<String> remove(String headerName) {
+        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        return removeNormal(normalName);
+    }
+
+    /**
+     * Removes the header entries that match the given header name, and returns them as a list.
+     */
+    public List<String> remove(HeaderName headerName) {
+        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        return removeNormal(normalName);
+    }
+
+    private List<String> removeNormal(String normalName) {
+        List<String> removed = new ArrayList<>();
+        clearMatchingStartingAt(0, normalName, removed);
+        return Collections.unmodifiableList(removed);
+    }
+
+    /**
+     * Removes all header entries that match the given predicate.   Do not access the header list from inside the
+     * {@link Predicate#test} body.
+     *
+     * @return if any elements were removed.
+     */
     public boolean removeIf(Predicate<? super Map.Entry<HeaderName, String>> filter) {
-        return delegate.entries().removeIf(filter);
+        requireNonNull(filter, "filter");
+        boolean removed = false;
+        int w = 0;
+        for (int r = 0; r < size(); r++) {
+            if (filter.test(new SimpleImmutableEntry<>(new HeaderName(originalName(r), name(r)), value(r)))) {
+                removed = true;
+            } else {
+                originalName(w, originalName(r));
+                name(w, name(r));
+                value(w, value(r));
+                w++;
+            }
+        }
+        truncate(w);
+        return removed;
     }
 
-    public Collection<Header> entries()
-    {
-        return delegate.entries()
-                .stream()
-                .map(entry -> new Header(entry.getKey(), entry.getValue()))
-                .collect(Collectors.toList());
+    /**
+     * Returns the collection of headers.
+     */
+    public Collection<Header> entries() {
+        List<Header> entries = new ArrayList<>(size());
+        for (int i = 0; i < size(); i++) {
+            entries.add(new Header(new HeaderName(originalName(i), name(i)), value(i)));
+        }
+        return Collections.unmodifiableList(entries);
     }
 
-    public Set<HeaderName> keySet()
-    {
-        return delegate.keySet();
+    /**
+     * Returns a set of header names found in this headers object.  If there are duplicate header names, the first
+     * one present takes precedence.
+     */
+    public Set<HeaderName> keySet() {
+        Set<HeaderName> headerNames = new LinkedHashSet<>(size());
+        for (int i = 0 ; i < size(); i++) {
+            HeaderName headerName = new HeaderName(originalName(i), name(i));
+            // We actually do need to check contains before adding to the set because the original name may change.
+            // In this case, the first name wins.
+            if (!headerNames.contains(headerName)) {
+                headerNames.add(headerName);
+            }
+        }
+        return Collections.unmodifiableSet(headerNames);
     }
 
-    public boolean contains(String name)
-    {
-        return contains(getHeaderName(name));
-    }
-    public boolean contains(HeaderName hn)
-    {
-        return delegate.containsKey(hn);
-    }
-
-    public boolean contains(String name, String value)
-    {
-        HeaderName hn = getHeaderName(name);
-        return contains(hn, value);
-    }
-    public boolean contains(HeaderName hn, String value)
-    {
-        return delegate.containsEntry(hn, value);
+    /**
+     * Returns if there is a header entry that matches the given name.
+     */
+    public boolean contains(String headerName) {
+        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        return findNormal(normalName) != ABSENT;
     }
 
-    public int size()
-    {
-        return delegate.size();
+    /**
+     * Returns if there is a header entry that matches the given name.
+     */
+    public boolean contains(HeaderName headerName) {
+        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        return findNormal(normalName) != ABSENT;
     }
 
-    public Headers immutableCopy()
-    {
-        return new Headers(ImmutableListMultimap.copyOf(delegate));
+    /**
+     * Returns if there is a header entry that matches the given name and value.
+     */
+    public boolean contains(String headerName, String value) {
+        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        requireNonNull(value, "value");
+        return containsNormal(normalName, value);
     }
 
-    @Deprecated // To be removed in a later Zuul Release.
-    public boolean isImmutable() {
+    /**
+     * Returns if there is a header entry that matches the given name and value.
+     */
+    public boolean contains(HeaderName headerName, String value) {
+        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        requireNonNull(value, "value");
+        return containsNormal(normalName, value);
+    }
+
+    private boolean containsNormal(String normalName, String value) {
+        for (int i = 0; i < size(); i++) {
+            if (name(i).equals(normalName) && value(i).equals(value)) {
+                return true;
+            }
+        }
         return false;
     }
 
-    @Override
-    public int hashCode()
-    {
-        return super.hashCode();
+    /**
+     * Returns the number of header entries.
+     */
+    public int size() {
+        return names.size();
     }
 
+    /**
+     * This method should only be used for testing, as it is expensive to call.
+     */
     @Override
-    public boolean equals(Object obj)
-    {
-        if (obj == null)
-            return false;
-        if (! (obj instanceof Headers))
-            return false;
-
-        Headers h2 = (Headers) obj;
-        return Iterables.elementsEqual(delegate.entries(), h2.delegate.entries());
+    @VisibleForTesting
+    public int hashCode() {
+        return asMap().hashCode();
     }
 
+    /**
+     * Equality on headers is not clearly defined, but this method makes an attempt to do so.   This method should
+     * only be used for testing, as it is expensive to call.  Two headers object are considered equal if they have
+     * the same, normalized header names, and have the corresponding header values in the same order.
+     */
     @Override
-    public String toString()
-    {
-        return delegate.toString();
+    @VisibleForTesting
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof Headers)) {
+            return false;
+        }
+        Headers other = (Headers) obj;
+
+        return asMap().equals(other.asMap());
+    }
+
+    private Map<String, List<String>> asMap() {
+        Map<String, List<String>> map = new LinkedHashMap<>(size());
+        for (int i = 0; i < size(); i++) {
+            map.computeIfAbsent(name(i), k -> new ArrayList<>()).add(value(i));
+        }
+        // Return an unwrapped collection since it should not ever be returned on the API.
+        return map;
+    }
+
+    /**
+     * This is used for debugging.  It is fairly expensive to construct, so don't call it on a hot path.
+     */
+    @Override
+    public String toString() {
+        return asMap().toString();
+    }
+
+    private String originalName(int i) {
+        return originalNames.get(i);
+    }
+
+    private void originalName(int i, String originalName) {
+        originalNames.set(i, originalName);
+    }
+
+    private String name(int i) {
+        return names.get(i);
+    }
+
+    private void name(int i, String name) {
+        names.set(i, name);
+    }
+
+    private String value(int i) {
+        return values.get(i);
+    }
+
+    private void value(int i, String val) {
+        values.set(i, val);
+    }
+
+    private void addNormal(String originalName, String normalName, String value) {
+        originalNames.add(originalName);
+        names.add(normalName);
+        values.add(value);
+    }
+
+    /**
+     * Removes all elements at and after the given index.
+     */
+    private void truncate(int i) {
+        for (int k = size() - 1; k >= i; k--) {
+            originalNames.remove(k);
+            names.remove(k);
+            values.remove(k);
+        }
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
@@ -217,7 +217,7 @@ public class ZuulMessageImpl implements ZuulMessage
 
     @Override
     public ZuulMessage clone() {
-        final ZuulMessageImpl copy = new ZuulMessageImpl(context.clone(), headers.clone());
+        final ZuulMessageImpl copy = new ZuulMessageImpl(context.clone(), Headers.copyOf(headers));
         this.bodyChunks.forEach(chunk -> {
             chunk.retain();
             copy.bufferBodyContents(chunk);

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpHeaderNames.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpHeaderNames.java
@@ -30,7 +30,7 @@ import com.netflix.zuul.message.HeaderName;
  * Date: 8/5/15
  * Time: 12:33 PM
  */
-public class HttpHeaderNames
+public final class HttpHeaderNames
 {
     private static final DynamicIntProperty MAX_CACHE_SIZE =
             DynamicPropertyFactory.getInstance().getIntProperty("com.netflix.zuul.message.http.HttpHeaderNames.maxCacheSize", 30);

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
@@ -359,7 +359,7 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
     public Cookies reParseCookies()
     {
         Cookies cookies = new Cookies();
-        for (String aCookieHeader : getHeaders().get(HttpHeaderNames.COOKIE))
+        for (String aCookieHeader : getHeaders().getAll(HttpHeaderNames.COOKIE))
         {
             try {
                 if (CLEAN_COOKIES.get()) {
@@ -413,10 +413,10 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
 
     protected HttpRequestInfo copyRequestInfo()
     {
-        // Unlike clone(), we create immutable copies of the Headers and HttpQueryParams here.
+
         HttpRequestMessageImpl req = new HttpRequestMessageImpl(message.getContext(),
                 protocol, method, path,
-                queryParams.immutableCopy(), message.getHeaders().immutableCopy(), clientIp, scheme,
+                queryParams.immutableCopy(),  Headers.copyOf(message.getHeaders()), clientIp, scheme,
                 port, serverName, clientRemoteAddress, true);
         req.setHasBody(hasBody());
         return req;

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
@@ -403,7 +403,7 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
     {
         HttpRequestMessageImpl clone = new HttpRequestMessageImpl(message.getContext().clone(),
                 protocol, method, path,
-                queryParams.clone(), message.getHeaders().clone(), clientIp, scheme,
+                queryParams.clone(), Headers.copyOf(message.getHeaders()), clientIp, scheme,
                 port, serverName, clientRemoteAddress, immutable);
         if (getInboundRequest() != null) {
             clone.inboundRequest = (HttpRequestInfo) getInboundRequest().clone();

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessageImpl.java
@@ -191,7 +191,7 @@ public class HttpResponseMessageImpl implements HttpResponseMessage
     public boolean hasSetCookieWithName(String cookieName)
     {
         boolean has = false;
-        for (String setCookieValue : getHeaders().get(HttpHeaderNames.SET_COOKIE)) {
+        for (String setCookieValue : getHeaders().getAll(HttpHeaderNames.SET_COOKIE)) {
             for (Cookie cookie : CookieDecoder.decode(setCookieValue)) {
                 if (cookie.getName().equalsIgnoreCase(cookieName)) {
                     has = true;
@@ -261,10 +261,12 @@ public class HttpResponseMessageImpl implements HttpResponseMessage
 
     protected HttpResponseInfo copyResponseInfo()
     {
-        // Unlike clone(), we create immutable copies of the Headers here.
-        HttpResponseMessageImpl response = new HttpResponseMessageImpl(getContext(),
-                getHeaders().immutableCopy(),
-               getOutboundRequest(), getStatus());
+        HttpResponseMessageImpl response =
+                new HttpResponseMessageImpl(
+                        getContext(),
+                        Headers.copyOf(getHeaders()),
+                        getOutboundRequest(),
+                        getStatus());
         response.setHasBody(hasBody());
         return response;
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessageImpl.java
@@ -251,7 +251,7 @@ public class HttpResponseMessageImpl implements HttpResponseMessage
     {
         // TODO - not sure if should be cloning the outbound request object here or not....
         HttpResponseMessageImpl clone = new HttpResponseMessageImpl(getContext().clone(),
-                getHeaders().clone(),
+                Headers.copyOf(getHeaders()),
                 getOutboundRequest(), getStatus());
         if (getInboundResponse() != null) {
             clone.inboundResponse = (HttpResponseInfo) getInboundResponse().clone();

--- a/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
@@ -26,20 +26,21 @@ import static com.netflix.zuul.context.Debug.setDebugRouting;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import com.google.common.truth.Truth;
 import com.netflix.zuul.message.Headers;
 import com.netflix.zuul.message.http.HttpQueryParams;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpRequestMessageImpl;
 import com.netflix.zuul.message.http.HttpResponseMessage;
 import com.netflix.zuul.message.http.HttpResponseMessageImpl;
-import java.net.SocketAddress;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.junit.runners.JUnit4;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(JUnit4.class)
 public class DebugTest {
 
     private SessionContext ctx;
@@ -90,10 +91,10 @@ public class DebugTest {
         Debug.writeDebugRequest(ctx, request, true).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        assertEquals(3, debugLines.size());
-        assertEquals("REQUEST_INBOUND:: > LINE: POST /some/where?k1=v1 HTTP/1.1", debugLines.get(0));
-        assertEquals("REQUEST_INBOUND:: > HDR: Content-Length:13", debugLines.get(1));
-        assertEquals("REQUEST_INBOUND:: > HDR: lah:deda", debugLines.get(2));
+        Truth.assertThat(debugLines).containsExactly(
+                "REQUEST_INBOUND:: > LINE: POST /some/where?k1=v1 HTTP/1.1",
+                "REQUEST_INBOUND:: > HDR: Content-Length:13",
+                "REQUEST_INBOUND:: > HDR: lah:deda");
     }
 
     @Test
@@ -103,10 +104,10 @@ public class DebugTest {
         Debug.writeDebugRequest(ctx, request, false).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        assertEquals(3, debugLines.size());
-        assertEquals("REQUEST_OUTBOUND:: > LINE: POST /some/where?k1=v1 HTTP/1.1", debugLines.get(0));
-        assertEquals("REQUEST_OUTBOUND:: > HDR: Content-Length:13", debugLines.get(1));
-        assertEquals("REQUEST_OUTBOUND:: > HDR: lah:deda", debugLines.get(2));
+        Truth.assertThat(debugLines).containsExactly(
+                "REQUEST_OUTBOUND:: > LINE: POST /some/where?k1=v1 HTTP/1.1",
+                "REQUEST_OUTBOUND:: > HDR: Content-Length:13",
+                "REQUEST_OUTBOUND:: > HDR: lah:deda");
     }
 
     @Test
@@ -116,11 +117,11 @@ public class DebugTest {
         Debug.writeDebugRequest(ctx, request, true).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        assertEquals(4, debugLines.size());
-        assertEquals("REQUEST_INBOUND:: > LINE: POST /some/where?k1=v1 HTTP/1.1", debugLines.get(0));
-        assertEquals("REQUEST_INBOUND:: > HDR: Content-Length:13", debugLines.get(1));
-        assertEquals("REQUEST_INBOUND:: > HDR: lah:deda", debugLines.get(2));
-        assertEquals("REQUEST_INBOUND:: > BODY: some text", debugLines.get(3));
+        Truth.assertThat(debugLines).containsExactly(
+                "REQUEST_INBOUND:: > LINE: POST /some/where?k1=v1 HTTP/1.1",
+                "REQUEST_INBOUND:: > HDR: Content-Length:13",
+                "REQUEST_INBOUND:: > HDR: lah:deda",
+                "REQUEST_INBOUND:: > BODY: some text");
     }
 
     @Test
@@ -130,10 +131,10 @@ public class DebugTest {
         Debug.writeDebugResponse(ctx, response, true).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        assertEquals(3, debugLines.size());
-        assertEquals("RESPONSE_INBOUND:: < STATUS: 200", debugLines.get(0));
-        assertEquals("RESPONSE_INBOUND:: < HDR: Content-Length:13", debugLines.get(1));
-        assertEquals("RESPONSE_INBOUND:: < HDR: lah:deda", debugLines.get(2));
+        Truth.assertThat(debugLines).containsExactly(
+                "RESPONSE_INBOUND:: < STATUS: 200",
+                "RESPONSE_INBOUND:: < HDR: Content-Length:13",
+                "RESPONSE_INBOUND:: < HDR: lah:deda");
     }
 
     @Test
@@ -143,10 +144,10 @@ public class DebugTest {
         Debug.writeDebugResponse(ctx, response, false).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        assertEquals(3, debugLines.size());
-        assertEquals("RESPONSE_OUTBOUND:: < STATUS: 200", debugLines.get(0));
-        assertEquals("RESPONSE_OUTBOUND:: < HDR: Content-Length:13", debugLines.get(1));
-        assertEquals("RESPONSE_OUTBOUND:: < HDR: lah:deda", debugLines.get(2));
+        Truth.assertThat(debugLines).containsExactly(
+                "RESPONSE_OUTBOUND:: < STATUS: 200",
+                "RESPONSE_OUTBOUND:: < HDR: Content-Length:13",
+                "RESPONSE_OUTBOUND:: < HDR: lah:deda");
     }
 
     @Test
@@ -156,10 +157,10 @@ public class DebugTest {
         Debug.writeDebugResponse(ctx, response, true).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        assertEquals(4, debugLines.size());
-        assertEquals("RESPONSE_INBOUND:: < STATUS: 200", debugLines.get(0));
-        assertEquals("RESPONSE_INBOUND:: < HDR: Content-Length:13", debugLines.get(1));
-        assertEquals("RESPONSE_INBOUND:: < HDR: lah:deda", debugLines.get(2));
-        assertEquals("RESPONSE_INBOUND:: < BODY: response text", debugLines.get(3));
+        Truth.assertThat(debugLines).containsExactly(
+                "RESPONSE_INBOUND:: < STATUS: 200",
+                "RESPONSE_INBOUND:: < HDR: Content-Length:13",
+                "RESPONSE_INBOUND:: < HDR: lah:deda",
+                "RESPONSE_INBOUND:: < BODY: response text");
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
@@ -99,7 +99,7 @@ public class GZipResponseFilterTest {
         assertEquals("gzip", result.getHeaders().getFirst("Content-Encoding"));
 
         // Check Content-Length header has been removed.;
-        assertEquals(0, result.getHeaders().get("Content-Length").size());
+        assertEquals(0, result.getHeaders().getAll("Content-Length").size());
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
@@ -17,9 +17,13 @@
 package com.netflix.zuul.message;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.truth.Truth;
 import java.util.List;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,6 +33,389 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class HeadersTest {
+
+    @Test
+    public void copyOf() {
+        Headers headers = new Headers();
+        headers.set("Content-Length", "5");
+        Headers headers2 = Headers.copyOf(headers);
+        headers2.add("Via", "duct");
+
+        Truth.assertThat(headers.getAll("Via")).isEmpty();
+    }
+
+    @Test
+    public void getFirst_normalizesName() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        Truth.assertThat(headers.getFirst("cOOkIE")).isEqualTo("this=that");
+    }
+
+    @Test
+    public void getFirst_headerName_normalizesName() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        Truth.assertThat(headers.getFirst(new HeaderName("cOOkIE"))).isEqualTo("this=that");
+    }
+
+    @Test
+    public void getFirst_returnsNull() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        Truth.assertThat(headers.getFirst("Date")).isNull();
+    }
+
+    @Test
+    public void getFirst_headerName_returnsNull() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        Truth.assertThat(headers.getFirst(new HeaderName("Date"))).isNull();
+    }
+
+    @Test
+    public void getFirst_returnsDefault() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        Truth.assertThat(headers.getFirst("Date", "tuesday")).isEqualTo("tuesday");
+    }
+
+    @Test
+    public void getFirst_headerName_returnsDefault() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        Truth.assertThat(headers.getFirst(new HeaderName("Date"), "tuesday")).isEqualTo("tuesday");
+    }
+
+    @Test
+    public void getAll() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        Truth.assertThat(headers.getAll("CookiE")).containsExactly("this=that", "frizzle=frazzle").inOrder();
+    }
+
+    @Test
+    public void getAll_headerName() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        Truth.assertThat(headers.getAll(new HeaderName("CookiE")))
+                .containsExactly("this=that", "frizzle=frazzle").inOrder();
+    }
+
+    @Test
+    public void setClearsExisting() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        headers.set("cookIe", "dilly=dally");
+
+        Truth.assertThat(headers.getAll("CookiE")).containsExactly("dilly=dally");
+        Truth.assertThat(headers.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void setClearsExisting_headerName() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        headers.set(new HeaderName("cookIe"), "dilly=dally");
+
+        Truth.assertThat(headers.getAll("CookiE")).containsExactly("dilly=dally");
+        Truth.assertThat(headers.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void setNullIsEmtpy() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        headers.set("cookIe", null);
+
+        Truth.assertThat(headers.getAll("CookiE")).isEmpty();
+        Truth.assertThat(headers.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void setNullIsEmtpy_headerName() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        headers.set(new HeaderName("cookIe"), null);
+
+        Truth.assertThat(headers.getAll("CookiE")).isEmpty();
+        Truth.assertThat(headers.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void setIfAbsentKeepsExisting() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        headers.setIfAbsent("cookIe", "dilly=dally");
+
+        Truth.assertThat(headers.getAll("CookiE")).containsExactly("this=that", "frizzle=frazzle").inOrder();
+    }
+
+    @Test
+    public void setIfAbsentKeepsExisting_headerName() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        headers.setIfAbsent(new HeaderName("cookIe"), "dilly=dally");
+
+        Truth.assertThat(headers.getAll("CookiE")).containsExactly("this=that", "frizzle=frazzle").inOrder();
+    }
+
+    @Test
+    public void setIfAbsentFailsOnNull() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        assertThrows(NullPointerException.class, () -> headers.setIfAbsent("cookIe", null));
+    }
+
+    @Test
+    public void setIfAbsentFailsOnNull_headerName() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        assertThrows(NullPointerException.class, () -> headers.setIfAbsent(new HeaderName("cookIe"), null));
+    }
+
+    @Test
+    public void setIfAbsent() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        headers.setIfAbsent("X-Netflix-Awesome", "true");
+
+        Truth.assertThat(headers.getAll("X-netflix-Awesome")).containsExactly("true");
+    }
+
+    @Test
+    public void setIfAbsent_headerName() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        headers.setIfAbsent(new HeaderName("X-Netflix-Awesome"), "true");
+
+        Truth.assertThat(headers.getAll("X-netflix-Awesome")).containsExactly("true");
+    }
+
+    @Test
+    public void add() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        headers.add("via", "con Dios");
+
+        Truth.assertThat(headers.getAll("Via")).containsExactly("duct", "con Dios").inOrder();
+    }
+
+    @Test
+    public void add_headerName() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        headers.add(new HeaderName("via"), "con Dios");
+
+        Truth.assertThat(headers.getAll("Via")).containsExactly("duct", "con Dios").inOrder();
+    }
+
+    @Test
+    public void putAll() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+
+        Headers other = new Headers();
+        other.add("cookie", "a=b");
+        other.add("via", "com");
+
+        headers.putAll(other);
+
+        // Only check the order per field, not for the entire set.
+        Truth.assertThat(headers.getAll("Via")).containsExactly("duct", "com").inOrder();
+        Truth.assertThat(headers.getAll("coOkiE")).containsExactly("this=that", "frizzle=frazzle", "a=b").inOrder();
+        Truth.assertThat(headers.size()).isEqualTo(5);
+    }
+
+
+    @Test
+    public void remove() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+        headers.add("Soup", "salad");
+
+        List<String> removed = headers.remove("Cookie");
+
+        Truth.assertThat(headers.getAll("Cookie")).isEmpty();
+        Truth.assertThat(headers.getAll("Soup")).containsExactly("salad");
+        Truth.assertThat(headers.size()).isEqualTo(2);
+        Truth.assertThat(removed).containsExactly("this=that", "frizzle=frazzle").inOrder();
+    }
+
+    @Test
+    public void remove_headerName() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+        headers.add("Soup", "salad");
+
+        List<String> removed = headers.remove(new HeaderName("Cookie"));
+
+        Truth.assertThat(headers.getAll("Cookie")).isEmpty();
+        Truth.assertThat(headers.getAll("Soup")).containsExactly("salad");
+        Truth.assertThat(headers.size()).isEqualTo(2);
+        Truth.assertThat(removed).containsExactly("this=that", "frizzle=frazzle").inOrder();
+    }
+
+    @Test
+    public void removeEmpty() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+        headers.add("Soup", "salad");
+
+        List<String> removed = headers.remove("Monkey");
+
+        Truth.assertThat(headers.getAll("Cookie")).isNotEmpty();
+        Truth.assertThat(headers.getAll("Soup")).containsExactly("salad");
+        Truth.assertThat(headers.size()).isEqualTo(4);
+        Truth.assertThat(removed).isEmpty();
+    }
+
+    @Test
+    public void removeEmpty_headerName() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=frazzle");
+        headers.add("Soup", "salad");
+
+        List<String> removed = headers.remove(new HeaderName("Monkey"));
+
+        Truth.assertThat(headers.getAll("Cookie")).isNotEmpty();
+        Truth.assertThat(headers.getAll("Soup")).containsExactly("salad");
+        Truth.assertThat(headers.size()).isEqualTo(4);
+        Truth.assertThat(removed).isEmpty();
+    }
+
+    @Test
+    public void removeIf() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("COOkie", "frizzle=frazzle");
+        headers.add("Soup", "salad");
+
+        boolean removed = headers.removeIf(entry -> entry.getKey().getName().equals("Cookie"));
+
+        assertTrue(removed);
+        Truth.assertThat(headers.getAll("cOoKie")).containsExactly("frizzle=frazzle");
+        Truth.assertThat(headers.size()).isEqualTo(3);
+    }
+
+    @Test
+    public void keySet() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("COOKie", "this=that");
+        headers.add("cookIE", "frizzle=frazzle");
+        headers.add("Soup", "salad");
+
+        Set<HeaderName> keySet = headers.keySet();
+
+        Truth.assertThat(keySet)
+                .containsExactly(new HeaderName("COOKie"), new HeaderName("Soup"), new HeaderName("Via"));
+        for (HeaderName headerName : keySet) {
+            if (headerName.getName().equals("COOKie")) {
+                return;
+            }
+        }
+        throw new AssertionError("didn't find right cookie in keys: " + keySet);
+    }
+
+    @Test
+    public void contains() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("COOKie", "this=that");
+        headers.add("cookIE", "frizzle=frazzle");
+        headers.add("Soup", "salad");
+
+        assertTrue(headers.contains("CoOkIe"));
+        assertTrue(headers.contains(new HeaderName("CoOkIe")));
+        assertFalse(headers.contains("Monkey"));
+        assertFalse(headers.contains(new HeaderName("Monkey")));
+    }
+
+    @Test
+    public void containsValue() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("COOKie", "this=that");
+        headers.add("cookIE", "frizzle=frazzle");
+        headers.add("Soup", "salad");
+
+        // note the swapping of the two cookie casings.
+        assertTrue(headers.contains("CoOkIe", "frizzle=frazzle"));
+        assertTrue(headers.contains(new HeaderName("CoOkIe"), "frizzle=frazzle"));
+        assertFalse(headers.contains("Via", "lin"));
+        assertFalse(headers.contains(new HeaderName("Soup"), "of the day"));
+    }
 
     @Test
     public void testCaseInsensitiveKeys_Set() {

--- a/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
@@ -42,6 +42,8 @@ public class HeadersTest {
         headers2.add("Via", "duct");
 
         Truth.assertThat(headers.getAll("Via")).isEmpty();
+        Truth.assertThat(headers2.size()).isEqualTo(2);
+        Truth.assertThat(headers2.getAll("Content-Length")).containsExactly("5");
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
@@ -22,12 +22,12 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link Headers}.
  */
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(JUnit4.class)
 public class HeadersTest {
 
     @Test
@@ -38,7 +38,7 @@ public class HeadersTest {
 
         assertEquals("10", headers.getFirst("Content-Length"));
         assertEquals("10", headers.getFirst("content-length"));
-        assertEquals(1, headers.get("content-length").size());
+        assertEquals(1, headers.getAll("content-length").size());
     }
 
     @Test
@@ -47,7 +47,7 @@ public class HeadersTest {
         headers.add("Content-Length", "5");
         headers.add("content-length", "10");
 
-        List<String> values = headers.get("content-length");
+        List<String> values = headers.getAll("content-length");
         assertTrue(values.contains("10"));
         assertTrue(values.contains("5"));
         assertEquals(2, values.size());
@@ -59,7 +59,7 @@ public class HeadersTest {
         headers.set("Content-Length", "5");
         headers.setIfAbsent("content-length", "10");
 
-        List<String> values = headers.get("content-length");
+        List<String> values = headers.getAll("content-length");
         assertEquals(1, values.size());
         assertEquals("5", values.get(0));
     }
@@ -73,7 +73,7 @@ public class HeadersTest {
         Headers headers2 = new Headers();
         headers2.putAll(headers);
 
-        List<String> values = headers2.get("content-length");
+        List<String> values = headers2.getAll("content-length");
         assertTrue(values.contains("10"));
         assertTrue(values.contains("5"));
         assertEquals(2, values.size());


### PR DESCRIPTION
This change has some performance improvements.  Since headers are usually small, using an array is typically faster than the ListMultimap that we use now.

Key changes:

* Headers now use ArrayLists of keys, values, and the original names.  This avoids the high memory allocation and slowness of ArrayListMultimap.  Both Netty and gRPC use linear time datastructures for their headers. 
    * This also allows making special accessor methods because we have control of the implementation.
* HeaderNames no longer try to intern their strings.  Interning is very slow, involves JNI and bring memory usage up.  This is noticeable on profiling.
* get() method is now getFirst and getAll for clarity.  This allows picking better performance if only one is wanted.
* Immutable headers are not longer a thing.  It was not widely used, and it's difficult to support.
* Added docs and testing for all the methods.  This makes it more clear what the code should do.
* HeaderNames are not allocated per access.   This is very expensive, since it involves synchronizing on the HeaderNameCache.


I have included Benchmarks below cherry-picking from my other PR.   Numbers are better for adding headers, setting headers and iterating over them.  They are slightly worse for getting headers, since a  List is returned.  I think this is a good apples-to apples comparison, but I expect that we will stop using the getAll accessor once this change is in, bringing the perf in range.


```
BEFORE


Benchmark                                                                           (count)  (nameLength)  Mode  Cnt     Score      Error   Units
HeadersBenchmark.AddHeaders.addHeaders_headerName                                         0            10  avgt    5    13.178 ±    0.351   ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate                          0            10  avgt    5  5778.258 ±  142.837  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate.norm                     0            10  avgt    5   120.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space                 0            10  avgt    5  5729.596 ±  662.448  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space.norm            0            10  avgt    5   118.979 ±   11.782    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space             0            10  avgt    5     0.158 ±    0.144  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space.norm        0            10  avgt    5     0.003 ±    0.003    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.count                               0            10  avgt    5    77.000             counts
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.time                                0            10  avgt    5    47.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_headerName                                         1            10  avgt    5    60.872 ±    2.131   ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate                          1            10  avgt    5  3669.285 ±  127.481  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate.norm                     1            10  avgt    5   352.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space                 1            10  avgt    5  3685.199 ±  659.552  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space.norm            1            10  avgt    5   353.490 ±   58.044    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space             1            10  avgt    5     0.154 ±    0.134  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space.norm        1            10  avgt    5     0.015 ±    0.013    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.count                               1            10  avgt    5    74.000             counts
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.time                                1            10  avgt    5    47.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_headerName                                         5            10  avgt    5   222.472 ±    5.596   ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate                          5            10  avgt    5  2009.810 ±   55.884  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate.norm                     5            10  avgt    5   704.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space                 5            10  avgt    5  2008.276 ±  179.376  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space.norm            5            10  avgt    5   703.458 ±   58.447    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space             5            10  avgt    5     0.170 ±    0.192  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space.norm        5            10  avgt    5     0.060 ±    0.066    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.count                               5            10  avgt    5    75.000             counts
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.time                                5            10  avgt    5    47.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_headerName                                        10            10  avgt    5   421.710 ±   14.271   ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate                         10            10  avgt    5  1722.183 ±   65.786  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate.norm                    10            10  avgt    5  1144.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space                10            10  avgt    5  1710.637 ±  374.629  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space.norm           10            10  avgt    5  1136.275 ±  241.343    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space            10            10  avgt    5     0.162 ±    0.105  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space.norm       10            10  avgt    5     0.107 ±    0.067    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.count                              10            10  avgt    5    74.000             counts
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.time                               10            10  avgt    5    46.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_headerName                                        30            10  avgt    5  1295.250 ±    8.772   ns/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate                         30            10  avgt    5  1557.763 ±   15.510  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.alloc.rate.norm                    30            10  avgt    5  3176.001 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space                30            10  avgt    5  1567.201 ±  250.967  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Eden_Space.norm           30            10  avgt    5  3195.180 ±  504.337    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space            30            10  avgt    5     0.195 ±    0.229  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.churn.PS_Survivor_Space.norm       30            10  avgt    5     0.398 ±    0.470    B/op
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.count                              30            10  avgt    5    73.000             counts
HeadersBenchmark.AddHeaders.addHeaders_headerName:·gc.time                               30            10  avgt    5    46.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_string                                             0            10  avgt    5    13.165 ±    0.977   ns/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate                              0            10  avgt    5  5790.782 ±  439.398  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate.norm                         0            10  avgt    5   120.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space                     0            10  avgt    5  5711.296 ± 1067.689  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space.norm                0            10  avgt    5   118.302 ±   13.808    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space                 0            10  avgt    5     0.137 ±    0.191  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space.norm            0            10  avgt    5     0.003 ±    0.004    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.count                                   0            10  avgt    5    75.000             counts
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.time                                    0            10  avgt    5    46.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_string                                             1            10  avgt    5   239.974 ±    3.108   ns/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate                              1            10  avgt    5   994.694 ±   11.430  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate.norm                         1            10  avgt    5   376.000 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space                     1            10  avgt    5  1001.661 ±   62.977  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space.norm                1            10  avgt    5   378.627 ±   21.534    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space                 1            10  avgt    5     0.141 ±    0.087  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space.norm            1            10  avgt    5     0.053 ±    0.033    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.count                                   1            10  avgt    5    75.000             counts
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.time                                    1            10  avgt    5    47.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_string                                             5            10  avgt    5  1182.916 ±   60.146   ns/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate                              5            10  avgt    5   442.468 ±   23.490  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate.norm                         5            10  avgt    5   824.001 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space                     5            10  avgt    5   439.803 ±   55.825  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space.norm                5            10  avgt    5   818.921 ±   73.927    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space                 5            10  avgt    5     0.158 ±    0.145  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space.norm            5            10  avgt    5     0.294 ±    0.265    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.count                                   5            10  avgt    5    71.000             counts
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.time                                    5            10  avgt    5    44.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_string                                            10            10  avgt    5  2306.242 ±   49.923   ns/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate                             10            10  avgt    5   380.798 ±    8.531  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate.norm                        10            10  avgt    5  1384.001 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space                    10            10  avgt    5   379.161 ±   24.429  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space.norm               10            10  avgt    5  1378.149 ±  108.699    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space                10            10  avgt    5     0.137 ±    0.121  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space.norm           10            10  avgt    5     0.498 ±    0.453    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.count                                  10            10  avgt    5    68.000             counts
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.time                                   10            10  avgt    5    43.000                 ms
HeadersBenchmark.AddHeaders.addHeaders_string                                            30            10  avgt    5  7093.121 ±   54.902   ns/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate                             30            10  avgt    5   349.157 ±    1.994  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.alloc.rate.norm                        30            10  avgt    5  3896.003 ±    0.001    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space                    30            10  avgt    5   350.932 ±   54.669  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Eden_Space.norm               30            10  avgt    5  3915.724 ±  599.573    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space                30            10  avgt    5     0.170 ±    0.117  MB/sec
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.churn.PS_Survivor_Space.norm           30            10  avgt    5     1.901 ±    1.313    B/op
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.count                                  30            10  avgt    5    61.000             counts
HeadersBenchmark.AddHeaders.addHeaders_string:·gc.time                                   30            10  avgt    5    39.000                 ms
HeadersBenchmark.GetSetHeaders.entries                                                    1            10  avgt    5   121.077 ±    8.737   ns/op
HeadersBenchmark.GetSetHeaders.entries:·gc.alloc.rate                                     1            10  avgt    5  2559.024 ±  182.661  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.alloc.rate.norm                                1            10  avgt    5   488.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Eden_Space                            1            10  avgt    5  2548.130 ±  237.599  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Eden_Space.norm                       1            10  avgt    5   485.901 ±   21.870    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Survivor_Space                        1            10  avgt    5     0.145 ±    0.150  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Survivor_Space.norm                   1            10  avgt    5     0.028 ±    0.028    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.count                                          1            10  avgt    5    73.000             counts
HeadersBenchmark.GetSetHeaders.entries:·gc.time                                           1            10  avgt    5    46.000                 ms
HeadersBenchmark.GetSetHeaders.entries                                                    5            10  avgt    5   228.565 ±    8.452   ns/op
HeadersBenchmark.GetSetHeaders.entries:·gc.alloc.rate                                     5            10  avgt    5  2423.391 ±   86.532  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.alloc.rate.norm                                5            10  avgt    5   872.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Eden_Space                            5            10  avgt    5  2440.025 ±  254.330  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Eden_Space.norm                       5            10  avgt    5   877.957 ±   80.759    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Survivor_Space                        5            10  avgt    5     0.170 ±    0.222  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Survivor_Space.norm                   5            10  avgt    5     0.061 ±    0.079    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.count                                          5            10  avgt    5    75.000             counts
HeadersBenchmark.GetSetHeaders.entries:·gc.time                                           5            10  avgt    5    47.000                 ms
HeadersBenchmark.GetSetHeaders.entries                                                   10            10  avgt    5   372.102 ±    7.033   ns/op
HeadersBenchmark.GetSetHeaders.entries:·gc.alloc.rate                                    10            10  avgt    5  2308.995 ±   41.091  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.alloc.rate.norm                               10            10  avgt    5  1352.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Eden_Space                           10            10  avgt    5  2323.215 ±  472.524  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Eden_Space.norm                      10            10  avgt    5  1360.260 ±  269.237    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Survivor_Space                       10            10  avgt    5     0.145 ±    0.170  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Survivor_Space.norm                  10            10  avgt    5     0.085 ±    0.100    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.count                                         10            10  avgt    5    76.000             counts
HeadersBenchmark.GetSetHeaders.entries:·gc.time                                          10            10  avgt    5    46.000                 ms
HeadersBenchmark.GetSetHeaders.entries                                                   30            10  avgt    5  1018.924 ±   30.509   ns/op
HeadersBenchmark.GetSetHeaders.entries:·gc.alloc.rate                                    30            10  avgt    5  2246.697 ±   62.955  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.alloc.rate.norm                               30            10  avgt    5  3608.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Eden_Space                           30            10  avgt    5  2273.708 ±  500.100  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Eden_Space.norm                      30            10  avgt    5  3650.728 ±  737.127    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Survivor_Space                       30            10  avgt    5     0.174 ±    0.146  MB/sec
HeadersBenchmark.GetSetHeaders.entries:·gc.churn.PS_Survivor_Space.norm                  30            10  avgt    5     0.280 ±    0.235    B/op
HeadersBenchmark.GetSetHeaders.entries:·gc.count                                         30            10  avgt    5    70.000             counts
HeadersBenchmark.GetSetHeaders.entries:·gc.time                                          30            10  avgt    5    42.000                 ms
HeadersBenchmark.GetSetHeaders.getHeader_first                                            1            10  avgt    5    10.011 ±    0.760   ns/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.alloc.rate                             1            10  avgt    5  2535.901 ±  185.928  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.alloc.rate.norm                        1            10  avgt    5    40.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Eden_Space                    1            10  avgt    5  2536.189 ±  181.466  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Eden_Space.norm               1            10  avgt    5    40.021 ±    5.003    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Survivor_Space                1            10  avgt    5     0.104 ±    0.127  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Survivor_Space.norm           1            10  avgt    5     0.002 ±    0.002    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.count                                  1            10  avgt    5    71.000             counts
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.time                                   1            10  avgt    5    46.000                 ms
HeadersBenchmark.GetSetHeaders.getHeader_first                                            5            10  avgt    5     9.860 ±    0.070   ns/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.alloc.rate                             5            10  avgt    5  2576.554 ±   29.778  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.alloc.rate.norm                        5            10  avgt    5    40.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Eden_Space                    5            10  avgt    5  2566.652 ±  318.055  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Eden_Space.norm               5            10  avgt    5    39.849 ±    5.282    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Survivor_Space                5            10  avgt    5     0.083 ±    0.126  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Survivor_Space.norm           5            10  avgt    5     0.001 ±    0.002    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.count                                  5            10  avgt    5    75.000             counts
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.time                                   5            10  avgt    5    48.000                 ms
HeadersBenchmark.GetSetHeaders.getHeader_first                                           10            10  avgt    5     9.928 ±    0.075   ns/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.alloc.rate                            10            10  avgt    5  2558.921 ±   20.174  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.alloc.rate.norm                       10            10  avgt    5    40.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Eden_Space                   10            10  avgt    5  2558.575 ±  336.718  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Eden_Space.norm              10            10  avgt    5    39.997 ±    5.547    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Survivor_Space               10            10  avgt    5     0.083 ±    0.150  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Survivor_Space.norm          10            10  avgt    5     0.001 ±    0.002    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.count                                 10            10  avgt    5    72.000             counts
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.time                                  10            10  avgt    5    48.000                 ms
HeadersBenchmark.GetSetHeaders.getHeader_first                                           30            10  avgt    5     9.958 ±    0.277   ns/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.alloc.rate                            30            10  avgt    5  2552.037 ±   69.982  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.alloc.rate.norm                       30            10  avgt    5    40.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Eden_Space                   30            10  avgt    5  2543.261 ±  252.119  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Eden_Space.norm              30            10  avgt    5    39.866 ±    4.456    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Survivor_Space               30            10  avgt    5     0.116 ±    0.192  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.churn.PS_Survivor_Space.norm          30            10  avgt    5     0.002 ±    0.003    B/op
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.count                                 30            10  avgt    5    73.000             counts
HeadersBenchmark.GetSetHeaders.getHeader_first:·gc.time                                  30            10  avgt    5    48.000                 ms
HeadersBenchmark.GetSetHeaders.getHeader_last                                             1            10  avgt    5     9.976 ±    0.679   ns/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.alloc.rate                              1            10  avgt    5  2543.476 ±  161.143  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.alloc.rate.norm                         1            10  avgt    5    40.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Eden_Space                     1            10  avgt    5  2524.308 ±  439.135  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Eden_Space.norm                1            10  avgt    5    39.700 ±    6.613    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Survivor_Space                 1            10  avgt    5     0.075 ±    0.091  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Survivor_Space.norm            1            10  avgt    5     0.001 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.count                                   1            10  avgt    5    73.000             counts
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.time                                    1            10  avgt    5    47.000                 ms
HeadersBenchmark.GetSetHeaders.getHeader_last                                             5            10  avgt    5    10.604 ±    0.202   ns/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.alloc.rate                              5            10  avgt    5  2396.674 ±   40.549  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.alloc.rate.norm                         5            10  avgt    5    40.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Eden_Space                     5            10  avgt    5  2408.854 ±  436.225  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Eden_Space.norm                5            10  avgt    5    40.203 ±    7.217    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Survivor_Space                 5            10  avgt    5     0.079 ±    0.173  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Survivor_Space.norm            5            10  avgt    5     0.001 ±    0.003    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.count                                   5            10  avgt    5    74.000             counts
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.time                                    5            10  avgt    5    48.000                 ms
HeadersBenchmark.GetSetHeaders.getHeader_last                                            10            10  avgt    5    10.602 ±    0.293   ns/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.alloc.rate                             10            10  avgt    5  2396.177 ±   63.889  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.alloc.rate.norm                        10            10  avgt    5    40.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Eden_Space                    10            10  avgt    5  2418.013 ±  251.197  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Eden_Space.norm               10            10  avgt    5    40.371 ±    5.103    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Survivor_Space                10            10  avgt    5     0.066 ±    0.105  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Survivor_Space.norm           10            10  avgt    5     0.001 ±    0.002    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.count                                  10            10  avgt    5    72.000             counts
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.time                                   10            10  avgt    5    47.000                 ms
HeadersBenchmark.GetSetHeaders.getHeader_last                                            30            10  avgt    5    10.733 ±    0.808   ns/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.alloc.rate                             30            10  avgt    5  2366.745 ±  174.145  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.alloc.rate.norm                        30            10  avgt    5    40.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Eden_Space                    30            10  avgt    5  2347.670 ±  548.214  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Eden_Space.norm               30            10  avgt    5    39.671 ±    8.212    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Survivor_Space                30            10  avgt    5     0.095 ±    0.144  MB/sec
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.churn.PS_Survivor_Space.norm           30            10  avgt    5     0.002 ±    0.002    B/op
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.count                                  30            10  avgt    5    74.000             counts
HeadersBenchmark.GetSetHeaders.getHeader_last:·gc.time                                   30            10  avgt    5    47.000                 ms
HeadersBenchmark.GetSetHeaders.setHeader_first                                            1            10  avgt    5    67.720 ±    1.302   ns/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.alloc.rate                             1            10  avgt    5  1799.587 ±   34.486  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.alloc.rate.norm                        1            10  avgt    5   192.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Eden_Space                    1            10  avgt    5  1789.208 ±  166.080  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Eden_Space.norm               1            10  avgt    5   190.909 ±   20.338    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Survivor_Space                1            10  avgt    5     0.136 ±    0.154  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Survivor_Space.norm           1            10  avgt    5     0.015 ±    0.017    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.count                                  1            10  avgt    5    72.000             counts
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.time                                   1            10  avgt    5    46.000                 ms
HeadersBenchmark.GetSetHeaders.setHeader_first                                            5            10  avgt    5    66.579 ±    4.214   ns/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.alloc.rate                             5            10  avgt    5  1831.881 ±  117.274  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.alloc.rate.norm                        5            10  avgt    5   192.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Eden_Space                    5            10  avgt    5  1851.634 ±  194.348  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Eden_Space.norm               5            10  avgt    5   194.069 ±   15.617    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Survivor_Space                5            10  avgt    5     0.157 ±    0.176  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Survivor_Space.norm           5            10  avgt    5     0.017 ±    0.018    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.count                                  5            10  avgt    5    73.000             counts
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.time                                   5            10  avgt    5    46.000                 ms
HeadersBenchmark.GetSetHeaders.setHeader_first                                           10            10  avgt    5    66.677 ±    1.790   ns/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.alloc.rate                            10            10  avgt    5  1825.553 ±   56.928  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.alloc.rate.norm                       10            10  avgt    5   192.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Eden_Space                   10            10  avgt    5  1821.090 ±  282.584  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Eden_Space.norm              10            10  avgt    5   191.550 ±   31.364    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Survivor_Space               10            10  avgt    5     0.157 ±    0.228  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Survivor_Space.norm          10            10  avgt    5     0.017 ±    0.024    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.count                                 10            10  avgt    5    74.000             counts
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.time                                  10            10  avgt    5    47.000                 ms
HeadersBenchmark.GetSetHeaders.setHeader_first                                           30            10  avgt    5    68.097 ±    1.980   ns/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.alloc.rate                            30            10  avgt    5  1789.571 ±   56.396  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.alloc.rate.norm                       30            10  avgt    5   192.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Eden_Space                   30            10  avgt    5  1808.289 ±  140.160  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Eden_Space.norm              30            10  avgt    5   194.014 ±   15.212    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Survivor_Space               30            10  avgt    5     0.153 ±    0.091  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.churn.PS_Survivor_Space.norm          30            10  avgt    5     0.016 ±    0.009    B/op
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.count                                 30            10  avgt    5    75.000             counts
HeadersBenchmark.GetSetHeaders.setHeader_first:·gc.time                                  30            10  avgt    5    48.000                 ms
HeadersBenchmark.GetSetHeaders.setHeader_last                                             1            10  avgt    5    65.259 ±    1.312   ns/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.alloc.rate                              1            10  avgt    5  1870.920 ±   49.808  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.alloc.rate.norm                         1            10  avgt    5   192.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Eden_Space                     1            10  avgt    5  1873.652 ±  407.130  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Eden_Space.norm                1            10  avgt    5   192.246 ±   38.366    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Survivor_Space                 1            10  avgt    5     0.174 ±    0.164  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Survivor_Space.norm            1            10  avgt    5     0.018 ±    0.017    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.count                                   1            10  avgt    5    74.000             counts
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.time                                    1            10  avgt    5    47.000                 ms
HeadersBenchmark.GetSetHeaders.setHeader_last                                             5            10  avgt    5    67.451 ±    0.833   ns/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.alloc.rate                              5            10  avgt    5  1807.081 ±   29.514  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.alloc.rate.norm                         5            10  avgt    5   192.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Eden_Space                     5            10  avgt    5  1806.482 ±  203.762  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Eden_Space.norm                5            10  avgt    5   191.938 ±   21.775    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Survivor_Space                 5            10  avgt    5     0.153 ±    0.109  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Survivor_Space.norm            5            10  avgt    5     0.016 ±    0.011    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.count                                   5            10  avgt    5    67.000             counts
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.time                                    5            10  avgt    5    46.000                 ms
HeadersBenchmark.GetSetHeaders.setHeader_last                                            10            10  avgt    5    67.112 ±    1.826   ns/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.alloc.rate                             10            10  avgt    5  1813.940 ±   49.994  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.alloc.rate.norm                        10            10  avgt    5   192.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Eden_Space                    10            10  avgt    5  1814.945 ±  229.176  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Eden_Space.norm               10            10  avgt    5   192.141 ±   28.375    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Survivor_Space                10            10  avgt    5     0.136 ±    0.106  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Survivor_Space.norm           10            10  avgt    5     0.014 ±    0.011    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.count                                  10            10  avgt    5    74.000             counts
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.time                                   10            10  avgt    5    45.000                 ms
HeadersBenchmark.GetSetHeaders.setHeader_last                                            30            10  avgt    5    66.100 ±    3.865   ns/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.alloc.rate                             30            10  avgt    5  1843.287 ±  112.151  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.alloc.rate.norm                        30            10  avgt    5   192.000 ±    0.001    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Eden_Space                    30            10  avgt    5  1828.230 ±  188.535  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Eden_Space.norm               30            10  avgt    5   190.429 ±   15.290    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Survivor_Space                30            10  avgt    5     0.136 ±    0.090  MB/sec
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.churn.PS_Survivor_Space.norm           30            10  avgt    5     0.014 ±    0.010    B/op
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.count                                  30            10  avgt    5    73.000             counts
HeadersBenchmark.GetSetHeaders.setHeader_last:·gc.time                                   30            10  avgt    5    47.000                 ms
HeadersBenchmark.newHeaders                                                             N/A           N/A  avgt    5    13.134 ±    0.614   ns/op
HeadersBenchmark.newHeaders:·gc.alloc.rate                                              N/A           N/A  avgt    5  5791.151 ±  264.205  MB/sec
HeadersBenchmark.newHeaders:·gc.alloc.rate.norm                                         N/A           N/A  avgt    5   120.000 ±    0.001    B/op
HeadersBenchmark.newHeaders:·gc.churn.PS_Eden_Space                                     N/A           N/A  avgt    5  5729.585 ±  401.732  MB/sec
HeadersBenchmark.newHeaders:·gc.churn.PS_Eden_Space.norm                                N/A           N/A  avgt    5   118.721 ±    4.866    B/op
HeadersBenchmark.newHeaders:·gc.churn.PS_Survivor_Space                                 N/A           N/A  avgt    5     0.120 ±    0.118  MB/sec
HeadersBenchmark.newHeaders:·gc.churn.PS_Survivor_Space.norm                            N/A           N/A  avgt    5     0.002 ±    0.002    B/op
HeadersBenchmark.newHeaders:·gc.count                                                   N/A           N/A  avgt    5    76.000             counts
HeadersBenchmark.newHeaders:·gc.time                                                    N/A           N/A  avgt    5    47.000                 ms
```


