### PR TITLE
zuul-core: make sure to lock conn counters properly

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
@@ -51,7 +51,7 @@ public final class ConnCounter {
     private static final Object[] locks = new Object[LOCK_COUNT];
 
     static {
-        assert (LOCK_COUNT ^ LOCK_MASK) != 0;
+        assert (LOCK_COUNT & LOCK_MASK) == 0;
         for (int i = 0; i < locks.length; i++) {
             locks[i] = new Object();
         }

--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
@@ -40,6 +40,23 @@ public final class ConnCounter {
 
     private static final AttributeKey<ConnCounter> CONN_COUNTER = AttributeKey.newInstance("zuul.conncounter");
 
+    private static final int LOCK_COUNT = 256;
+    private static final int LOCK_MASK = LOCK_COUNT - 1;
+
+    /**
+     * An array of locks to guard the gauges.   This is the same as Guava's Striped, but avoids the dep.
+     *
+     * This can be removed after https://github.com/Netflix/spectator/issues/862 is fixed.
+     */
+    private static final Object[] locks = new Object[LOCK_COUNT];
+
+    static {
+        assert (LOCK_COUNT ^ LOCK_MASK) != 0;
+        for (int i = 0; i < locks.length; i++) {
+            locks[i] = new Object();
+        }
+    }
+
     private final Registry registry;
     private final Channel chan;
     private final Id metricBase;
@@ -91,7 +108,8 @@ public final class ConnCounter {
         lastCountKey = event;
         Id id = registry.createId(metricBase.name() + '.' + event).withTags(metricBase.tags()).withTags(dimTags);
         Gauge gauge = registry.gauge(id);
-        synchronized (gauge) {
+
+        synchronized (locks[id.hashCode() & LOCK_MASK]) {
             double current = gauge.value();
             gauge.set(Double.isNaN(current) ? 1 : current + 1);
         }
@@ -106,7 +124,7 @@ public final class ConnCounter {
             logger.warn("Missing conn counter increment {}", event);
             return;
         }
-        synchronized (gauge) {
+        synchronized (locks[gauge.id().hashCode() & LOCK_MASK]) {
             assert !Double.isNaN(gauge.value());
             gauge.set(gauge.value() - 1);
         }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
@@ -477,7 +477,7 @@ public class Server
             child.attr(CONN_DIMENSIONS).set(Attrs.newInstance());
             ConnTimer timer = ConnTimer.install(child, registry, registry.createId("zuul.conn.client.timing"));
             timer.record(now, "ACCEPT");
-            ConnCounter.install(child, registry, registry.createId("zuul.conn.client.active"));
+            ConnCounter.install(child, registry, registry.createId("zuul.conn.client.current"));
             super.channelRead(ctx, msg);
         }
     }


### PR DESCRIPTION
The gauge object returned by Spectator is usually not the same, so it doesn't provide the synchronization needed.