### PR TITLE
zuul-processor: make a Configuration based processor, and stop producing generated Ja…

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/StaticFilterLoader.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/StaticFilterLoader.java
@@ -19,13 +19,21 @@ package com.netflix.zuul;
 import com.google.errorprone.annotations.DoNotCall;
 import com.netflix.zuul.filters.FilterType;
 import com.netflix.zuul.filters.ZuulFilter;
+import com.netflix.zuul.message.ZuulMessage;
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -34,11 +42,17 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An immutable static collection of filters.
  */
 public final class StaticFilterLoader implements FilterLoader {
+
+    private static final Logger logger = LoggerFactory.getLogger(StaticFilterLoader.class);
+
+    public static final String RESOURCE_NAME = "META-INF/zuul/allfilters";
 
     private final Map<FilterType, ? extends SortedSet<ZuulFilter<?, ?>>> filtersByType;
     private final Map<FilterType, ? extends Map<String, ZuulFilter<?, ?>>> filtersByTypeAndName;
@@ -68,6 +82,45 @@ public final class StaticFilterLoader implements FilterLoader {
         }
         this.filtersByTypeAndName = Collections.unmodifiableMap(immutableFiltersByName);
         this.filtersByType = Collections.unmodifiableMap(filtersByType);
+    }
+
+    public static Set<Class<ZuulFilter<?, ?>>> loadFilterTypesFromResources(ClassLoader loader)
+            throws IOException {
+        Set<Class<ZuulFilter<?, ?>>> filterTypes = new LinkedHashSet<>();
+        for (URL url : Collections.list(loader.getResources(RESOURCE_NAME))) {
+            try (InputStream is = url.openStream();
+                    InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+                    BufferedReader br = new BufferedReader(isr)) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    String trimmed = line.trim();
+                    if (!trimmed.isEmpty()) {
+                        Class<?> clz;
+                        try {
+                            clz = Class.forName(trimmed, false, loader);
+                        } catch (ClassNotFoundException e) {
+                            // This can happen if a filter is deleted, but the annotation processor doesn't
+                            // remove it from the list.   This is mainly a problem with IntelliJ, which
+                            // forces append only annotation processors.  Incremental recompilation drops
+                            // most of the classpath, making the processor unable to reconstruct the filter
+                            // list.  To work around this problem, use the stale, cached filter list from
+                            // the initial full compilation and add to it.  This makes incremental
+                            // compilation work later, at the cost of polluting the filter list.  It's a
+                            // better experience to log a warning (and do a clean build), than to
+                            // mysteriously classes.
+
+                            logger.warn("Missing Filter", e);
+                            continue;
+                        }
+                        @SuppressWarnings("unchecked")
+                        Class<ZuulFilter<?, ?>> filterClz =
+                                (Class<ZuulFilter<?, ?>>) clz.asSubclass(ZuulFilter.class);
+                        filterTypes.add(filterClz);
+                    }
+                }
+            }
+        }
+        return Collections.unmodifiableSet(filterTypes);
     }
 
     @Override

--- a/zuul-processor/src/test/java/com/netflix/zuul/filters/processor/FilterProcessorTest.java
+++ b/zuul-processor/src/test/java/com/netflix/zuul/filters/processor/FilterProcessorTest.java
@@ -16,15 +16,12 @@
 
 package com.netflix.zuul.filters.processor;
 
-import static org.junit.Assert.assertEquals;
-
 import com.google.common.truth.Truth;
+import com.netflix.zuul.StaticFilterLoader;
 import com.netflix.zuul.filters.ZuulFilter;
-import com.netflix.zuul.filters.processor.override.MySubpackage;
 import com.netflix.zuul.filters.processor.override.SubpackageFilter;
 import com.netflix.zuul.filters.processor.subpackage.OverrideFilter;
-import com.netflix.zuul.filters.processor.subpackage.ProcessorSubpackageFilters;
-import java.util.List;
+import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -36,52 +33,16 @@ import org.junit.runners.JUnit4;
 public class FilterProcessorTest {
 
     @Test
-    public void allFilterClassedRecorded() {
-        List<? extends Class<? extends ZuulFilter<?, ?>>> filters = FiltersProcessorFilters.getFilters();
-        List<? extends Class<? extends ZuulFilter<?, ?>>> subpackage = ProcessorSubpackageFilters.getFilters();
-        List<? extends Class<? extends ZuulFilter<?, ?>>> override = MySubpackage.getFilters();
+    public void allFilterClassedRecorded() throws Exception {
+        Collection<Class<ZuulFilter<?, ?>>> filters =
+                StaticFilterLoader.loadFilterTypesFromResources(getClass().getClassLoader());
 
         Truth.assertThat(filters).containsExactly(
                 OuterClassFilter.class,
                 TopLevelFilter.class,
                 TopLevelFilter.StaticSubclassFilter.class,
-                TopLevelFilter.SubclassFilter.class);
-        Truth.assertThat(subpackage).containsExactly(OverrideFilter.class);
-        Truth.assertThat(override).containsExactly(SubpackageFilter.class);
-    }
-
-    @Test
-    public void deriveGeneratedClassName_emptyPackage() {
-        String className = FilterProcessor.deriveGeneratedClassName("");
-
-        assertEquals("Filters", className);
-    }
-
-    @Test
-    public void deriveGeneratedClassName_shortPackage() {
-        String className = FilterProcessor.deriveGeneratedClassName("somepackage");
-
-        assertEquals("SomepackageFilters", className);
-    }
-
-    @Test
-    public void deriveGeneratedClassName_twoPartPackage() {
-        String className = FilterProcessor.deriveGeneratedClassName("two.part");
-
-        assertEquals("TwoPartFilters", className);
-    }
-
-    @Test
-    public void deriveGeneratedClassName_threePartPackage() {
-        String className = FilterProcessor.deriveGeneratedClassName("packed.three.part");
-
-        assertEquals("ThreePartFilters", className);
-    }
-
-    @Test
-    public void deriveGeneratedClassName_underscorePackage() {
-        String className = FilterProcessor.deriveGeneratedClassName("packed.three_under.part");
-
-        assertEquals("ThreeUnderPartFilters", className);
+                TopLevelFilter.SubclassFilter.class,
+                OverrideFilter.class,
+                SubpackageFilter.class);
     }
 }


### PR DESCRIPTION
…va files.

While Gradle worked fine with the existing code, IntelliJ does not.  IntelliJ's
incremental compilation does not include the full classpath, making most of the
files in the Filter class not available.  The generated file thus changes frequently
and prevents running from the IDE.   JetBrains considers this a feature, and will
not change it.

Work around this by generating a list of classes, which is appended, rather than
created from scratch each compilation.  This allows incremental compilation in
IntelliJ to keep running at the cost of potentially having stale filters listed.