### PR TITLE
fix PPv2 for H2

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2StreamInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2StreamInitializer.java
@@ -98,6 +98,7 @@ public class Http2StreamInitializer extends ChannelInboundHandlerAdapter
                 SourceAddressChannelHandler.ATTR_SOURCE_PORT,
                 SourceAddressChannelHandler.ATTR_SERVER_LOCAL_ADDRESS,
                 SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT,
+                SourceAddressChannelHandler.ATTR_PROXY_PROTOCOL_DESTINATION_ADDRESS,
 
                 PROTOCOL_NAME,
                 SslHandshakeInfoHandler.ATTR_SSL_INFO,


### PR DESCRIPTION
Copy `SourceAddressChannelHandler.ATTR_PROXY_PROTOCOL_DESTINATION_ADDRESS` to H2 child channel. Fixes PPv2 for H2.