### PR TITLE
zuul-core: Selectively enable body caching on retries

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -164,7 +164,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
      * to decide to cache request bodies.
      */
     private static final CachedDynamicLongProperty THROTTLE_MEMORY_SECONDS =
-            new CachedDynamicLongProperty("zuul.proxy.throtle_memory_seconds", Duration.ofMinutes(5).getSeconds());
+            new CachedDynamicLongProperty("zuul.proxy.throttle_memory_seconds", Duration.ofMinutes(5).getSeconds());
 
 
     private static final Set<HeaderName> REQUEST_HEADERS_TO_REMOVE = Sets.newHashSet(HttpHeaderNames.CONNECTION, HttpHeaderNames.KEEP_ALIVE);

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -100,10 +100,12 @@ import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.URLDecoder;
 import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicReference;
@@ -127,6 +129,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
     /* Individual request related state */
     protected final HttpRequestMessage zuulRequest;
     protected final SessionContext context;
+    @Nullable
     protected final NettyOrigin origin;
     protected final RequestAttempts requestAttempts;
     protected final CurrentPassport passport;
@@ -156,6 +159,13 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
 
     private static final CachedDynamicLongProperty MAX_OUTBOUND_READ_TIMEOUT_MS =
             new CachedDynamicLongProperty("zuul.origin.readtimeout.max", Duration.ofSeconds(90).toMillis());
+    /**
+     * Indicates how long Zuul should remember throttle events for an origin.  As of this writing, throttling is used
+     * to decide to cache request bodies.
+     */
+    private static final CachedDynamicLongProperty THROTTLE_MEMORY_SECONDS =
+            new CachedDynamicLongProperty("zuul.proxy.throtle_memory_seconds", Duration.ofMinutes(5).getSeconds());
+
 
     private static final Set<HeaderName> REQUEST_HEADERS_TO_REMOVE = Sets.newHashSet(HttpHeaderNames.CONNECTION, HttpHeaderNames.KEEP_ALIVE);
     private static final Set<HeaderName> RESPONSE_HEADERS_TO_REMOVE = Sets.newHashSet(HttpHeaderNames.CONNECTION, HttpHeaderNames.KEEP_ALIVE);
@@ -164,7 +174,6 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
     private static final Counter NO_RETRY_INCOMPLETE_BODY = SpectatorUtils.newCounter("zuul.no.retry","incomplete_body");
     private static final Counter NO_RETRY_RESP_STARTED = SpectatorUtils.newCounter("zuul.no.retry","resp_started");
     private final Counter populatedRetryBody;
-
 
     public ProxyEndpoint(final HttpRequestMessage inMesg, final ChannelHandlerContext ctx,
                          final FilterRunner<HttpResponseMessage, ?> filters, MethodBinding<?> methodBinding) {
@@ -184,6 +193,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
         chosenServer = new AtomicReference<>();
         chosenHostAddr = new AtomicReference<>();
 
+        // This must happen after origin is set, since it depends on it.
         this.retryBodyCache = preCacheBodyForRetryingRequests();
         this.populatedRetryBody = SpectatorUtils.newCounter(
                 "zuul.populated.retry.body", origin == null ? "null" : origin.getName().getTarget());
@@ -583,6 +593,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
         }
     }
 
+    @Nullable
     private byte[] preCacheBodyForRetryingRequests() {
         // Netty SSL handler clears body ByteBufs, so we need to cache the body if we want to retry POSTs
         // Followup: We expect most origin connections to be secure, so it's okay to unconditionally cache here.
@@ -593,8 +604,15 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
             // plaintext requests.  Unfortunately, the cost of cahcing the body is non trivial, and as of the
             // current implementation, it's only technically required for SSL.  See comment above.
             if (origin.getClientConfig().get(Keys.IsSecure, false) || ENABLE_CACHING_PLAINTEXT_BODIES.get()) {
-                // only cache requests if already buffered
-                return zuulRequest.getBody();
+                ZonedDateTime lastThrottleEvent = origin.stats().lastThrottleEvent();
+                if (lastThrottleEvent != null) {
+                    // This is technically the wrong method to call, but the toSeconds() method is only present in JDK9.
+                    long timeSinceLastThrottle = Duration.between(lastThrottleEvent, ZonedDateTime.now()).getSeconds();
+                    if (timeSinceLastThrottle <= THROTTLE_MEMORY_SECONDS.get()) {
+                        // only cache requests if already buffered
+                        return zuulRequest.getBody();
+                    }
+                }
             }
         }
         return null;
