### PR TITLE
zuul-core: add debugging and locking around CurrentPassport.

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/passport/CurrentPassport.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/passport/CurrentPassport.java
@@ -28,17 +28,24 @@ import io.netty.channel.Channel;
 import io.netty.util.AttributeKey;
 
 import java.util.ArrayList;
+import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class CurrentPassport
 {
+    private static final Logger logger = LoggerFactory.getLogger(CurrentPassport.class);
+
     private static final CachedDynamicBooleanProperty COUNT_STATES = new CachedDynamicBooleanProperty(
             "zuul.passport.count.enabled", false);
 
@@ -59,6 +66,29 @@ public class CurrentPassport
     private final LinkedList<PassportItem> history;
     private final HashSet<PassportState> statesAdded;
     private final long creationTimeSinceEpochMs;
+
+    private final ReentrantLock historyLock = new ReentrantLock();
+    private final Unlocker unlocker = new Unlocker();
+    private final class Unlocker implements AutoCloseable {
+
+        @Override
+        public void close() {
+            historyLock.unlock();
+        }
+    }
+
+    private Unlocker lock() {
+        boolean locked = false;
+        if (historyLock.isHeldByCurrentThread() || historyLock.isLocked() || !(locked = historyLock.tryLock())) {
+            logger.warn(
+                    "CurrentPassport already locked!, lock={}, self={}",
+                    historyLock, Thread.currentThread(), new ConcurrentModificationException());
+        }
+        if (!locked) {
+            historyLock.lock();
+        }
+        return unlocker;
+    }
 
     CurrentPassport()
     {
@@ -118,14 +148,19 @@ public class CurrentPassport
         ch.attr(CHANNEL_ATTR).set(null);
     }
 
-    public PassportState getState()
-    {
-        return history.peekLast().getState();
+    public PassportState getState() {
+        try (Unlocker ignored = lock()){
+            return history.peekLast().getState();
+        }
     }
 
+    @VisibleForTesting
     public LinkedList<PassportItem> getHistory()
     {
-        return history;
+        try (Unlocker ignored = lock()) {
+            // best effort, but doesn't actually protect anything
+            return history;
+        }
     }
 
     public void add(PassportState state)
@@ -136,8 +171,10 @@ public class CurrentPassport
                 return;
             }
         }
-        
-        history.addLast(new PassportItem(state, now()));
+
+        try (Unlocker ignored = lock()) {
+            history.addLast(new PassportItem(state, now()));
+        }
         statesAdded.add(state);
     }
 
