### PR TITLE
Downgrade to Netty 4.1.57

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 versions_groovy=3.0.3
 versions_ribbon=2.4.4
-versions_netty=4.1.57.Final
+versions_netty=4.1.55.Final
 release.scope=patch
 release.version=2.3.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 versions_groovy=3.0.3
 versions_ribbon=2.4.4
-versions_netty=4.1.58.Final
+versions_netty=4.1.57.Final
 release.scope=patch
 release.version=2.3.0-SNAPSHOT

--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "io.netty:netty-codec-haproxy:${versions_netty}"
     implementation "io.netty:netty-transport-native-epoll:${versions_netty}:linux-x86_64"
     implementation "io.netty:netty-transport-native-kqueue:${versions_netty}:osx-x86_64"
-    runtimeOnly "io.netty:netty-tcnative-boringssl-static:2.0.36.Final"
+    runtimeOnly "io.netty:netty-tcnative-boringssl-static:2.0.35.Final"
 
     implementation 'io.perfmark:perfmark-api:0.23.0'
     implementation 'javax.inject:javax.inject:1'

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -37,31 +37,31 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"
@@ -128,31 +128,31 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"
@@ -220,34 +220,34 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"
@@ -321,34 +321,34 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"
@@ -407,31 +407,31 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"
@@ -496,34 +496,34 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -37,31 +37,31 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"
@@ -128,31 +128,31 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"
@@ -220,34 +220,34 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.36.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"
@@ -321,34 +321,34 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.36.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"
@@ -407,31 +407,31 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"
@@ -496,34 +496,34 @@
             "locked": "0.123.1"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.36.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.23.0"

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -70,37 +70,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -197,37 +197,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -334,37 +334,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -376,19 +376,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -516,37 +516,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -558,19 +558,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -680,37 +680,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -817,37 +817,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -859,19 +859,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -70,37 +70,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -197,37 +197,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -334,61 +334,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -516,61 +516,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -680,37 +680,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -817,61 +817,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -73,37 +73,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -200,37 +200,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -343,37 +343,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -385,19 +385,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -528,37 +528,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -570,19 +570,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -695,37 +695,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -838,37 +838,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -880,19 +880,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -73,37 +73,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -200,37 +200,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -343,61 +343,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -528,61 +528,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -695,37 +695,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -838,61 +838,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -70,37 +70,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -194,37 +194,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -328,61 +328,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -504,61 +504,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -678,61 +678,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -839,37 +839,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -970,61 +970,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -70,37 +70,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -194,37 +194,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -328,37 +328,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -370,19 +370,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -504,37 +504,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -546,19 +546,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -678,37 +678,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -720,19 +720,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -839,37 +839,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -970,37 +970,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1012,19 +1012,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -86,37 +86,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -128,19 +128,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -259,37 +259,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -404,37 +404,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -567,37 +567,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -609,19 +609,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -778,37 +778,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -820,19 +820,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -963,37 +963,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1120,37 +1120,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1162,19 +1162,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.58.Final"
+            "locked": "4.1.57.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -86,61 +86,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -259,37 +259,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -404,37 +404,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -567,61 +567,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -778,61 +778,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -963,37 +963,37 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1120,61 +1120,61 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.36.Final"
+            "locked": "2.0.35.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.57.Final"
+            "locked": "4.1.55.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
Netty 4.1.58 introduced a regression in H2 stream handling: See: https://github.com/netty/netty/issues/10941