@@ -906,6 +924,8 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
             statusCategory = FAILURE_ORIGIN_THROTTLED;
             niwsErrorType = ClientException.ErrorType.SERVER_THROTTLED;
             obe = new OutboundException(OutboundErrorType.SERVICE_UNAVAILABLE, requestAttempts);
+            // TODO(carl-mastrangelo): pass in the clock for testing.
+            origin.stats().lastThrottleEvent(ZonedDateTime.now());
             if (originConn != null) {
                 originConn.getServerStats().incrementSuccessiveConnectionFailureCount();
                 originConn.getServerStats().addToFailureCount();
@@ -1058,6 +1078,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
      * Note: this method gets called in the constructor so if overloading it or any methods called within, you cannot
      * rely on your own constructor parameters.
      */
+    @Nullable
     protected NettyOrigin getOrigin(HttpRequestMessage request) {
         SessionContext context = request.getContext();
         OriginManager<NettyOrigin> originManager = (OriginManager<NettyOrigin>) context.get(CommonContextKeys.ORIGIN_MANAGER);

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOrigin.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOrigin.java
@@ -51,6 +51,7 @@ import java.net.InetAddress;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
 
 /**
  * Netty Origin basic implementation that can be used for most apps, with the more complex methods having no-op
@@ -66,6 +67,7 @@ public class BasicNettyOrigin implements NettyOrigin {
     private final IClientConfig config;
     private final ClientChannelManager clientChannelManager;
     private final NettyRequestAttemptFactory requestAttemptFactory;
+    private final OriginStats stats = new OriginStats();
 
     private final AtomicInteger concurrentRequests;
     private final Counter rejectedRequests;
@@ -230,6 +232,11 @@ public class BasicNettyOrigin implements NettyOrigin {
     @Override
     public void recordProxyRequestEnd() {
         concurrentRequests.decrementAndGet();
+    }
+
+    @Override
+    public final OriginStats stats() {
+        return stats;
     }
 
     /* Not required for basic operation */

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/InstrumentedOrigin.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/InstrumentedOrigin.java
@@ -17,6 +17,7 @@
 package com.netflix.zuul.origins;
 
 import com.netflix.zuul.message.http.HttpRequestMessage;
+import javax.annotation.Nullable;
 
 /**
  * User: michaels@netflix.com
@@ -36,4 +37,13 @@ public interface InstrumentedOrigin extends Origin {
     void recordSuccessResponse();
 
     void recordProxyRequestEnd();
+
+    /**
+     * Returns the mutable origin stats for this origin.  Unlike the other methods in this interface,
+     * External callers are expected to update these numbers, rather than this object itself.
+     * @return
+     */
+    default OriginStats stats() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/OriginStats.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/OriginStats.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.origins;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Information about an {@link Origin} to be used for proxying.
+ */
+@ThreadSafe
+public final class OriginStats {
+
+    /**
+     * Represents the last time a Server in this Origin was throttled.
+     */
+    private final AtomicReference<ZonedDateTime> lastThrottleEvent = new AtomicReference<>();
+
+
+    /**
+     * Gets the last time a Server in this Origin was throttled.  Returns {@code null} if there was
+     * no throttling.  This class does not define what throttling is; see
+     * {@link com.netflix.zuul.filters.endpoint.ProxyEndpoint}.
+     */
+    @Nullable
+    public ZonedDateTime lastThrottleEvent() {
+        return lastThrottleEvent.get();
+    }
+
+    /**
+     * Sets the last throttle event, if it is after the existing last throttle event.
+     */
+    public void lastThrottleEvent(ZonedDateTime lastThrottleEvent) {
+        Objects.requireNonNull(lastThrottleEvent);
+        ZonedDateTime existing;
+        do {
+            existing = this.lastThrottleEvent.get();
+            if (existing != null && lastThrottleEvent.compareTo(existing) <= 0) {
+                break;
+            }
+        } while (!this.lastThrottleEvent.compareAndSet(existing, lastThrottleEvent));
+    }
+}


### PR DESCRIPTION
This change modifies the proxy logic to cache request bodies only if there have recently
been throttling events.  This means that if we get back a 503, we more agressively cache
request bodies to be able to retry the request.  Previously, Zuul would cache the body
if the origin was secure, or manually request to cache.  This found to be expensive, since
it results in caching all the time, even if the origin is healthy.

This change makes Zuul look to see if there have been any failures in the past 5 minutes.
If there have, Zuul will cache the body for retry, under the expectation the origin will
recover.  This means the very first request that fails due to throttling cannot be retried,
but subsequent failures can.  After enough time has past from the last throttle, Zuul will
stop caching again.   Zuul can be configured to unconditionally cache by setting this value
to -1.