### PR TITLE
Fix x-forwarded-port

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -271,7 +271,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
         final int port = channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).get();
         final HAProxyMessage haProxyMessage = channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE).get();
         if (haProxyMessage != null) {
-            context.set(CommonContextKeys.PROXY_PROTOCOL_PORT, haProxyMessage.sourcePort());
+            context.set(CommonContextKeys.PROXY_PROTOCOL_PORT, haProxyMessage.destinationPort());
         }
         final String serverName = channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_ADDRESS).get();
         final SocketAddress clientDestinationAddress = channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get();

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
@@ -51,7 +51,7 @@ public class ClientRequestReceiverTest {
                 HAProxyProtocolVersion.V2,
                 HAProxyCommand.PROXY,
                 HAProxyProxiedProtocol.TCP4,
-                "1.1.1.1", "2.2.2.2", 444, 9000);
+                "1.1.1.1", "2.2.2.2", 9000, 444);
         ClientRequestReceiver receiver = new ClientRequestReceiver(null);
         EmbeddedChannel channel = new EmbeddedChannel(receiver);
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);


### PR DESCRIPTION
Fix bug from previous PR where x-forwarded-for was using PPv2 source address instead of destination