### PR TITLE
Use LinkedListMultimap for query parameters

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpQueryParams.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpQueryParams.java
@@ -16,7 +16,7 @@
 package com.netflix.zuul.message.http;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
@@ -44,7 +44,7 @@ public class HttpQueryParams implements Cloneable
 
     public HttpQueryParams()
     {
-        delegate = ArrayListMultimap.create();
+        delegate = LinkedListMultimap.create();
         immutable = false;
         trailingEquals = new HashMap<>();
     }


### PR DESCRIPTION
Use LinkedListMultimap instead of ArrayListMultiMap for query parameters to ensure that the request URI is not modified

Issue: https://github.com/Netflix/zuul/issues/525