### PR TITLE
Revert "Always allow h2 for ALPN for h2 config"

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2Configuration.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2Configuration.java
@@ -42,21 +42,30 @@ public class Http2Configuration {
     public static SslContext configureSSL(SslContextFactory sslContextFactory, String metricId) {
         SslContextBuilder builder = sslContextFactory.createBuilderForServer();
 
-        String[] supportedProtocols = new String[]{ApplicationProtocolNames.HTTP_2, ApplicationProtocolNames.HTTP_1_1};
+        String[] supportedProtocol;
+        if (HTTP2_DISABLED.get()) {
+            supportedProtocol = new String[]{ApplicationProtocolNames.HTTP_1_1};
+        }
+        else {
+            supportedProtocol = new String[]{ApplicationProtocolNames.HTTP_2,
+                    ApplicationProtocolNames.HTTP_1_1};
+        }
+
         ApplicationProtocolConfig apn = new ApplicationProtocolConfig(
                 ApplicationProtocolConfig.Protocol.ALPN,
                 // NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.
                 ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
                 // ACCEPT is currently the only mode supported by both OpenSsl and JDK providers.
                 ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
-                supportedProtocols);
+                supportedProtocol);
 
         final SslContext sslContext;
         try {
             sslContext = builder
                     .applicationProtocolConfig(apn)
                     .build();
-        } catch (SSLException e) {
+        }
+        catch (SSLException e) {
             throw new RuntimeException("Error configuring SslContext with ALPN!", e);
         }
 


### PR DESCRIPTION
Keep this in place till we cleanly separate the SNI builder logic for non h2 spec.