### PR TITLE
zuul-core: Default worker pool size to 2 * processor count

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/DefaultEventLoopConfig.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/DefaultEventLoopConfig.java
@@ -33,7 +33,7 @@ public class DefaultEventLoopConfig implements EventLoopConfig
 
     public DefaultEventLoopConfig()
     {
-        eventLoopCount = WORKER_THREADS.get() > 0 ? WORKER_THREADS.get() : PROCESSOR_COUNT;
+        eventLoopCount = WORKER_THREADS.get() > 0 ? WORKER_THREADS.get() : Math.max(8, PROCESSOR_COUNT*2);
         acceptorCount = ACCEPTOR_THREADS.get();
     }
 


### PR DESCRIPTION
In my past experience with Netty, at reasonable scale, a conservative but sane default has been to set the worker pool to 2x the virtual CPU.
This PR sets a ceiling of `8`(arguably, a magic number),  but more importantly, doubles the worker pool for anything running on lower than 4 cores.

We obviously need to run benchmarks on this, but I believe this is worth reconsidering.