### PR TITLE
restrict header validation to control characters

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
@@ -554,7 +554,7 @@ public final class Headers {
             for (int i = 0; i < l; i++) {
                 char c = value.charAt(i);
                 // ASCII non-control characters, per RFC 7230 but slightly more lenient
-                if (c < 31 || c >= 127) {
+                if (c < 31 || c == 127) {
                     Spectator.globalRegistry().counter("zuul.header.invalid.char").increment();
                     throw new ZuulException("Invalid header field: char " + (int) c + " in string " + value
                             + " does not comply with RFC 7230");


### PR DESCRIPTION
Change to relax the Header validation to restrict only the control characters (0-30 and 127).
The other ASCII printable and non-ASCII characters are treated as opaque characters in line with https://tools.ietf.org/html/rfc7230#section-3.2.4 last paragraph.