### PR TITLE
all: bump to groovy 3.0.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-versions_groovy=2.4.4
+versions_groovy=3.0.3
 versions_ribbon=2.7.17
 versions_netty=4.1.48.Final
 release.scope=patch

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -105,8 +105,8 @@
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
-            "locked": "2.4.4",
-            "requested": "2.4.4"
+            "locked": "3.0.3",
+            "requested": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
@@ -227,8 +227,8 @@
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
-            "locked": "2.4.4",
-            "requested": "2.4.4"
+            "locked": "3.0.3",
+            "requested": "3.0.3"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.21",
@@ -361,8 +361,8 @@
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
-            "locked": "2.4.4",
-            "requested": "2.4.4"
+            "locked": "3.0.3",
+            "requested": "3.0.3"
         },
         "org.mockito:mockito-core": {
             "locked": "3.3.3",
@@ -495,8 +495,8 @@
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
-            "locked": "2.4.4",
-            "requested": "2.4.4"
+            "locked": "3.0.3",
+            "requested": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30",
@@ -617,8 +617,8 @@
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
-            "locked": "2.4.4",
-            "requested": "2.4.4"
+            "locked": "3.0.3",
+            "requested": "3.0.3"
         },
         "org.mockito:mockito-core": {
             "locked": "3.3.3",
@@ -747,8 +747,8 @@
             "requested": "1.+"
         },
         "org.codehaus.groovy:groovy-all": {
-            "locked": "2.4.4",
-            "requested": "2.4.4"
+            "locked": "3.0.3",
+            "requested": "3.0.3"
         },
         "org.mockito:mockito-core": {
             "locked": "3.3.3",

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -123,7 +123,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -264,7 +264,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.21",
@@ -471,7 +471,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.mockito:mockito-core": {
             "locked": "3.3.3",
@@ -670,7 +670,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -815,7 +815,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.mockito:mockito-core": {
             "locked": "3.3.3",
@@ -1018,7 +1018,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.mockito:mockito-core": {
             "locked": "3.3.3",

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -119,7 +119,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -256,7 +256,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.21",
@@ -452,7 +452,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.21",
@@ -640,7 +640,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -826,7 +826,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -963,7 +963,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1151,7 +1151,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -176,7 +176,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -319,7 +319,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -470,7 +470,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.21",
@@ -689,7 +689,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.21",
@@ -908,7 +908,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1051,7 +1051,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1262,7 +1262,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.4.4"
+            "locked": "3.0.3"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
This avoids the "reflective access" warning on later JDKs