### PR TITLE
Fix exception when XFF port is present, but empty

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
@@ -534,7 +534,7 @@ public class HttpRequestMessageImpl implements HttpRequestMessage
             return ((InetSocketAddress) context.get(CommonContextKeys.PROXY_PROTOCOL_DESTINATION_ADDRESS)).getPort();
         }
         String portStr = headers.getFirst(HttpHeaderNames.X_FORWARDED_PORT);
-        if (portStr != null) {
+        if (portStr != null && !portStr.isEmpty()) {
             return Integer.parseInt(portStr);
         }
         // Check if port was specified on a Host header.

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
@@ -342,6 +342,15 @@ public class HttpRequestMessageImplTest {
     }
 
     @Test
+    public void getOriginalPort_EmptyXFFPort() throws URISyntaxException {
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.X_FORWARDED_PORT, "");
+
+        // Default to using server port
+        assertEquals(9999, HttpRequestMessageImpl.getOriginalPort(new SessionContext(), headers, 9999));
+    }
+
+    @Test
     public void getOriginalPort_respectsProxyProtocol() throws URISyntaxException {
         SessionContext context = new SessionContext();
         context.set(CommonContextKeys.PROXY_PROTOCOL_DESTINATION_ADDRESS,


### PR DESCRIPTION
This will still happen when the port is present, but has only whitespaces, ie `"    "`
jdk11 introduced `isBlank()` that doesn't allocate. I prefer not to use `trim()` to save the allocation, for now.