### PR TITLE
zuul-core: add a conneciton timer class

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/Attrs.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/Attrs.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * A heterogeneous map of attributes.
+ */
+public final class Attrs {
+
+    final Map<Key<?>, Object> storage = new IdentityHashMap<>();
+
+    public static <T> Key<T> newKey(String keyName) {
+        return new Key<>(keyName);
+    }
+
+    public static final class Key<T> {
+
+        private final String name;
+
+        /**
+         * Returns the value in the attributes, or {@code null} if absent.
+         */
+        @Nullable
+        @SuppressWarnings("unchecked")
+        public T get(Attrs attrs) {
+            Objects.requireNonNull(attrs, "attrs");
+            return (T) attrs.storage.get(this);
+        }
+
+        /**
+         * Returns the value in the attributes or {@code defaultValue} if absent.
+         * @throws NullPointerException if defaultValue is null.
+         */
+        @SuppressWarnings("unchecked")
+        public T getOrDefault(Attrs attrs, T defaultValue) {
+            Objects.requireNonNull(attrs, "attrs");
+            Objects.requireNonNull(defaultValue, "defaultValue");
+            T result = (T) attrs.storage.get(this);
+            if (result != null) {
+                return result;
+            }
+            return defaultValue;
+        }
+
+        public void put(Attrs attrs, T value) {
+            Objects.requireNonNull(attrs, "attrs");
+            Objects.requireNonNull(value);
+            attrs.storage.put(this, value);
+        }
+
+        public String name() {
+            return name;
+        }
+
+        private Key(String name) {
+            this.name = Objects.requireNonNull(name);
+        }
+
+        @Override
+        public String toString() {
+            return "Key{" + name + '}';
+        }
+    }
+
+    private Attrs() {}
+
+    public static Attrs newInstance() {
+        return new Attrs();
+    }
+
+    public Set<Key<?>> keySet() {
+        return Collections.unmodifiableSet(new LinkedHashSet<>(storage.keySet()));
+    }
+
+    @Override
+    public String toString() {
+        return "Attrs{" + storage + '}';
+    }
+
+    @Override
+    @VisibleForTesting
+    public boolean equals(Object other) {
+        if (!(other instanceof Attrs)) {
+            return false;
+        }
+        Attrs that = (Attrs) other;
+        return Objects.equals(this.storage, that.storage);
+    }
+
+    @Override
+    @VisibleForTesting
+    public int hashCode() {
+        return Objects.hash(storage);
+    }
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnTimer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnTimer.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.monitoring;
+
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.histogram.PercentileTimer;
+import com.netflix.zuul.Attrs;
+import com.netflix.zuul.Attrs.Key;
+import com.netflix.zuul.netty.server.Server;
+import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A timer for connection stats.  Not thread-safe.
+ */
+public final class ConnTimer {
+
+    private static final AttributeKey<ConnTimer> CONN_TIMER = AttributeKey.newInstance("zuul.conntimer");
+
+    private static final Duration MIN_CONN_TIMING = Duration.ofNanos(512);
+    private static final Duration MAX_CONN_TIMING = Duration.ofDays(366);
+
+    private final Registry registry;
+    private final Channel chan;
+    // TODO(carl-mastrangelo): make this changable.
+    private final Id metricBase;
+
+    private final Map<String, Long> timings = new LinkedHashMap<>();
+
+    private ConnTimer(Registry registry, Channel chan, Id metricBase) {
+        this.registry = Objects.requireNonNull(registry);
+        this.chan = Objects.requireNonNull(chan);
+        this.metricBase = Objects.requireNonNull(metricBase);
+    }
+
+    public static ConnTimer install(Channel chan, Registry registry, Id metricBase) {
+        ConnTimer timer = new ConnTimer(registry, chan, metricBase);
+        if (!chan.attr(CONN_TIMER).compareAndSet(null, timer)) {
+            throw new IllegalStateException("pre-existing timer already present");
+        }
+        return timer;
+    }
+
+    public static ConnTimer from(Channel chan) {
+        Objects.requireNonNull(chan);
+        ConnTimer timer = chan.attr(CONN_TIMER).get();
+        if (timer != null) {
+            return timer;
+        }
+        if (chan.parent() != null && (timer = chan.parent().attr(CONN_TIMER).get()) != null) {
+            return timer;
+        }
+        throw new IllegalStateException("no timer on channel");
+    }
+
+    public void record(Long now, String event) {
+        if (timings.containsKey(event)) {
+            return;
+        }
+        Attrs dims = chan.attr(Server.CONN_DIMENSIONS).get();
+        Set<Key<?>> dimKeys = dims.keySet();
+        Map<String, String> dimTags = new HashMap<>(dimKeys.size());
+        for (Key<?> key : dims.keySet()) {
+            dimTags.put(key.name(), String.valueOf(key.get(dims)));
+        }
+
+        // Note: this is effectively O(n^2) because it will be called for each event in the connection
+        // setup.  It should be bounded to at most 10 or so.
+        timings.forEach((k, v) -> {
+            long durationNanos = now - v;
+            if (durationNanos == 0) {
+                // This may happen if an event is double listed, or if the timer is not accurate enough to record
+                // it.
+                return;
+            }
+            PercentileTimer.builder(registry)
+                    .withId(metricBase.withTags(dimTags).withTags("from", k, "to", event))
+                    .withRange(MIN_CONN_TIMING, MAX_CONN_TIMING)
+                    .build()
+                    .record(durationNanos, TimeUnit.NANOSECONDS);
+        });
+        timings.put(event, now);
+    }
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
@@ -109,6 +109,7 @@ public abstract class BaseServerStartup
         addrsToChannelInitializers = chooseAddrsAndChannels(clientChannels);
 
         server = new Server(
+                registry,
                 serverStatusManager,
                 addrsToChannelInitializers,
                 clientConnectionsShutdown,

--- a/zuul-core/src/test/java/com/netflix/zuul/AttrsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/AttrsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.truth.Truth;
+import com.netflix.zuul.Attrs.Key;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AttrsTest {
+    @Test
+    public void keysAreUnique() {
+        Attrs attrs = Attrs.newInstance();
+        Key<String> key1 = Attrs.newKey("foo");
+        key1.put(attrs, "bar");
+        Key<String> key2 = Attrs.newKey("foo");
+        key2.put(attrs, "baz");
+
+        Truth.assertThat(attrs.keySet()).containsExactly(key1, key2);
+    }
+
+    @Test
+    public void newKeyFailsOnNull() {
+        assertThrows(NullPointerException.class, () -> Attrs.newKey(null));
+    }
+
+    @Test
+    public void attrsPutFailsOnNull() {
+        Attrs attrs = Attrs.newInstance();
+        Key<String> key = Attrs.newKey("foo");
+
+        assertThrows(NullPointerException.class, () -> key.put(attrs, null));
+    }
+
+    @Test
+    public void attrsPutReplacesOld() {
+        Attrs attrs = Attrs.newInstance();
+        Key<String> key = Attrs.newKey("foo");
+        key.put(attrs, "bar");
+        key.put(attrs, "baz");
+
+        assertEquals("baz", key.get(attrs));
+        Truth.assertThat(attrs.keySet()).containsExactly(key);
+    }
+
+    @Test
+    public void getReturnsNull() {
+        Attrs attrs = Attrs.newInstance();
+        Key<String> key = Attrs.newKey("foo");
+
+        assertNull(key.get(attrs));
+    }
+
+    @Test
+    public void getOrDefault_picksDefault() {
+        Attrs attrs = Attrs.newInstance();
+        Key<String> key = Attrs.newKey("foo");
+
+        assertEquals("bar", key.getOrDefault(attrs, "bar"));
+    }
+
+    @Test
+    public void getOrDefault_failsOnNullDefault() {
+        Attrs attrs = Attrs.newInstance();
+        Key<String> key = Attrs.newKey("foo");
+        key.put(attrs, "bar");
+
+        assertThrows(NullPointerException.class, () -> key.getOrDefault(attrs, null));
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnTimerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnTimerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.monitoring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.histogram.PercentileTimer;
+import com.netflix.zuul.Attrs;
+import com.netflix.zuul.netty.server.Server;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ConnTimerTest {
+    @Test
+    public void record() {
+        EmbeddedChannel chan = new EmbeddedChannel();
+        Attrs attrs = Attrs.newInstance();
+        chan.attr(Server.CONN_DIMENSIONS).set(attrs);
+        Registry registry = new DefaultRegistry();
+        ConnTimer timer = ConnTimer.install(chan, registry, registry.createId("foo"));
+
+        timer.record(1000L, "start");
+        timer.record(2000L, "middle");
+        Attrs.newKey("bar").put(attrs, "baz");
+        timer.record(4000L, "end");
+
+        PercentileTimer meter1 =
+                PercentileTimer.get(registry, registry.createId("foo", "from", "start", "to", "middle"));
+        assertNotNull(meter1);
+        assertEquals(1000L, meter1.totalTime());
+
+        PercentileTimer meter2 =
+                PercentileTimer.get(registry, registry.createId("foo", "from", "middle", "to", "end", "bar", "baz"));
+        assertNotNull(meter2);
+        assertEquals(2000L, meter2.totalTime());
+
+        PercentileTimer meter3 =
+                PercentileTimer.get(registry, registry.createId("foo", "from", "start", "to", "end", "bar", "baz"));
+        assertNotNull(meter3);
+        assertEquals(3000L, meter3.totalTime());
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ServerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ServerTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import com.netflix.netty.common.metrics.EventLoopGroupMetrics;
 import com.netflix.netty.common.status.ServerStatusManager;
+import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Spectator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
@@ -73,7 +74,7 @@ public class ServerTest {
                 return 1;
             }
         };
-        Server s = new Server(ssm, initializers, ccs, elgm, elc);
+        Server s = new Server(new NoopRegistry(), ssm, initializers, ccs, elgm, elc);
         s.start(/* sync= */ false);
 
         List<SocketAddress> addrs = s.getListeningAddresses();


### PR DESCRIPTION
I picked to make a new Attrs class because the channel one doesn't really allow grouping.   It also forces thread safety when we dont need it, and makes keys identical based on name.   These have proved problematic in the past, so I made a new one.

The idea of the conn timer is to store it on the channel itself, along with the set of dimensions to break down stats by.  The attrs map is dynamic, and allows updating it as new metrics come in.   I plan on using these dimensions for other connection stats in the future.