### PR TITLE
Return SYNC for getSyncType() in HttpSyncEndpoint

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/http/HttpSyncEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/http/HttpSyncEndpoint.java
@@ -17,8 +17,8 @@
 package com.netflix.zuul.filters.http;
 
 import com.netflix.config.CachedDynamicBooleanProperty;
-import com.netflix.zuul.exception.ZuulFilterConcurrencyExceededException;
 import com.netflix.zuul.filters.Endpoint;
+import com.netflix.zuul.filters.FilterSyncType;
 import com.netflix.zuul.filters.SyncZuulFilter;
 import com.netflix.zuul.message.ZuulMessage;
 import com.netflix.zuul.message.http.HttpRequestMessage;
@@ -62,6 +62,11 @@ public abstract class HttpSyncEndpoint extends Endpoint<HttpRequestMessage, Http
         else {
             return Observable.just(this.apply(input));
         }
+    }
+
+    @Override
+    public FilterSyncType getSyncType() {
+        return FilterSyncType.SYNC;
     }
 
     @Override


### PR DESCRIPTION
I wrote a `HttpSyncEndpoint` subclass that overrides `needsBodyBuffered()` to return `true`.  After running the filter, I get an NPE thrown in Zuul's internals, and the endpoint returns 500.  The NPE stack trace is:

```
java.lang.NullPointerException: null
	at com.netflix.zuul.netty.filter.BaseZuulFilterRunner.addPerfMarkTags(BaseZuulFilterRunner.java:176)
	at com.netflix.zuul.netty.filter.BaseZuulFilterRunner.invokeNextStage(BaseZuulFilterRunner.java:146)
	at com.netflix.zuul.netty.filter.ZuulEndPointRunner.filter(ZuulEndPointRunner.java:150)
	at com.netflix.zuul.netty.filter.ZuulEndPointRunner.filter(ZuulEndPointRunner.java:50)
	at com.netflix.zuul.netty.filter.BaseZuulFilterRunner.invokeNextStage(BaseZuulFilterRunner.java:126)
	at com.netflix.zuul.netty.filter.ZuulFilterChainRunner.filter(ZuulFilterChainRunner.java:129)
	at com.netflix.zuul.netty.filter.ZuulFilterChainHandler.channelRead(ZuulFilterChainHandler.java:84)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at com.netflix.zuul.netty.server.ClientRequestReceiver.channelRead(ClientRequestReceiver.java:149)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:227)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at com.netflix.netty.common.proxyprotocol.StripUntrustedProxyHeadersHandler.channelRead(StripUntrustedProxyHeadersHandler.java:84)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at com.netflix.netty.common.accesslog.AccessLogChannelHandler.channelRead(AccessLogChannelHandler.java:71)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at com.netflix.netty.common.metrics.HttpBodySizeRecordingChannelHandler.channelRead(HttpBodySizeRecordingChannelHandler.java:85)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at com.netflix.netty.common.HttpServerLifecycleChannelHandler.channelRead(HttpServerLifecycleChannelHandler.java:47)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at com.netflix.netty.common.HttpRequestReadTimeoutHandler.channelRead(HttpRequestReadTimeoutHandler.java:81)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at com.netflix.zuul.netty.insights.PassportStateHttpServerHandler.channelRead(PassportStateHttpServerHandler.java:70)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.CombinedChannelDuplexHandler.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:321)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:295)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at com.netflix.netty.common.throttle.MaxInboundConnectionsHandler.channelRead(MaxInboundConnectionsHandler.java:80)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
	at com.netflix.netty.common.proxyprotocol.ElbProxyProtocolChannelHandler.channelRead(ElbProxyProtocolChannelHandler.java:155)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:377)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.epoll.AbstractEpollStreamChannel.epollInReady(AbstractEpollStreamChannel.java:792)
	at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:475)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378)
	at io.netty.util.concurrent.SingleThreadEventExecutor.run(SingleThreadEventExecutor.java:989)
	at io.netty.util.internal.ThreadExecutorMap.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:830)
```

After doing a bit of digging, I found that the filter runner was calling `getSyncType()` on my filter, which was returning `ASYNC`, so it was reaching the bottom of `BaseZuulFilterRunner.filter(ZuulFilter, ZuulMessage)` which returns `null`.  Unfortunately, the caller was `ZuulEndpointRunner.filter(HttpRequestMessage, HttpContent)`, which was calling `invokeNextStage(filter(endpoint, zuulReq))`.  `invokeNextStage()` is not set up to handle `null` as its argument.  It calls `addPerfMarkTags()` with that argument, which attempts to call `.getContext()` on it, which throws an NPE.

Having my filter report that it's a sync filter fixes the issue for me, though I'm not sure if this is the right approach for all `HttpSyncFilter`s or not.