### PR TITLE
Add counter to track HAPM decode failures when proxy protocol is enabled

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
@@ -235,7 +235,7 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
         pipeline.addLast("channelMetrics", channelMetrics);
         pipeline.addLast(perEventLoopConnectionMetricsHandler);
 
-        new ElbProxyProtocolChannelHandler(withProxyProtocol).addProxyProtocol(pipeline);
+        new ElbProxyProtocolChannelHandler(registry, withProxyProtocol).addProxyProtocol(pipeline);
 
         pipeline.addLast(maxConnectionsHandler);
     }


### PR DESCRIPTION
We could potentially be more specific here about tracking the states of the HAPM decoding. For now, this assumes that if we initialized requesting proxy protocol be enabled, but the messages were detected to be non HAPM, we should report those failures.