### PR TITLE
zuul-core: HashMap's key override equals and hashCode method

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/channel/config/ChannelConfig.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/channel/config/ChannelConfig.java
@@ -32,6 +32,7 @@ public class ChannelConfig implements Cloneable
         parameters = new HashMap<>();
     }
 
+    @SuppressWarnings("unchecked")
     public ChannelConfig(HashMap<ChannelConfigKey, ChannelConfigValue> parameters)
     {
         this.parameters = (HashMap<ChannelConfigKey, ChannelConfigValue>) parameters.clone();
@@ -47,6 +48,7 @@ public class ChannelConfig implements Cloneable
         this.parameters.put(key, new ChannelConfigValue<>(key, value));
     }
 
+    @SuppressWarnings("unchecked")
     public <T> T get(ChannelConfigKey<T> key)
     {
         ChannelConfigValue<T> ccv = parameters.get(key);
@@ -59,6 +61,7 @@ public class ChannelConfig implements Cloneable
         return value;
     }
 
+    @SuppressWarnings("unchecked")
     public <T> ChannelConfigValue<T> getConfig(ChannelConfigKey<T> key)
     {
         return (ChannelConfigValue<T>) parameters.get(key);

--- a/zuul-core/src/main/java/com/netflix/netty/common/channel/config/ChannelConfigKey.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/channel/config/ChannelConfigKey.java
@@ -16,6 +16,8 @@
 
 package com.netflix.netty.common.channel.config;
 
+import java.util.Objects;
+
 /**
  * User: michaels@netflix.com
  * Date: 2/8/17
@@ -59,5 +61,26 @@ public class ChannelConfigKey<T>
                 "key='" + key + '\'' +
                 ", defaultValue=" + defaultValue +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (!(o instanceof ChannelConfigKey))
+        {
+            return false;
+        }
+        ChannelConfigKey<?> that = (ChannelConfigKey<?>) o;
+        return key.equals(that.key);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(key);
     }
 }


### PR DESCRIPTION
`ChannelConfigKey` used as HashMap's key in `ChannelConfig`,so `ChannelConfigKey`  override equals and hashCode method is a good way to prevent potential memory leak.