### PR TITLE
zuul-core: make filterOrder, type, and sync derived from the annotations

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/Filter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/Filter.java
@@ -57,4 +57,18 @@ public @interface Filter {
     @interface FilterPackageName {
         String value();
     }
+
+    /**
+     * Indicates that the annotated filter should run after another filter in the chain, if the other filter is present.
+     * In the case of inbound filters, this implies that the annotated filter should have an order greater than the
+     * filters listed.  For outbound filters, the order of this filter should be less than the ones listed.  Usage of
+     * this annotation should be used on homogeneous filter types.  Additionally, this should not be applied to endpoint
+     * filters.
+     */
+    @Target({TYPE})
+    @Retention(RUNTIME)
+    @Documented
+    @interface ApplyAfter {
+        Class<? extends ZuulFilter<?, ?>>[] value();
+    }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.zuul.filters;
 
+import com.netflix.zuul.Filter;
 import com.netflix.zuul.exception.ZuulFilterConcurrencyExceededException;
 import com.netflix.zuul.message.ZuulMessage;
 import io.netty.handler.codec.http.HttpContent;
@@ -34,12 +35,18 @@ public interface ZuulFilter<I extends ZuulMessage, O extends ZuulMessage> extend
     String filterName();
 
     /**
-     * filterOrder() must also be defined for a filter. Filters may have the same  filterOrder if precedence is not
+     * filterOrder() must also be defined for a filter. Filters may have the same filterOrder if precedence is not
      * important for a filter. filterOrders do not need to be sequential.
      *
      * @return the int order of a filter
      */
-    int filterOrder();
+    default int filterOrder() {
+        Filter f = getClass().getAnnotation(Filter.class);
+        if (f != null) {
+            return f.order();
+        }
+        throw new UnsupportedOperationException("not implemented");
+    }
 
     /**
      * to classify a filter by type. Standard types in Zuul are "in" for pre-routing filtering,
@@ -47,7 +54,13 @@ public interface ZuulFilter<I extends ZuulMessage, O extends ZuulMessage> extend
      *
      * @return FilterType
      */
-    FilterType filterType();
+    default FilterType filterType() {
+        Filter f = getClass().getAnnotation(Filter.class);
+        if (f != null) {
+            return f.type();
+        }
+        throw new UnsupportedOperationException("not implemented");
+    }
 
     /**
      * Whether this filter's shouldFilter() method should be checked, and apply() called, even
@@ -75,7 +88,13 @@ public interface ZuulFilter<I extends ZuulMessage, O extends ZuulMessage> extend
      */
     void decrementConcurrency();
 
-    FilterSyncType getSyncType();
+    default FilterSyncType getSyncType() {
+        Filter f = getClass().getAnnotation(Filter.class);
+        if (f != null) {
+            return f.sync();
+        }
+        throw new UnsupportedOperationException("not implemented");
+    }
 
     /**
      * Choose a default message to use if the applyAsync() method throws an exception.

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/common/GZipResponseFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/common/GZipResponseFilter.java
@@ -37,9 +37,10 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.LastHttpContent;
 
 /**
- * General-purpose filter for gzipping/ungzipping response bodies if requested/needed.
+ * General-purpose filter for gzipping/ungzipping response bodies if requested/needed.  This should be run as late as
+ * possible to ensure final encoded body length is considered
  *
- * You can just subclass this in your project, and use as-is.
+ * <p>You can just subclass this in your project, and use as-is.
  *
  * @author Mike Smith
  */
@@ -58,14 +59,6 @@ public class GZipResponseFilter extends HttpOutboundSyncFilter
 
     private static final CachedDynamicBooleanProperty ENABLED =
             new CachedDynamicBooleanProperty("zuul.response.gzip.filter.enabled", true);
-
-    @Override
-    public int filterOrder() {
-
-        // run as late as possible to ensure the
-        // final encoded body length is considered
-        return 110;
-    }
 
     @Override
     public boolean shouldFilter(HttpResponseMessage response) {

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/passport/InboundPassportStampingFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/passport/InboundPassportStampingFilter.java
@@ -16,12 +16,11 @@
 
 package com.netflix.zuul.filters.passport;
 
+import static com.netflix.zuul.filters.FilterType.INBOUND;
+
 import com.netflix.zuul.Filter;
-import com.netflix.zuul.filters.FilterType;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.passport.PassportState;
-
-import static com.netflix.zuul.filters.FilterType.INBOUND;
 
 /**
  * Created by saroskar on 3/14/17.
@@ -32,10 +31,4 @@ public final class InboundPassportStampingFilter extends PassportStampingFilter<
     public InboundPassportStampingFilter(PassportState stamp) {
         super(stamp);
     }
-
-    @Override
-    public FilterType filterType() {
-        return INBOUND;
-    }
-
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/passport/OutboundPassportStampingFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/passport/OutboundPassportStampingFilter.java
@@ -32,10 +32,4 @@ public final class OutboundPassportStampingFilter extends PassportStampingFilter
     public OutboundPassportStampingFilter(PassportState stamp) {
         super(stamp);
     }
-
-    @Override
-    public FilterType filterType() {
-        return OUTBOUND;
-    }
-
 }


### PR DESCRIPTION
This allows users to just annotate their filters rather than extending.  That way, there isn't any stuttering when specifying the order and other params.

Several times, the filter order has comments explaining why it runs in it's place.  To fill this use, I added another annotation that indicates what are the dependencies of this filter.  Consuming filters list what they need (ApplyAfter)  rather than producer filters indicating what they provide (ApplyBefore).

In a later version, the ordering can be enforced as part of unit tests.   It is not the intent for these partial orderings be a replacement for the total ordering.