@@ -151,9 +188,11 @@ public class CurrentPassport
     public long calculateTimeBetweenFirstAnd(PassportState endState)
     {
         long startTime = firstTime();
-        for (PassportItem item : history) {
-            if (item.getState() == endState) {
-                return item.getTime() - startTime;
+        try (Unlocker ignored = lock()) {
+            for (PassportItem item : history) {
+                if (item.getState() == endState) {
+                    return item.getTime() - startTime;
+                }
             }
         }
         return now() - startTime;
@@ -164,7 +203,9 @@ public class CurrentPassport
      */
     public long firstTime()
     {
-        return history.getFirst().getTime();
+        try (Unlocker ignored = lock()) {
+            return history.getFirst().getTime();
+        }
     }
 
     public long creationTimeSinceEpochMs()
@@ -197,26 +238,31 @@ public class CurrentPassport
     public StartAndEnd findStartAndEndStates(PassportState startState, PassportState endState)
     {
         StartAndEnd sae = new StartAndEnd();
-        for (PassportItem item : history) {
-            if (item.getState() == startState) {
-                sae.startTime = item.getTime();
-            }
-            else if (item.getState() == endState) {
-                sae.endTime = item.getTime();
+        try (Unlocker ignored = lock()) {
+            for (PassportItem item : history) {
+                if (item.getState() == startState) {
+                    sae.startTime = item.getTime();
+                }
+                else if (item.getState() == endState) {
+                    sae.endTime = item.getTime();
+                }
             }
         }
+
         return sae;
     }
 
     public StartAndEnd findFirstStartAndLastEndStates(PassportState startState, PassportState endState)
     {
         StartAndEnd sae = new StartAndEnd();
-        for (PassportItem item : history) {
-            if (sae.startNotFound() && item.getState() == startState) {
-                sae.startTime = item.getTime();
-            }
-            else if (item.getState() == endState) {
-                sae.endTime = item.getTime();
+        try (Unlocker ignored = lock()) {
+            for (PassportItem item : history) {
+                if (sae.startNotFound() && item.getState() == startState) {
+                    sae.startTime = item.getTime();
+                }
+                else if (item.getState() == endState) {
+                    sae.endTime = item.getTime();
+                }
             }
         }
         return sae;
@@ -225,12 +271,13 @@ public class CurrentPassport
     public StartAndEnd findLastStartAndFirstEndStates(PassportState startState, PassportState endState)
     {
         StartAndEnd sae = new StartAndEnd();
-        for (PassportItem item : history) {
-            if (item.getState() == startState) {
-                sae.startTime = item.getTime();
-            }
-            else if (sae.endNotFound() && item.getState() == endState) {
-                sae.endTime = item.getTime();
+        try (Unlocker ignored = lock()) {
+            for (PassportItem item : history) {
+                if (item.getState() == startState) {
+                    sae.startTime = item.getTime();
+                } else if (sae.endNotFound() && item.getState() == endState) {
+                    sae.endTime = item.getTime();
+                }
             }
         }
         return sae;
@@ -242,19 +289,20 @@ public class CurrentPassport
 
         StartAndEnd currentPair = null;
 
-        for (PassportItem item : history) {
+        try (Unlocker ignored = lock()) {
+            for (PassportItem item : history) {
 
-            if (item.getState() == startState) {
-                if (currentPair == null) {
-                    currentPair = new StartAndEnd();
-                    currentPair.startTime = item.getTime();
-                }
-            }
-            else if (item.getState() == endState) {
-                if (currentPair != null) {
-                    currentPair.endTime = item.getTime();
-                    items.add(currentPair);
-                    currentPair = null;
+                if (item.getState() == startState) {
+                    if (currentPair == null) {
+                        currentPair = new StartAndEnd();
+                        currentPair.startTime = item.getTime();
+                    }
+                } else if (item.getState() == endState) {
+                    if (currentPair != null) {
+                        currentPair.endTime = item.getTime();
+                        items.add(currentPair);
+                        currentPair = null;
+                    }
                 }
             }
         }
@@ -264,9 +312,11 @@ public class CurrentPassport
 
     public PassportItem findState(PassportState state)
     {
-        for (PassportItem item : history) {
-            if (item.getState() == state) {
-                return item;
+        try (Unlocker ignored = lock()) {
+            for (PassportItem item : history) {
+                if (item.getState() == state) {
+                    return item;
+                }
             }
         }
         return null;
@@ -274,11 +324,13 @@ public class CurrentPassport
 
     public PassportItem findStateBackwards(PassportState state)
     {
-        Iterator itr = history.descendingIterator();
-        while (itr.hasNext()) {
-            PassportItem item = (PassportItem) itr.next();
-            if (item.getState() == state) {
-                return item;
+        try (Unlocker ignored = lock()) {
+            Iterator itr = history.descendingIterator();
+            while (itr.hasNext()) {
+                PassportItem item = (PassportItem) itr.next();
+                if (item.getState() == state) {
+                    return item;
+                }
             }
         }
         return null;
@@ -287,9 +339,11 @@ public class CurrentPassport
     public List<PassportItem> findStates(PassportState state)
     {
         ArrayList<PassportItem> items = new ArrayList<>();
-        for (PassportItem item : history) {
-            if (item.getState() == state) {
-                items.add(item);
+        try (Unlocker ignored = lock()) {
+            for (PassportItem item : history) {
+                if (item.getState() == state) {
+                    items.add(item);
+                }
             }
         }
         return items;
@@ -299,9 +353,11 @@ public class CurrentPassport
     {
         long startTick = firstTime();
         ArrayList<Long> items = new ArrayList<>();
-        for (PassportItem item : history) {
-            if (item.getState() == state) {
-                items.add(item.getTime() - startTick);
+        try (Unlocker ignored = lock()) {
+            for (PassportItem item : history) {
+                if (item.getState() == state) {
+                    items.add(item.getTime() - startTick);
+                }
             }
         }
         return items;
@@ -322,23 +378,26 @@ public class CurrentPassport
     @Override
     public String toString()
     {
-        long startTime = history.size() > 0 ? firstTime() : 0;
-        long now = now();
-        
-        StringBuilder sb = new StringBuilder();
-        sb.append("CurrentPassport {");
-        sb.append("start_ms=").append(creationTimeSinceEpochMs()).append(", ");
-        
-        sb.append('[');
-        for (PassportItem item : history) {
-            sb.append('+').append(item.getTime() - startTime).append('=').append(item.getState().name()).append(", ");
+        try (Unlocker ignored = lock()) {
+            long startTime = history.size() > 0 ? firstTime() : 0;
+            long now = now();
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("CurrentPassport {");
+            sb.append("start_ms=").append(creationTimeSinceEpochMs()).append(", ");
+
+            sb.append('[');
+            for (PassportItem item : history) {
+                sb.append('+').append(item.getTime() - startTime).append('=').append(item.getState().name())
+                        .append(", ");
+            }
+            sb.append('+').append(now - startTime).append('=').append("NOW");
+            sb.append(']');
+
+            sb.append('}');
+
+            return sb.toString();
         }
-        sb.append('+').append(now - startTime).append('=').append("NOW");
-        sb.append(']');
-        
-        sb.append('}');
-        
-        return sb.toString();
     }
 
     @VisibleForTesting
@@ -352,19 +411,20 @@ public class CurrentPassport
             String[] stateStrs = m.group(1).split(", ");
             MockTicker ticker = new MockTicker();
             passport = new CurrentPassport(ticker);
-            for (String stateStr : stateStrs) {
-                Matcher stateMatch = ptnState.matcher(stateStr);
-                if (stateMatch.matches()) {
-                    String stateName = stateMatch.group(2);
-                    if (stateName.equals("NOW")) {
-                        long startTime = passport.getHistory().size() > 0 ? passport.firstTime() : 0;
-                        long now = Long.valueOf(stateMatch.group(1)) + startTime;
-                        ticker.setNow(now);
-                    }
-                    else {
-                        PassportState state = PassportState.valueOf(stateName);
-                        PassportItem item = new PassportItem(state, Long.valueOf(stateMatch.group(1)));
-                        passport.getHistory().add(item);
+            try (Unlocker ignored = passport.lock()) {
+                for (String stateStr : stateStrs) {
+                    Matcher stateMatch = ptnState.matcher(stateStr);
+                    if (stateMatch.matches()) {
+                        String stateName = stateMatch.group(2);
+                        if (stateName.equals("NOW")) {
+                            long startTime = passport.history.size() > 0 ? passport.firstTime() : 0;
+                            long now = Long.valueOf(stateMatch.group(1)) + startTime;
+                            ticker.setNow(now);
+                        } else {
+                            PassportState state = PassportState.valueOf(stateName);
+                            PassportItem item = new PassportItem(state, Long.valueOf(stateMatch.group(1)));
+                            passport.history.add(item);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This is needed to help debug a seemingly impossible ConcurrentModificationException.   The passport should live entirely on a single thread, and not be re-entrant.  This code checks not only if the passport is locked, but also if it accidentally owns it already.   The lock will keep access safe, but it does not stop the sharing of the object. Once we know where the object is being accessed, we can disable this code.