### PR TITLE
Sanitize header fields and values

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
@@ -503,7 +503,7 @@ public final class Headers {
     private String sanitizeField(String value) {
         if (value != null) {
             int l = value.length();
-            StringBuilder clean = new StringBuilder();
+            StringBuilder clean = new StringBuilder(l);
             for (int i = 0; i < l; i++) {
                 char c = value.charAt(i);
                 // ASCII non-control characters, per RFC 7230

--- a/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
@@ -464,7 +464,7 @@ public final class Headers {
     }
 
     private void originalName(int i, String originalName) {
-        originalNames.set(i, originalName);
+        originalNames.set(i, sanitizeField(originalName));
     }
 
     private String name(int i) {
@@ -472,7 +472,7 @@ public final class Headers {
     }
 
     private void name(int i, String name) {
-        names.set(i, name);
+        names.set(i, sanitizeField(name));
     }
 
     private String value(int i) {
@@ -480,13 +480,13 @@ public final class Headers {
     }
 
     private void value(int i, String val) {
-        values.set(i, val);
+        values.set(i, sanitizeField(val));
     }
 
     private void addNormal(String originalName, String normalName, String value) {
-        originalNames.add(originalName);
-        names.add(normalName);
-        values.add(value);
+        originalNames.add(sanitizeField(originalName));
+        names.add(sanitizeField(normalName));
+        values.add(sanitizeField(value));
     }
 
     /**
@@ -498,5 +498,21 @@ public final class Headers {
             names.remove(k);
             values.remove(k);
         }
+    }
+
+    private String sanitizeField(String value) {
+        if (value != null) {
+            int l = value.length();
+            StringBuilder clean = new StringBuilder();
+            for (int i = 0; i < l; i++) {
+                char c = value.charAt(i);
+                // ASCII non-control characters, per RFC 7230
+                if (c > 31 && c < 127) {
+                    clean.append(c);
+                }
+            }
+            return clean.toString();
+        }
+        return value;
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
@@ -18,6 +18,7 @@ package com.netflix.zuul.message;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.netflix.spectator.api.Spectator;
 import com.netflix.zuul.exception.ZuulException;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
@@ -506,8 +507,9 @@ public final class Headers {
             int l = value.length();
             for (int i = 0; i < l; i++) {
                 char c = value.charAt(i);
-                // ASCII non-control characters, per RFC 7230
+                // ASCII non-control characters, per RFC 7230 but slightly more lenient
                 if (c < 31 || c >= 127) {
+                    Spectator.globalRegistry().counter("zuul.header.invalid.char").increment();
                     throw new ZuulException("Invalid header field: char " + (int) c + " in string " + value
                             + " does not comply with RFC 7230", true);
                 }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
@@ -487,4 +487,44 @@ public class HeadersTest {
         assertTrue(values.contains("5"));
         assertEquals(2, values.size());
     }
+
+    @Test
+    public void testSanitizeValues_CRLF() {
+        Headers headers = new Headers();
+        headers.add("x-test-break1", "a\r\nb\r\nc");
+        headers.set("x-test-break2", "a\r\nb\r\nc");
+
+        assertEquals(headers.getFirst("x-test-break1"), "abc");
+        assertEquals(headers.getFirst("x-test-break2"), "abc");
+    }
+
+    @Test
+    public void testSanitizeValues_LF() {
+        Headers headers = new Headers();
+        headers.add("x-test-break1", "a\nb\nc");
+        headers.set("x-test-break2", "a\nb\nc");
+
+        assertEquals(headers.getFirst("x-test-break1"), "abc");
+        assertEquals(headers.getFirst("x-test-break2"), "abc");
+    }
+
+    @Test
+    public void testSanitizeValues_addSetHeaderName() {
+        Headers headers = new Headers();
+        headers.set(new HeaderName("x-test-break1"), "a\nb\nc");
+        headers.add(new HeaderName("x-test-break2"), "a\r\nb\r\nc");
+
+        assertEquals(headers.getFirst("x-test-break1"), "abc");
+        assertEquals(headers.getFirst("x-test-break2"), "abc");
+    }
+
+    @Test
+    public void testSanitizeValues_nameCRLF() {
+        Headers headers = new Headers();
+        headers.add("x-test-br\r\neak1", "a\r\nb\r\nc");
+        headers.set("x-test-br\r\neak2", "a\r\nb\r\nc");
+
+        assertEquals(headers.getFirst("x-test-break1"), "abc");
+        assertEquals(headers.getFirst("x-test-break2"), "abc");
+    }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.truth.Truth;
+import com.netflix.zuul.exception.ZuulException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -491,40 +492,32 @@ public class HeadersTest {
     @Test
     public void testSanitizeValues_CRLF() {
         Headers headers = new Headers();
-        headers.add("x-test-break1", "a\r\nb\r\nc");
-        headers.set("x-test-break2", "a\r\nb\r\nc");
 
-        assertEquals(headers.getFirst("x-test-break1"), "abc");
-        assertEquals(headers.getFirst("x-test-break2"), "abc");
+        assertThrows(ZuulException.class, () -> headers.add("x-test-break1", "a\r\nb\r\nc"));
+        assertThrows(ZuulException.class, () -> headers.set("x-test-break1", "a\r\nb\r\nc"));
     }
 
     @Test
     public void testSanitizeValues_LF() {
         Headers headers = new Headers();
-        headers.add("x-test-break1", "a\nb\nc");
-        headers.set("x-test-break2", "a\nb\nc");
 
-        assertEquals(headers.getFirst("x-test-break1"), "abc");
-        assertEquals(headers.getFirst("x-test-break2"), "abc");
+        assertThrows(ZuulException.class, () -> headers.add("x-test-break1", "a\nb\nc"));
+        assertThrows(ZuulException.class, () -> headers.set("x-test-break1", "a\nb\nc"));
     }
 
     @Test
     public void testSanitizeValues_addSetHeaderName() {
         Headers headers = new Headers();
-        headers.set(new HeaderName("x-test-break1"), "a\nb\nc");
-        headers.add(new HeaderName("x-test-break2"), "a\r\nb\r\nc");
 
-        assertEquals(headers.getFirst("x-test-break1"), "abc");
-        assertEquals(headers.getFirst("x-test-break2"), "abc");
+        assertThrows(ZuulException.class, () -> headers.set(new HeaderName("x-test-break1"), "a\nb\nc"));
+        assertThrows(ZuulException.class, () -> headers.add(new HeaderName("x-test-break2"), "a\r\nb\r\nc"));
     }
 
     @Test
     public void testSanitizeValues_nameCRLF() {
         Headers headers = new Headers();
-        headers.add("x-test-br\r\neak1", "a\r\nb\r\nc");
-        headers.set("x-test-br\r\neak2", "a\r\nb\r\nc");
 
-        assertEquals(headers.getFirst("x-test-break1"), "abc");
-        assertEquals(headers.getFirst("x-test-break2"), "abc");
+        assertThrows(ZuulException.class, () -> headers.add("x-test-br\r\neak1", "a\r\nb\r\nc"));
+        assertThrows(ZuulException.class, () -> headers.set("x-test-br\r\neak2", "a\r\nb\r\nc"));
     }
 }


### PR DESCRIPTION
This will prevent headers set in filters/handlers from inadvertently being invalid or broken.