### PR TITLE
refactor: always set the server address on service connection pool

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
@@ -407,7 +407,7 @@ public class DefaultClientChannelManager implements ClientChannelManager {
         selectedServer.set(chosenServer);
 
         // Now get the connection-pool for this server.
-        IConnectionPool pool = perServerPools.computeIfAbsent(chosenServer, s -> {
+        IConnectionPool pool = getPerServerPoolsByAddress(chosenServer, finalServerAddr).computeIfAbsent(chosenServer, s -> {
             // Get the stats from LB for this server.
             LoadBalancerStats lbStats = loadBalancer.getLoadBalancerStats();
             ServerStats stats = lbStats.getSingleServerStat(chosenServer);
@@ -478,7 +478,13 @@ public class DefaultClientChannelManager implements ClientChannelManager {
         return this.loadBalancer.getClientConfig();
     }
 
-    protected ConcurrentHashMap<Server, IConnectionPool> getPerServerPools() {
+    protected ConcurrentHashMap<Server, IConnectionPool> getPerServerPools() { return perServerPools; }
+
+    protected ConcurrentHashMap<Server, IConnectionPool> getPerServerPoolsByAddress(Server chosenServer, SocketAddress finalServerAddr) {
+        IConnectionPool currentServerPool = perServerPools.get(chosenServer);
+        if(finalServerAddr != null && currentServerPool != null && !currentServerPool.getServerAddr().equals(finalServerAddr)){
+            perServerPools.remove(chosenServer);
+        }
         return perServerPools;
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/IConnectionPool.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/IConnectionPool.java
@@ -20,6 +20,7 @@ import com.netflix.zuul.passport.CurrentPassport;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Promise;
 
+import java.net.SocketAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -37,5 +38,6 @@ public interface IConnectionPool
     boolean isAvailable();
     int getConnsInUse();
     int getConnsInPool();
+    SocketAddress getServerAddr();
     ConnectionPoolConfig getConfig();
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPool.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPool.java
@@ -134,6 +134,8 @@ public class PerServerConnectionPool implements IConnectionPool
         return niwsClientConfig;
     }
 
+    public SocketAddress getServerAddr() { return this.serverAddr; }
+
     @Override
     public boolean isAvailable()
     {


### PR DESCRIPTION
Logic to avoid DNS/IP address caching on perServerConnectionPool that causes 502 Bad Gateway error connecting to the Origin endpoint. Issue described on https://github.com/Netflix/zuul/issues/780