### PR TITLE
Make consistent with 740

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/FilterFileManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/FilterFileManager.java
@@ -171,8 +171,7 @@ public class FilterFileManager {
             tasks.add(() -> {
                 try {
                     return filterLoader.putFilter(file);
-                }
-                catch(Exception e) {
+                } catch (Exception e) {
                     LOG.error("Error loading groovy filter from disk! file = " + String.valueOf(file), e);
                     return false;
                 }

--- a/zuul-core/src/main/java/com/netflix/zuul/FilterFileManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/FilterFileManager.java
@@ -172,7 +172,7 @@ public class FilterFileManager {
                 try {
                     return filterLoader.putFilter(file);
                 } catch (Exception e) {
-                    LOG.error("Error loading groovy filter from disk! file = " + String.valueOf(file), e);
+                    LOG.error("Error loading groovy filter from disk! file = " + file, e);
                     return false;
                 }
             });


### PR DESCRIPTION
In #740, `catch` was reformatted and redundant code was removed ([here](https://github.com/Netflix/zuul/pull/740/files#diff-82c9bb1f2c04684f2eb0482bcdc297dcR128-R130)), but its similar code was not modified.
I think the modification is needed for consistency.