### PR TITLE
core: add a named socket class for use with Server startup

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
@@ -68,7 +68,7 @@ public abstract class BaseServerStartup
     protected final FilterLoader filterLoader;
     protected final FilterUsageNotifier usageNotifier;
 
-    private Map<? extends SocketAddress, ? extends ChannelInitializer<?>> addrsToChannelInitializers;
+    private Map<NamedSocketAddress, ? extends ChannelInitializer<?>> addrsToChannelInitializers;
     private ClientConnectionsShutdown clientConnectionsShutdown;
     private Server server;
 
@@ -127,7 +127,7 @@ public abstract class BaseServerStartup
     }
 
     @ForOverride
-    protected Map<SocketAddress, ChannelInitializer<?>> chooseAddrsAndChannels(ChannelGroup clientChannels) {
+    protected Map<NamedSocketAddress, ChannelInitializer<?>> chooseAddrsAndChannels(ChannelGroup clientChannels) {
         @SuppressWarnings("unchecked") // Channel init map has the wrong generics and we can't fix without api breakage.
         Map<Integer, ChannelInitializer<?>> portMap =
                 (Map<Integer, ChannelInitializer<?>>) (Map) choosePortsAndChannels(clientChannels);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/NamedSocketAddress.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/NamedSocketAddress.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.netty.server;
+
+import java.net.SocketAddress;
+import java.util.Objects;
+
+public final class NamedSocketAddress extends SocketAddress {
+
+    private final String name;
+    private final SocketAddress delegate;
+
+    public NamedSocketAddress(String name, SocketAddress delegate) {
+        this.name = Objects.requireNonNull(name);
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public SocketAddress unwrap() {
+        return delegate;
+    }
+
+    @Override
+    public String toString() {
+        return "NamedSocketAddress{" +
+                "name='" + name + '\'' +
+                ", delegate=" + delegate +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NamedSocketAddress that = (NamedSocketAddress) o;
+        return Objects.equals(name, that.name) && Objects.equals(delegate, that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, delegate);
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ServerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ServerTest.java
@@ -48,15 +48,15 @@ public class ServerTest {
     @Test
     public void getListeningSockets() throws Exception {
         ServerStatusManager ssm = mock(ServerStatusManager.class);
-        Map<SocketAddress, ChannelInitializer<?>> initializers = new HashMap<>();
+        Map<NamedSocketAddress, ChannelInitializer<?>> initializers = new HashMap<>();
         ChannelInitializer<Channel> init = new ChannelInitializer<Channel>() {
             @Override
             protected void initChannel(Channel ch) {}
         };
-        initializers.put(new InetSocketAddress(0), init);
+        initializers.put(new NamedSocketAddress("test", new InetSocketAddress(0)), init);
         // Pick an InetAddress likely different than the above.  The port to channel map has a unique Key; this
         // prevents the key being a duplicate.
-        initializers.put(new InetSocketAddress(InetAddress.getLocalHost(), 0), init);
+        initializers.put(new NamedSocketAddress("test2", new InetSocketAddress(InetAddress.getLocalHost(), 0)), init);
         ClientConnectionsShutdown ccs =
                 new ClientConnectionsShutdown(
                         new DefaultChannelGroup(GlobalEventExecutor.INSTANCE),

--- a/zuul-sample/src/main/java/com/netflix/zuul/sample/SampleServerStartup.java
+++ b/zuul-sample/src/main/java/com/netflix/zuul/sample/SampleServerStartup.java
@@ -89,8 +89,8 @@ public class SampleServerStartup extends BaseServerStartup {
     }
 
     @Override
-    protected Map<SocketAddress, ChannelInitializer<?>> chooseAddrsAndChannels(ChannelGroup clientChannels) {
-        Map<SocketAddress, ChannelInitializer<?>> addrsToChannels = new HashMap<>();
+    protected Map<NamedSocketAddress, ChannelInitializer<?>> chooseAddrsAndChannels(ChannelGroup clientChannels) {
+        Map<NamedSocketAddress, ChannelInitializer<?>> addrsToChannels = new HashMap<>();
         SocketAddress sockAddr;
         String metricId;
         {
@@ -131,7 +131,7 @@ public class SampleServerStartup extends BaseServerStartup {
                 channelConfig.set(CommonChannelConfigKeys.withProxyProtocol, false);
 
                 addrsToChannels.put(
-                        sockAddr,
+                        new NamedSocketAddress("http", sockAddr),
                         new ZuulServerChannelInitializer(
                                 metricId, channelConfig, channelDependencies, clientChannels));
                 logAddrConfigured(sockAddr);
@@ -155,7 +155,7 @@ public class SampleServerStartup extends BaseServerStartup {
                 addHttp2DefaultConfig(channelConfig, mainListenAddressName);
 
                 addrsToChannels.put(
-                        sockAddr,
+                        new NamedSocketAddress("http2", sockAddr),
                         new Http2SslChannelInitializer(
                                 metricId, channelConfig, channelDependencies, clientChannels));
                 logAddrConfigured(sockAddr, sslConfig);
@@ -186,7 +186,7 @@ public class SampleServerStartup extends BaseServerStartup {
                 channelConfig.set(CommonChannelConfigKeys.sslContextFactory, new BaseSslContextFactory(registry, sslConfig));
 
                 addrsToChannels.put(
-                        sockAddr,
+                        new NamedSocketAddress("http_mtls", sockAddr),
                         new Http1MutualSslChannelInitializer(
                                 metricId, channelConfig, channelDependencies, clientChannels));
                 logAddrConfigured(sockAddr, sslConfig);
@@ -203,13 +203,13 @@ public class SampleServerStartup extends BaseServerStartup {
                 channelDependencies.set(ZuulDependencyKeys.pushConnectionRegistry, pushConnectionRegistry);
 
                 addrsToChannels.put(
-                        sockAddr,
+                        new NamedSocketAddress("websocket", sockAddr),
                         new SampleWebSocketPushChannelInitializer(
                                 metricId, channelConfig, channelDependencies, clientChannels));
                 logAddrConfigured(sockAddr);
 
                 // port to accept push message from the backend, should be accessible on internal network only.
-                addrsToChannels.put(pushSockAddr, pushSenderInitializer);
+                addrsToChannels.put(new NamedSocketAddress("http.push", pushSockAddr), pushSenderInitializer);
                 logAddrConfigured(pushSockAddr);
                 break;
 
@@ -224,12 +224,12 @@ public class SampleServerStartup extends BaseServerStartup {
                 channelDependencies.set(ZuulDependencyKeys.pushConnectionRegistry, pushConnectionRegistry);
 
                 addrsToChannels.put(
-                        sockAddr,
+                        new NamedSocketAddress("sse", sockAddr),
                         new SampleSSEPushChannelInitializer(
                                 metricId, channelConfig, channelDependencies, clientChannels));
                 logAddrConfigured(sockAddr);
                 // port to accept push message from the backend, should be accessible on internal network only.
-                addrsToChannels.put(pushSockAddr, pushSenderInitializer);
+                addrsToChannels.put(new NamedSocketAddress("http.push", pushSockAddr), pushSenderInitializer);
                 logAddrConfigured(pushSockAddr);
                 break;
         }


### PR DESCRIPTION
I plan on using this to help deflake some tests.   I need to know the name of the port that gets bounds to do so.