### PR TITLE
Respect Proxy Protocol value of original client IP address

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
@@ -43,6 +43,7 @@ public class CommonContextKeys {
     public static final String USE_FULL_VIP_NAME = "use_full_vip_name";
     public static final String ACTUAL_VIP = "origin_vip_actual";
     public static final String ORIGIN_VIP_SECURE = "origin_vip_secure";
+    public static final String REMOTE_PORT = "remote_port";
 
     public static final String SSL_HANDSHAKE_INFO = "ssl_handshake_info";
 

--- a/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
@@ -43,7 +43,12 @@ public class CommonContextKeys {
     public static final String USE_FULL_VIP_NAME = "use_full_vip_name";
     public static final String ACTUAL_VIP = "origin_vip_actual";
     public static final String ORIGIN_VIP_SECURE = "origin_vip_secure";
-    public static final String REMOTE_PORT = "remote_port";
+
+    /**
+     * The original client port reported to Zuul by a proxy running Proxy Protocol.
+     * Will only be set if both Zuul and the connected proxy are both using set to use Proxy Protocol.
+     */
+    public static final String PROXY_PROTOCOL_PORT = "proxy_protocol";
 
     public static final String SSL_HANDSHAKE_INFO = "ssl_handshake_info";
 

--- a/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
@@ -48,7 +48,7 @@ public class CommonContextKeys {
      * The original client port reported to Zuul by a proxy running Proxy Protocol.
      * Will only be set if both Zuul and the connected proxy are both using set to use Proxy Protocol.
      */
-    public static final String PROXY_PROTOCOL_PORT = "proxy_protocol";
+    public static final String PROXY_PROTOCOL_PORT = "proxy_protocol_port";
 
     public static final String SSL_HANDSHAKE_INFO = "ssl_handshake_info";
 

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
@@ -522,14 +522,17 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
     @Override
     public int getOriginalPort() {
         try {
-            return getOriginalPort(getHeaders(), getPort());
+            return getOriginalPort(getContext(), getHeaders(), getPort());
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
     }
 
     @VisibleForTesting
-    static int getOriginalPort(Headers headers, int serverPort) throws URISyntaxException {
+    static int getOriginalPort(SessionContext context, Headers headers, int serverPort) throws URISyntaxException {
+        if (context.containsKey(CommonContextKeys.REMOTE_PORT)) {
+            return (int) context.get(CommonContextKeys.REMOTE_PORT);
+        }
         String portStr = headers.getFirst(HttpHeaderNames.X_FORWARDED_PORT);
         if (portStr != null) {
             return Integer.parseInt(portStr);

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
@@ -530,8 +530,8 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
 
     @VisibleForTesting
     static int getOriginalPort(SessionContext context, Headers headers, int serverPort) throws URISyntaxException {
-        if (context.containsKey(CommonContextKeys.REMOTE_PORT)) {
-            return (int) context.get(CommonContextKeys.REMOTE_PORT);
+        if (context.containsKey(CommonContextKeys.PROXY_PROTOCOL_PORT)) {
+            return (int) context.get(CommonContextKeys.PROXY_PROTOCOL_PORT);
         }
         String portStr = headers.getFirst(HttpHeaderNames.X_FORWARDED_PORT);
         if (portStr != null) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -62,6 +62,8 @@ import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
+
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;
@@ -267,6 +269,10 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
 
         // This is the only way I found to get the port of the request with netty...
         final int port = channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).get();
+        final SocketAddress remoteAddress = channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get();
+        if (remoteAddress instanceof InetSocketAddress) {
+            context.set(CommonContextKeys.REMOTE_PORT, ((InetSocketAddress) remoteAddress).getPort());
+        }
         final String serverName = channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_ADDRESS).get();
         final SocketAddress clientDestinationAddress = channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get();
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -22,6 +22,7 @@ import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReaso
 import static com.netflix.zuul.netty.server.http2.Http2OrHttpHandler.PROTOCOL_NAME;
 
 import com.netflix.netty.common.SourceAddressChannelHandler;
+import com.netflix.netty.common.proxyprotocol.HAProxyMessageChannelHandler;
 import com.netflix.netty.common.ssl.SslHandshakeInfo;
 import com.netflix.netty.common.throttle.RejectionUtils;
 import com.netflix.zuul.context.CommonContextKeys;
@@ -63,7 +64,6 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;
@@ -269,9 +269,9 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
 
         // This is the only way I found to get the port of the request with netty...
         final int port = channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).get();
-        final SocketAddress remoteAddress = channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get();
-        if (remoteAddress instanceof InetSocketAddress) {
-            context.set(CommonContextKeys.REMOTE_PORT, ((InetSocketAddress) remoteAddress).getPort());
+        final HAProxyMessage haProxyMessage = channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE).get();
+        if (haProxyMessage != null) {
+            context.set(CommonContextKeys.PROXY_PROTOCOL_PORT, haProxyMessage.sourcePort());
         }
         final String serverName = channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_ADDRESS).get();
         final SocketAddress clientDestinationAddress = channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get();

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
@@ -341,7 +341,7 @@ public class HttpRequestMessageImplTest {
     @Test
     public void getOriginalPort_respectsProxyProtocol() throws URISyntaxException {
         SessionContext context = new SessionContext();
-        context.set(CommonContextKeys.REMOTE_PORT, 443);
+        context.set(CommonContextKeys.PROXY_PROTOCOL_PORT, 443);
         Headers headers = new Headers();
         headers.add("X-Forwarded-Port", "6000");
         assertEquals(443, HttpRequestMessageImpl.getOriginalPort(context, headers, 9999));

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.netflix.zuul.context.CommonContextKeys;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.Headers;
 import io.netty.channel.local.LocalAddress;
@@ -334,7 +335,16 @@ public class HttpRequestMessageImplTest {
         Headers headers = new Headers();
         headers.add("Host", "ba::33");
 
-        assertEquals(9999, HttpRequestMessageImpl.getOriginalPort(headers, 9999));
+        assertEquals(9999, HttpRequestMessageImpl.getOriginalPort(new SessionContext(), headers, 9999));
+    }
+
+    @Test
+    public void getOriginalPort_respectsProxyProtocol() throws URISyntaxException {
+        SessionContext context = new SessionContext();
+        context.set(CommonContextKeys.REMOTE_PORT, 443);
+        Headers headers = new Headers();
+        headers.add("X-Forwarded-Port", "6000");
+        assertEquals(443, HttpRequestMessageImpl.getOriginalPort(context, headers, 9999));
     }
 
     @Test


### PR DESCRIPTION
Use proxy protocol port for Zuul `HttpRequestMessage.getOriginalPort()` if available