### PR TITLE
Add blacklist for allowing XFF headers

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  *      Licensed under the Apache License, Version 2.0 (the "License");
  *      you may not use this file except in compliance with the License.

--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandler.java
@@ -118,7 +118,7 @@ public class StripUntrustedProxyHeadersHandler extends ChannelInboundHandlerAdap
     @VisibleForTesting
     void checkBlacklist(HttpRequest req, List<String> blacklist) {
         // blacklist headers from
-        if (blacklist.contains(req.headers().get(HttpHeaderNames.HOST).toLowerCase())) {
+        if (blacklist.stream().anyMatch(h -> h.equalsIgnoreCase(req.headers().get(HttpHeaderNames.HOST)))) {
             stripXFFHeaders(req);
         }
     }

--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandler.java
@@ -16,19 +16,23 @@
 
 package com.netflix.netty.common.proxyprotocol;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
+import com.netflix.config.DynamicStringListProperty;
 import com.netflix.netty.common.ssl.SslHandshakeInfo;
 import com.netflix.zuul.netty.server.ssl.SslHandshakeInfoHandler;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.util.AsciiString;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Strip out any X-Forwarded-* headers from inbound http requests if connection is not trusted.
@@ -36,6 +40,9 @@ import java.util.Collection;
 @ChannelHandler.Sharable
 public class StripUntrustedProxyHeadersHandler extends ChannelInboundHandlerAdapter
 {
+    private static final DynamicStringListProperty XFF_BLACKLIST =
+            new DynamicStringListProperty("zuul.proxy.headers.host.blacklist", "");
+
     public enum AllowWhen {
         ALWAYS,
         MUTUAL_SSL_AUTH,
@@ -70,10 +77,12 @@ public class StripUntrustedProxyHeadersHandler extends ChannelInboundHandlerAdap
                 case MUTUAL_SSL_AUTH:
                     if (! connectionIsUsingMutualSSLWithAuthEnforced(ctx.channel())) {
                         stripXFFHeaders(req);
+                    } else {
+                        checkBlacklist(req, XFF_BLACKLIST.get());
                     }
                     break;
                 case ALWAYS:
-                    // Do nothing.
+                    checkBlacklist(req, XFF_BLACKLIST.get());
                     break;
                 default:
                     // default to not allow.
@@ -84,7 +93,8 @@ public class StripUntrustedProxyHeadersHandler extends ChannelInboundHandlerAdap
         super.channelRead(ctx, msg);
     }
 
-    private boolean connectionIsUsingMutualSSLWithAuthEnforced(Channel ch)
+    @VisibleForTesting
+    boolean connectionIsUsingMutualSSLWithAuthEnforced(Channel ch)
     {
         boolean is = false;
         SslHandshakeInfo sslHandshakeInfo = ch.attr(SslHandshakeInfoHandler.ATTR_SSL_INFO).get();
@@ -96,11 +106,20 @@ public class StripUntrustedProxyHeadersHandler extends ChannelInboundHandlerAdap
         return is;
     }
 
-    private void stripXFFHeaders(HttpRequest req)
+    @VisibleForTesting
+    void stripXFFHeaders(HttpRequest req)
     {
         HttpHeaders headers = req.headers();
         for (AsciiString headerName : HEADERS_TO_STRIP) {
             headers.remove(headerName);
+        }
+    }
+
+    @VisibleForTesting
+    void checkBlacklist(HttpRequest req, List<String> blacklist) {
+        // blacklist headers from
+        if (blacklist.contains(req.headers().get(HttpHeaderNames.HOST).toLowerCase())) {
+            stripXFFHeaders(req);
         }
     }
 }

--- a/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
@@ -1,0 +1,123 @@
+package com.netflix.netty.common.proxyprotocol;
+
+import static com.netflix.zuul.netty.server.ssl.SslHandshakeInfoHandler.ATTR_SSL_INFO;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import com.google.common.collect.ImmutableList;
+import com.netflix.netty.common.proxyprotocol.StripUntrustedProxyHeadersHandler.AllowWhen;
+import com.netflix.netty.common.ssl.SslHandshakeInfo;
+import com.netflix.zuul.netty.server.ssl.SslHandshakeInfoHandler;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.DefaultAttributeMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Strip Untrusted Proxy Headers Handler Test
+ *
+ * @author Arthur Gonigberg
+ * @since May 27, 2020
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class StripUntrustedProxyHeadersHandlerTest {
+
+    @Mock
+    private ChannelHandlerContext channelHandlerContext;
+    @Mock
+    private HttpRequest msg;
+    @Mock
+    private HttpHeaders headers;
+    @Mock
+    private Channel channel;
+    @Mock
+    private SslHandshakeInfo sslHandshakeInfo;
+
+
+    @Before
+    public void before() {
+        when(channelHandlerContext.channel()).thenReturn(channel);
+
+        DefaultAttributeMap attributeMap = new DefaultAttributeMap();
+        attributeMap.attr(ATTR_SSL_INFO).set(sslHandshakeInfo);
+        when(channel.attr(any())).thenAnswer(arg -> attributeMap.attr((AttributeKey) arg.getArguments()[0]));
+
+        when(msg.headers()).thenReturn(headers);
+        when(headers.get(eq(HttpHeaderNames.HOST))).thenReturn("netflix.com");
+    }
+
+    @Test
+    public void allow_never() throws Exception {
+        StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.NEVER);
+
+        stripHandler.channelRead(channelHandlerContext, msg);
+
+        verify(stripHandler).stripXFFHeaders(any());
+    }
+
+    @Test
+    public void allow_always() throws Exception {
+        StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.ALWAYS);
+
+        stripHandler.channelRead(channelHandlerContext, msg);
+
+        verify(stripHandler, never()).stripXFFHeaders(any());
+        verify(stripHandler).checkBlacklist(any(), any());
+    }
+
+    @Test
+    public void allow_mtls_noCert() throws Exception {
+        StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
+
+        stripHandler.channelRead(channelHandlerContext, msg);
+
+        verify(stripHandler).stripXFFHeaders(any());
+    }
+
+    @Test
+    public void allow_mtls_cert() throws Exception {
+        StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
+        when(sslHandshakeInfo.getClientAuthRequirement()).thenReturn(ClientAuth.REQUIRE);
+
+        stripHandler.channelRead(channelHandlerContext, msg);
+
+        verify(stripHandler, never()).stripXFFHeaders(any());
+        verify(stripHandler).checkBlacklist(any(), any());
+    }
+
+    @Test
+    public void blacklist_noMatch() throws Exception {
+        StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
+
+        stripHandler.checkBlacklist(msg, ImmutableList.of("netflix.net"));
+
+        verify(stripHandler, never()).stripXFFHeaders(any());
+    }
+
+    @Test
+    public void blacklist_match() throws Exception {
+        StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
+
+        stripHandler.checkBlacklist(msg, ImmutableList.of("netflix.com"));
+
+        verify(stripHandler).stripXFFHeaders(any());
+    }
+
+    private StripUntrustedProxyHeadersHandler getHandler(AllowWhen allowWhen) {
+        return spy(new StripUntrustedProxyHeadersHandler(allowWhen));
+    }
+
+}

--- a/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
 package com.netflix.netty.common.proxyprotocol;
 
 import static com.netflix.zuul.netty.server.ssl.SslHandshakeInfoHandler.ATTR_SSL_INFO;
@@ -10,14 +26,12 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.netflix.netty.common.proxyprotocol.StripUntrustedProxyHeadersHandler.AllowWhen;
 import com.netflix.netty.common.ssl.SslHandshakeInfo;
-import com.netflix.zuul.netty.server.ssl.SslHandshakeInfoHandler;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.ssl.ClientAuth;
-import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.DefaultAttributeMap;
 import org.junit.Before;

--- a/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
@@ -132,6 +132,15 @@ public class StripUntrustedProxyHeadersHandlerTest {
     }
 
     @Test
+    public void blacklist_match_casing() {
+        StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
+
+        stripHandler.checkBlacklist(msg, ImmutableList.of("NeTfLiX.cOm"));
+
+        verify(stripHandler).stripXFFHeaders(any());
+    }
+
+    @Test
     public void strip_match() {
         StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
 


### PR DESCRIPTION
A simple convenience property for disallowing XFF from certain hosts.