### PR TITLE
Remove duplicate conns count. Reduce synchronization

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
@@ -45,7 +45,7 @@ public final class ConnCounter {
 
     /**
      * An array of locks to guard the gauges.   This is the same as Guava's Striped, but avoids the dep.
-     *
+     * <p>
      * This can be removed after https://github.com/Netflix/spectator/issues/862 is fixed.
      */
     private static final Object[] locks = new Object[LOCK_COUNT];
@@ -119,6 +119,10 @@ public final class ConnCounter {
             gauge.set(Double.isNaN(current) ? 1 : current + 1);
         }
         counts.put(event, gauge);
+    }
+
+    public double getCurrentActiveConns() {
+        return counts.containsKey("active") ? counts.get("active").value() : 0.0;
     }
 
     public void decrement(String event) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/insights/PassportLoggingHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/insights/PassportLoggingHandler.java
@@ -24,6 +24,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpResponseMessage;
+import com.netflix.zuul.monitoring.ConnCounter;
 import com.netflix.zuul.netty.ChannelUtils;
 import com.netflix.zuul.netty.server.ClientRequestReceiver;
 import com.netflix.zuul.niws.RequestAttempts;
@@ -91,7 +92,7 @@ public class PassportLoggingHandler extends ChannelInboundHandlerAdapter
         // Do some debug logging of the Passport.
         if (LOG.isDebugEnabled()) {
             LOG.debug("State after complete. "
-                    + ", current-server-conns = " + ServerStateHandler.InboundHandler.currentConnectionCountFromChannel(channel)
+                    + ", current-server-conns = " + ConnCounter.from(channel).getCurrentActiveConns()
                     + ", current-http-reqs = " + HttpMetricsChannelHandler.getInflightRequestCountFromChannel(channel)
                     + ", status = " + (response == null ? getRequestId(channel, ctx) : response.getStatus())
                     + ", nfstatus = " + String.valueOf(StatusCategoryUtils.getStatusCategory(ctx))

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/insights/ServerStateHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/insights/ServerStateHandlerTest.java
@@ -60,7 +60,6 @@ public class ServerStateHandlerTest {
         channel.pipeline().addLast(new InboundHandler(registry, listener));
 
         final Counter connects = (Counter) registry.get(connectsId);
-        final Gauge currentConns = (Gauge) registry.get(currentConnsId);
         final Counter closes = (Counter) registry.get(closesId);
         final Counter errors = (Counter) registry.get(errorsId);
 
@@ -69,13 +68,11 @@ public class ServerStateHandlerTest {
         channel.pipeline().context(DummyChannelHandler.class).fireChannelActive();
         channel.pipeline().context(DummyChannelHandler.class).fireChannelActive();
 
-        assertEquals(3.0, currentConns.value(), 0.0);
         assertEquals(3, connects.count());
 
         // Closes X 1
         channel.pipeline().context(DummyChannelHandler.class).fireChannelInactive();
 
-        assertEquals(2.0, currentConns.value(), 0.0);
         assertEquals(3, connects.count());
         assertEquals(1, closes.count());
         assertEquals(0, errors.count());


### PR DESCRIPTION
The `zuul.conn.client.current.active` effectively employs a similar locking mechanism and it doesn't seem useful to have 2 code paths employing synchronization, for similar goals.
Minor update for this to expose the `nascent` -> `active` counts, which should effectively be a clean replacement for the old metric.