### PR TITLE
Fix NPE when zuulRequest is null

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -189,7 +189,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
                 }
             }
 
-            if (reason == CompleteReason.INACTIVE) {
+            if (reason == CompleteReason.INACTIVE && zuulRequest != null) {
                 // Client closed connection prematurely.
                 StatusCategoryUtils.setStatusCategory(zuulRequest.getContext(), ZuulStatusCategory.FAILURE_CLIENT_CANCELLED);
             }


### PR DESCRIPTION
Fixes an NPE for edge cases where a client closes the connection and Zuul hasn't built a request. 