### PR TITLE
Ensure SessionContext isn't modified when iterating over it

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/context/Debug.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/Debug.java
@@ -121,6 +121,10 @@ public class Debug {
      */
     public static void compareContextState(String filterName, SessionContext context, SessionContext copy) {
         // TODO - only comparing Attributes. Need to compare the messages too.
+
+        // Ensure that the routingDebug property already exists, otherwise we'll have a ConcurrentModificationException below
+        getRoutingDebug(context);
+
         Iterator<String> it = context.keySet().iterator();
         String key = it.next();
         while (key != null) {

--- a/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
@@ -163,4 +163,14 @@ public class DebugTest {
                 "RESPONSE_INBOUND:: < HDR: lah:deda",
                 "RESPONSE_INBOUND:: < BODY: response text");
     }
+
+    @Test
+    public void testNoCMEWhenComparingContexts() {
+        final SessionContext context = new SessionContext();
+        final SessionContext copy = new SessionContext();
+
+        context.set("foo", "bar");
+
+        Debug.compareContextState("testfilter", context, copy);
+    }
 }


### PR DESCRIPTION
When routing debugging is enabled, Zuul will record changes in the session context after each filter is run.  If the context already has a "routingDebug" property on it, all will be fine.  If not, the comparison code will (as a side effect) add that property.  However, it's added while there is an active iterator over the context.  Once the code tries to fetch the next element from the iterator, a
ConcurrentModificationException is thrown.

This fix is simple, though the ideal fix would probably be to refactor the code to be safer.