### PR TITLE
Remove erroneous @Nullable annotations

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java
@@ -25,7 +25,6 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.ProtocolDetectionState;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
-import javax.annotation.Nullable;
 
 /**
  * Decides if we need to decode a HAProxyMessage. If so, adds the decoder followed by the handler.
@@ -38,7 +37,7 @@ public final class ElbProxyProtocolChannelHandler extends ChannelInboundHandlerA
     private final Registry spectatorRegistry;
     private final Counter hapmDecodeFailure;
 
-    public ElbProxyProtocolChannelHandler(@Nullable Registry registry, boolean withProxyProtocol) {
+    public ElbProxyProtocolChannelHandler(Registry registry, boolean withProxyProtocol) {
         this.withProxyProtocol = withProxyProtocol;
         this.spectatorRegistry = checkNotNull(registry);
         this.hapmDecodeFailure = spectatorRegistry.counter("zuul.hapm.failure");

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ssl/SslHandshakeInfoHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ssl/SslHandshakeInfoHandler.java
@@ -33,7 +33,6 @@ import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.util.AttributeKey;
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.netty.common.ssl.SslHandshakeInfo;
-import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +57,7 @@ public class SslHandshakeInfoHandler extends ChannelInboundHandlerAdapter
     private final Registry spectatorRegistry;
     private final boolean isSSlFromIntermediary;
 
-    public SslHandshakeInfoHandler(@Nullable Registry spectatorRegistry, boolean isSSlFromIntermediary)
+    public SslHandshakeInfoHandler(Registry spectatorRegistry, boolean isSSlFromIntermediary)
     {
         this.spectatorRegistry = checkNotNull(spectatorRegistry);
         this.isSSlFromIntermediary = isSSlFromIntermediary;


### PR DESCRIPTION
These `@Nullable` annotations are erroneous, as they are followed by `checkNotNull` which generates an exception if they're null.