### PR TITLE
zuul-core: fix direct memory usage by passing non-null ref

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/DirectMemoryMonitor.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/DirectMemoryMonitor.java
@@ -99,14 +99,14 @@ public final class DirectMemoryMonitor {
                     .withName(PROP_PREFIX + ".reserved")
                     .withDelay(Duration.ofSeconds(TASK_DELAY_PROP.get()))
                     .scheduleOn(service)
-                    .monitorValue(null, DirectMemoryMonitor::getReservedMemory);
+                    .monitorValue(DirectMemoryMonitor.class, DirectMemoryMonitor::getReservedMemory);
         }
         if (directMemoryLimitGetter != null) {
             PolledMeter.using(registry)
                     .withName(PROP_PREFIX + ".max")
                     .withDelay(Duration.ofSeconds(TASK_DELAY_PROP.get()))
                     .scheduleOn(service)
-                    .monitorValue(null, DirectMemoryMonitor::getMaxMemory);
+                    .monitorValue(DirectMemoryMonitor.class, DirectMemoryMonitor::getMaxMemory);
         }
     }
 


### PR DESCRIPTION
Filed an issue upstream to avoid this problem in the future: https://github.com/Netflix/spectator/issues/819