### PR TITLE
zuul-core:fix bug #802,Null pointer Exception in PassportLoggingHandler

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/DefaultEventLoopConfig.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/DefaultEventLoopConfig.java
@@ -35,12 +35,14 @@ public class DefaultEventLoopConfig implements EventLoopConfig
     {
         eventLoopCount = WORKER_THREADS.get() > 0 ? WORKER_THREADS.get() : PROCESSOR_COUNT;
         acceptorCount = ACCEPTOR_THREADS.get();
+        setArenasMatchingEventLoopCount();
     }
 
     public DefaultEventLoopConfig(int eventLoopCount, int acceptorCount)
     {
         this.eventLoopCount = eventLoopCount;
         this.acceptorCount = acceptorCount;
+        setArenasMatchingEventLoopCount();
     }
 
     @Override
@@ -53,5 +55,18 @@ public class DefaultEventLoopConfig implements EventLoopConfig
     public int acceptorCount()
     {
         return acceptorCount;
+    }
+
+    /**
+     * With an event loop per thread, not setting these mean the default values do not guarantee
+     * allocating an arena per worker thread. This might lead to higher contention.
+     */
+    private void setArenasMatchingEventLoopCount() {
+        if (System.getProperty("io.netty.allocator.numDirectArenas") == null) {
+            System.setProperty("io.netty.allocator.numDirectArenas", String.valueOf(eventLoopCount));
+        }
+        if (System.getProperty("io.netty.allocator.numHeapArenas") == null) {
+            System.setProperty("io.netty.allocator.numHeapArenas", String.valueOf(eventLoopCount));
+        }
     }
 }


### PR DESCRIPTION
In this issue # 802, PassportLoggingHandler throws a Null pointer Exception, because com.netflix.zuul.netty.server.ClientRequestReceiver.channelRead() at the time of decoding failure, Did not call com.netflix. Zuul. Stats. Status. StatusCategoryUtils. SetStatusCategory (ctx, statusCategory) method, lead to the context is empty, the com.netflix.zuul.net ty. Insights. PassportLoggingHandler. LogPassport (channel) printed in the log, Can't get the statusCategory in Conext, so Null pointer Exception is thrown.
stack trace:
Error logging passport info after request completed!
java.lang.NullPointerException
	at com.netflix.zuul.stats.status.StatusCategoryUtils.getStatusCategory(StatusCategoryUtils.java:39)
	at com.netflix.zuul.netty.insights.PassportLoggingHandler.logPassport(PassportLoggingHandler.java:98)
	at com.netflix.zuul.netty.insights.PassportLoggingHandler.userEventTriggered(PassportLoggingHandler.java:73)
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:329)
	at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:315)
	at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:307)
	at io.netty.channel.ChannelInboundHandlerAdapter.userEventTriggered(ChannelInboundHandlerAdapter.java:108)
 
The solution is to call com.netflix.zuul.stats.status.StatusCategoryUtils.setStatusCategory(ctx, statusCategory) to add the statusCategory of the context when decoding fails.Please review this pull request, thk