### PR TITLE
Downgrade ribbon to fix proxying

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 versions_groovy=3.0.3
-versions_ribbon=2.7.17
+versions_ribbon=2.4.4
 versions_netty=4.1.52.Final
 release.scope=patch
 release.version=2.1.9-SNAPSHOT

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -19,19 +19,19 @@
             "locked": "0.3.0"
         },
         "com.netflix.ribbon:ribbon-archaius": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.110.0"
@@ -81,10 +81,10 @@
     },
     "jmh": {
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.25.1"
+            "locked": "1.25.2"
         },
         "org.openjdk.jmh:jmh-generator-annprocess": {
-            "locked": "1.25.1"
+            "locked": "1.25.2"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
             "locked": "1.21"
@@ -110,19 +110,19 @@
             "locked": "0.3.0"
         },
         "com.netflix.ribbon:ribbon-archaius": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.110.0"
@@ -167,10 +167,10 @@
             "locked": "1.66"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.25.1"
+            "locked": "1.25.2"
         },
         "org.openjdk.jmh:jmh-generator-annprocess": {
-            "locked": "1.25.1"
+            "locked": "1.25.2"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
             "locked": "1.21"
@@ -202,19 +202,19 @@
             "locked": "0.3.0"
         },
         "com.netflix.ribbon:ribbon-archaius": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.110.0"
@@ -265,13 +265,13 @@
             "locked": "1.66"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.5.10"
+            "locked": "3.5.13"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.25.1"
+            "locked": "1.25.2"
         },
         "org.openjdk.jmh:jmh-generator-annprocess": {
-            "locked": "1.25.1"
+            "locked": "1.25.2"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
             "locked": "1.21"
@@ -303,19 +303,19 @@
             "locked": "0.3.0"
         },
         "com.netflix.ribbon:ribbon-archaius": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.110.0"
@@ -389,19 +389,19 @@
             "locked": "0.3.0"
         },
         "com.netflix.ribbon:ribbon-archaius": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.110.0"
@@ -449,7 +449,7 @@
             "locked": "1.66"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.5.10"
+            "locked": "3.5.13"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25"
@@ -478,19 +478,19 @@
             "locked": "0.3.0"
         },
         "com.netflix.ribbon:ribbon-archaius": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.110.0"
@@ -541,7 +541,7 @@
             "locked": "1.66"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.5.10"
+            "locked": "3.5.13"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.30"

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -31,31 +31,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -158,31 +158,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -295,31 +295,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -421,7 +421,7 @@
             "locked": "3.0.3"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.5.10"
+            "locked": "3.5.13"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.21"
@@ -477,31 +477,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -641,31 +641,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -725,7 +725,7 @@
             "locked": "3.0.3"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.5.10"
+            "locked": "3.5.13"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -778,31 +778,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -904,7 +904,7 @@
             "locked": "3.0.3"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.5.10"
+            "locked": "3.5.13"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -31,31 +31,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -158,31 +158,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -301,31 +301,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -427,7 +427,7 @@
             "locked": "1.66"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.5.10"
+            "locked": "3.5.13"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.21"
@@ -486,31 +486,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -653,31 +653,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -737,7 +737,7 @@
             "locked": "4.13"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.5.10"
+            "locked": "3.5.13"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -796,31 +796,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -922,7 +922,7 @@
             "locked": "1.66"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.5.10"
+            "locked": "3.5.13"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -31,31 +31,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -155,31 +155,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -289,31 +289,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -465,31 +465,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -633,31 +633,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -800,31 +800,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -931,31 +931,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -41,31 +41,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -211,31 +211,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -356,31 +356,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -512,31 +512,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -723,31 +723,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -915,31 +915,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -1065,31 +1065,31 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-eureka": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-httpclient": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.7.17"
+            "locked": "2.4.4"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
The Ribbon bump appears to not be compatible `ProxyEndpoint`. In the long term we'll need to refactor how retries work in that class. 