### PR TITLE
core: add attrs to request message

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/Attrs.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/Attrs.java
@@ -30,10 +30,14 @@ import javax.annotation.Nullable;
  */
 public final class Attrs {
 
-    final Map<Key<?>, Object> storage = new IdentityHashMap<>();
+    final Map<Key<?>, Object> storage;
 
     public static <T> Key<T> newKey(String keyName) {
         return new Key<>(keyName);
+    }
+
+    public static Attrs copyOf(Attrs base) {
+        return new Attrs(new IdentityHashMap<>(base.storage));
     }
 
     public static final class Key<T> {
@@ -85,10 +89,12 @@ public final class Attrs {
         }
     }
 
-    private Attrs() {}
+    private Attrs(Map<Key<?>, Object> storage) {
+        this.storage = Objects.requireNonNull(storage);
+    }
 
     public static Attrs newInstance() {
-        return new Attrs();
+        return new Attrs(new IdentityHashMap<>());
     }
 
     public Set<Key<?>> keySet() {

--- a/zuul-core/src/main/java/com/netflix/zuul/context/CommonAttrKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/CommonAttrKeys.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.context;
+
+public final class CommonAttrKeys {
+
+    private CommonAttrKeys() {}
+
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/MissingEndpointHandlingFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/MissingEndpointHandlingFilter.java
@@ -47,7 +47,7 @@ public final class MissingEndpointHandlingFilter extends SyncZuulFilterAdapter<H
         final String errMesg = "Missing Endpoint filter, name = " + name;
         zuulCtx.setError(new ZuulException(errMesg, true));
         LOG.error(errMesg);
-        return new HttpResponseMessageImpl(zuulCtx, request, 500);
+        return new HttpResponseMessageImpl(zuulCtx, request.getAttrs(), request, 500);
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessage.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessage.java
@@ -16,6 +16,7 @@
 
 package com.netflix.zuul.message;
 
+import com.netflix.zuul.Attrs;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.filters.ZuulFilter;
 import io.netty.handler.codec.http.HttpContent;
@@ -32,6 +33,14 @@ public interface ZuulMessage extends Cloneable {
      * Returns the session context of this message.
      */
     SessionContext getContext();
+
+    /**
+     * Returns the attributes associated with the message.  This is an <strong>experimental</strong>
+     * API and is not considered stable.
+     */
+    default Attrs getAttrs() {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Returns the headers for this message.  They may be request or response headers, depending on the underlying type

--- a/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
@@ -19,6 +19,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.netflix.config.DynamicIntProperty;
 import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.zuul.Attrs;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.filters.ZuulFilter;
 import com.netflix.zuul.message.http.HttpHeaderNames;
@@ -31,6 +32,8 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import org.w3c.dom.Attr;
 
 /**
  * User: michaels@netflix.com
@@ -49,16 +52,18 @@ public class ZuulMessageImpl implements ZuulMessage
     private boolean hasBody;
     private boolean bodyBufferedCompletely;
     private List<HttpContent> bodyChunks;
+    private final Attrs attrs;
 
 
-    public ZuulMessageImpl(SessionContext context) {
-        this(context, new Headers());
+    public ZuulMessageImpl(SessionContext context, Attrs attrs) {
+        this(context, new Headers(), attrs);
     }
 
-    public ZuulMessageImpl(SessionContext context, Headers headers) {
+    public ZuulMessageImpl(SessionContext context, Headers headers, Attrs attrs) {
         this.context = context == null ? new SessionContext() : context;
         this.headers = headers == null ? new Headers() : headers;
         this.bodyChunks = new ArrayList<>(16);
+        this.attrs = Objects.requireNonNull(attrs);
     }
 
     @Override
@@ -217,7 +222,7 @@ public class ZuulMessageImpl implements ZuulMessage
 
     @Override
     public ZuulMessage clone() {
-        final ZuulMessageImpl copy = new ZuulMessageImpl(context.clone(), Headers.copyOf(headers));
+        final ZuulMessageImpl copy = new ZuulMessageImpl(context.clone(), Headers.copyOf(headers), Attrs.copyOf(attrs));
         this.bodyChunks.forEach(chunk -> {
             chunk.retain();
             copy.bufferBodyContents(chunk);

--- a/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import org.w3c.dom.Attr;
 
 /**
  * User: michaels@netflix.com

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
@@ -122,7 +122,8 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
         else {
             final SessionContext zuulCtx = zuulRequest.getContext();
             StatusCategoryUtils.storeStatusCategoryIfNotAlreadyFailure(zuulCtx, statusCategory);
-            final HttpResponseMessage zuulResponse = new HttpResponseMessageImpl(zuulCtx, zuulRequest, status);
+            final HttpResponseMessage zuulResponse =
+                    new HttpResponseMessageImpl(zuulCtx, zuulRequest.getAttrs(), zuulRequest, status);
             final Headers headers = zuulResponse.getHeaders();
             headers.add("Connection", "close");
             headers.add("Content-Length", "0");

--- a/zuul-core/src/test/java/com/netflix/zuul/AttrsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/AttrsTest.java
@@ -28,6 +28,7 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class AttrsTest {
+
     @Test
     public void keysAreUnique() {
         Attrs attrs = Attrs.newInstance();
@@ -37,6 +38,20 @@ public class AttrsTest {
         key2.put(attrs, "baz");
 
         Truth.assertThat(attrs.keySet()).containsExactly(key1, key2);
+    }
+
+    @Test
+    public void copyOf() {
+        Attrs attrs1 = Attrs.newInstance();
+        Key<String> key1 = Attrs.newKey("foo");
+        key1.put(attrs1, "bar");
+
+        Attrs attrs2 = Attrs.copyOf(attrs1);
+        Key<String> key2 = Attrs.newKey("foo");
+        key2.put(attrs2, "baz");
+
+        Truth.assertThat(attrs1.keySet()).containsExactly(key1);
+        Truth.assertThat(attrs2.keySet()).containsExactly(key1, key2);
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.truth.Truth;
+import com.netflix.zuul.Attrs;
 import com.netflix.zuul.message.Headers;
 import com.netflix.zuul.message.http.HttpQueryParams;
 import com.netflix.zuul.message.http.HttpRequestMessage;
@@ -64,7 +65,7 @@ public class DebugTest {
         request.setBodyAsText("some text");
         request.storeInboundRequest();
 
-        response = new HttpResponseMessageImpl(ctx, headers, request, 200);
+        response = new HttpResponseMessageImpl(ctx, Attrs.newInstance(), headers, request, 200);
         response.setBodyAsText("response text");
     }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+import com.netflix.zuul.Attrs;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.Headers;
 import com.netflix.zuul.message.http.HttpHeaderNames;
@@ -60,7 +61,7 @@ public class GZipResponseFilterTest {
         when(originalRequest.getHeaders()).thenReturn(originalRequestHeaders);
 
         filter = Mockito.spy(new GZipResponseFilter());
-        response = new HttpResponseMessageImpl(context, request, 99);
+        response = new HttpResponseMessageImpl(context, Attrs.newInstance(), request, 99);
         response.getHeaders().set(HttpHeaderNames.CONTENT_TYPE, "text/html");
         when(response.getInboundRequest()).thenReturn(originalRequest);
     }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/ZuulMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/ZuulMessageImplTest.java
@@ -19,6 +19,7 @@ package com.netflix.zuul.message;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.netflix.zuul.Attrs;
 import com.netflix.zuul.context.SessionContext;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultHttpContent;
@@ -33,11 +34,12 @@ public class ZuulMessageImplTest {
     @Test
     public void testClone() {
         SessionContext ctx1 = new SessionContext();
+        Attrs attrs = Attrs.newInstance();
         ctx1.set("k1", "v1");
         Headers headers1 = new Headers();
         headers1.set("k1", "v1");
 
-        ZuulMessage msg1 = new ZuulMessageImpl(ctx1, headers1);
+        ZuulMessage msg1 = new ZuulMessageImpl(ctx1, headers1, attrs);
         ZuulMessage msg2 = msg1.clone();
 
         assertEquals(msg1.getBodyAsText(), msg2.getBodyAsText());
@@ -54,7 +56,7 @@ public class ZuulMessageImplTest {
 
     @Test
     public void testBufferBody2GetBody() {
-        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
+        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers(), Attrs.newInstance());
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("Hello ".getBytes())));
         msg.bufferBodyContents(new DefaultLastHttpContent(Unpooled.copiedBuffer("World!".getBytes())));
         final String body = new String(msg.getBody());
@@ -65,7 +67,7 @@ public class ZuulMessageImplTest {
 
     @Test
     public void testBufferBody3GetBody() {
-        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
+        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers(), Attrs.newInstance());
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("Hello ".getBytes())));
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("World!".getBytes())));
         msg.bufferBodyContents(new DefaultLastHttpContent());
@@ -77,7 +79,7 @@ public class ZuulMessageImplTest {
 
     @Test
     public void testBufferBody3GetBodyAsText() {
-        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
+        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers(), Attrs.newInstance());
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("Hello ".getBytes())));
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("World!".getBytes())));
         msg.bufferBodyContents(new DefaultLastHttpContent());
@@ -89,7 +91,7 @@ public class ZuulMessageImplTest {
 
     @Test
     public void testSetBodyGetBody() {
-        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
+        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers(), Attrs.newInstance());
         msg.setBody("Hello World!".getBytes());
         final String body = new String(msg.getBody());
         assertEquals("Hello World!", body);
@@ -97,7 +99,7 @@ public class ZuulMessageImplTest {
 
     @Test
     public void testSetBodyAsTextGetBody() {
-        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
+        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers(), Attrs.newInstance());
         msg.setBodyAsText("Hello World!");
         final String body = new String(msg.getBody());
         assertTrue(msg.hasBody());
@@ -107,7 +109,7 @@ public class ZuulMessageImplTest {
 
     @Test
     public void testSetBodyAsTextGetBodyAsText() {
-        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
+        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers(), Attrs.newInstance());
         msg.setBodyAsText("Hello World!");
         final String body = msg.getBodyAsText();
         assertTrue(msg.hasBody());
@@ -117,7 +119,7 @@ public class ZuulMessageImplTest {
 
     @Test
     public void testMultiSetBodyAsTextGetBody() {
-        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
+        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers(), Attrs.newInstance());
         msg.setBodyAsText("Hello World!");
         String body = new String(msg.getBody());
         assertTrue(msg.hasBody());
@@ -132,7 +134,7 @@ public class ZuulMessageImplTest {
 
     @Test
     public void testMultiSetBodyGetBody() {
-        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
+        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers(), Attrs.newInstance());
         msg.setBody("Hello World!".getBytes());
         String body = new String(msg.getBody());
         assertTrue(msg.hasBody());

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpResponseMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpResponseMessageImplTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.netflix.zuul.Attrs;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.Headers;
 import org.junit.Before;
@@ -41,7 +42,8 @@ public class HttpResponseMessageImplTest {
 
     @Before
     public void setup() {
-        response = new HttpResponseMessageImpl(new SessionContext(), new Headers(), request, 200);
+        response = new HttpResponseMessageImpl(
+                new SessionContext(), Attrs.newInstance(), new Headers(), request, 200);
     }
 
     @Test


### PR DESCRIPTION
This is an example of adding Attrs (as an alternative to SessionContext).  Attrs are type safe, and make it easy to find out where a particular Key is used.  Attrs is mutable as there are several places where it its mutated.    Since we don't have the error prone checks to ensure return values are used, it would be risky to make Attrs immutable.