### PR TITLE
Modify the type of the Chosen Host address to be an InetAddress.

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ClientChannelManager.java
@@ -22,6 +22,7 @@ import com.netflix.zuul.passport.CurrentPassport;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Promise;
 
+import java.net.InetAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -48,7 +49,7 @@ public interface ClientChannelManager
             Object key,
             CurrentPassport passport,
             AtomicReference<Server> selectedServer,
-            AtomicReference<String> selectedHostAddr);
+            AtomicReference<? super InetAddress> selectedHostAddr);
 
     boolean isCold();
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
@@ -326,7 +326,7 @@ public class DefaultClientChannelManager implements ClientChannelManager {
             @Nullable Object key,
             CurrentPassport passport,
             AtomicReference<Server> selectedServer,
-            AtomicReference<String> selectedHostAddr) {
+            AtomicReference<? super InetAddress> selectedHostAddr) {
 
         if (shuttingDown) {
             Promise<PooledConnection> promise = eventLoop.newPromise();

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/IConnectionPool.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/IConnectionPool.java
@@ -20,6 +20,7 @@ import com.netflix.zuul.passport.CurrentPassport;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Promise;
 
+import java.net.InetAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -30,7 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public interface IConnectionPool
 {
     Promise<PooledConnection> acquire(
-            EventLoop eventLoop, CurrentPassport passport, AtomicReference<String> selectedHostAddr);
+            EventLoop eventLoop, CurrentPassport passport, AtomicReference<? super InetAddress> selectedHostAddr);
     boolean release(PooledConnection conn);
     boolean remove(PooledConnection conn);
     void shutdown();

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOrigin.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOrigin.java
@@ -48,6 +48,7 @@ import com.netflix.zuul.stats.status.StatusCategory;
 import com.netflix.zuul.stats.status.StatusCategoryUtils;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Promise;
+import java.net.InetAddress;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -118,7 +119,7 @@ public class BasicNettyOrigin implements NettyOrigin {
     @Override
     public Promise<PooledConnection> connectToOrigin(
             HttpRequestMessage zuulReq, EventLoop eventLoop, int attemptNumber, CurrentPassport passport,
-            AtomicReference<Server> chosenServer, AtomicReference<String> chosenHostAddr) {
+            AtomicReference<Server> chosenServer, AtomicReference<? super InetAddress> chosenHostAddr) {
         return clientChannelManager.acquire(eventLoop, null, passport, chosenServer, chosenHostAddr);
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/NettyOrigin.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/NettyOrigin.java
@@ -30,6 +30,7 @@ import com.netflix.zuul.stats.Timing;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Promise;
 
+import java.net.InetAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -43,7 +44,7 @@ public interface NettyOrigin extends InstrumentedOrigin {
     Promise<PooledConnection> connectToOrigin(final HttpRequestMessage zuulReq, EventLoop eventLoop,
                                               int attemptNumber, CurrentPassport passport,
                                               AtomicReference<Server> chosenServer,
-                                              AtomicReference<String> chosenHostAddr);
+                                              AtomicReference<? super InetAddress> chosenHostAddr);
 
     Timing getProxyTiming(HttpRequestMessage zuulReq);
 


### PR DESCRIPTION
This will allow clearer understanding of what this type can be used as in other parts of the Zuul Code base.   The long term vision is to modify this to not be an InetAddress, but a `ExtendedSocketAddress` which includes the other metaa information about the addr.    The change as is is more to make sure the type is consitent with the current semantics, rather than changing the semantics.

`ZUUL_ORIGIN_ATTEMPT_IPADDR_MAP_KEY` will eventually be deleted, as it only seems to be used for event context logging.    That too will occur in a followup change.