### PR TITLE
add netty-transport-native-epoll linux-aarch_64

### DIFF
--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     implementation "io.netty:netty-codec-haproxy:${versions_netty}"
     implementation "io.netty:netty-transport-native-epoll:${versions_netty}:linux-x86_64"
+    implementation "io.netty:netty-transport-native-epoll:${versions_netty}:linux-aarch_64"
     implementation "io.netty:netty-transport-native-kqueue:${versions_netty}:osx-x86_64"
     runtimeOnly "io.netty:netty-tcnative-boringssl-static:2.0.35.Final"
 


### PR DESCRIPTION
add netty-transport-native-epoll with classifier linux-aarch_64
    
This classifier indicates ARM architecture 64 bit
    
Netty 4.1.55 supports the linux-aarch_64 classifier:
https://github.com/netty/netty/pull/10845/files
