### PR TITLE
Abstract out origin timeout logic

### DIFF
--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -8,21 +8,18 @@ dependencies {
     api libraries.slf4j
     implementation 'org.bouncycastle:bcprov-jdk15on:1.+'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.12.1'
-    api 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
 
     api "com.netflix.archaius:archaius-core:0.7.5"
     api "com.netflix.spectator:spectator-api:0.123.1"
-    api "com.netflix.netflix-commons:netflix-commons-util:0.3.0"
+    implementation "com.netflix.netflix-commons:netflix-commons-util:0.3.0"
 
-    api project(":zuul-discovery")
+    implementation project(":zuul-discovery")
 
-    api "com.netflix.ribbon:ribbon-core:${versions_ribbon}"
-    //TODO(argha-c): the only remaining dep is ExecutionContext. Remove this once decoupled.
-    api "com.netflix.ribbon:ribbon-loadbalancer:${versions_ribbon}"
-    api "com.netflix.ribbon:ribbon-archaius:${versions_ribbon}"
+    implementation "com.netflix.ribbon:ribbon-core:${versions_ribbon}"
+    implementation "com.netflix.ribbon:ribbon-archaius:${versions_ribbon}"
 
-
-    api "com.netflix.eureka:eureka-client:1.9.18"
+    implementation "com.netflix.eureka:eureka-client:1.9.18"
     api "io.reactivex:rxjava:1.2.1"
 
     // TODO(carl-mastrangelo): some of these could probably be implementation.   Do a deeper check.

--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -8,18 +8,18 @@ dependencies {
     api libraries.slf4j
     implementation 'org.bouncycastle:bcprov-jdk15on:1.+'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.12.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.12.1'
 
     api "com.netflix.archaius:archaius-core:0.7.5"
     api "com.netflix.spectator:spectator-api:0.123.1"
-    implementation "com.netflix.netflix-commons:netflix-commons-util:0.3.0"
+    api "com.netflix.netflix-commons:netflix-commons-util:0.3.0"
 
-    implementation project(":zuul-discovery")
+    api project(":zuul-discovery")
 
-    implementation "com.netflix.ribbon:ribbon-core:${versions_ribbon}"
-    implementation "com.netflix.ribbon:ribbon-archaius:${versions_ribbon}"
+    api "com.netflix.ribbon:ribbon-core:${versions_ribbon}"
+    api "com.netflix.ribbon:ribbon-archaius:${versions_ribbon}"
 
-    implementation "com.netflix.eureka:eureka-client:1.9.18"
+    api "com.netflix.eureka:eureka-client:1.9.18"
     api "io.reactivex:rxjava:1.2.1"
 
     // TODO(carl-mastrangelo): some of these could probably be implementation.   Do a deeper check.

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -37,7 +37,6 @@ import com.netflix.client.config.IClientConfigKey.Keys;
 import com.netflix.config.CachedDynamicLongProperty;
 import com.netflix.config.DynamicBooleanProperty;
 import com.netflix.config.DynamicIntegerSetProperty;
-import com.netflix.loadbalancer.Server;
 import com.netflix.spectator.api.Counter;
 import com.netflix.zuul.Filter;
 import com.netflix.zuul.context.CommonContextKeys;

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
 package com.netflix.zuul.netty.timeouts;
 
 import static com.netflix.client.config.CommonClientConfigKey.ReadTimeout;

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManager.java
@@ -1,0 +1,110 @@
+package com.netflix.zuul.netty.timeouts;
+
+import static com.netflix.client.config.CommonClientConfigKey.ReadTimeout;
+
+import com.google.common.base.Strings;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.config.DynamicLongProperty;
+import com.netflix.zuul.context.CommonContextKeys;
+import com.netflix.zuul.message.http.HttpRequestMessage;
+import com.netflix.zuul.origins.NettyOrigin;
+import java.time.Duration;
+import javax.annotation.Nullable;
+
+/**
+ * Origin Timeout Manager
+ *
+ * @author Arthur Gonigberg
+ * @since February 24, 2021
+ */
+public class OriginTimeoutManager {
+
+    private final NettyOrigin origin;
+
+    public OriginTimeoutManager(NettyOrigin origin) {
+        this.origin = origin;
+    }
+
+    private static final DynamicLongProperty MAX_OUTBOUND_READ_TIMEOUT_MS =
+            new DynamicLongProperty("zuul.origin.readtimeout.max", Duration.ofSeconds(90).toMillis());
+
+    public Object getRequestReadTimeout(IClientConfig requestConfig, Long defaultTimeout) {
+        return requestConfig.getProperty(ReadTimeout, defaultTimeout);
+    }
+
+    public void setRequestReadTimeout(IClientConfig requestConfig, Object timeout) {
+        requestConfig.setProperty(ReadTimeout, timeout);
+    }
+
+    public Object getOriginReadTimeout(Long noTimeout) {
+        return origin.getClientConfig().getProperty(ReadTimeout, noTimeout);
+    }
+
+    public Object computeOverriddenReadTimeout(Object originalTimeout, IClientConfig requestConfig) {
+        // check if there is a numeric override of the timeout
+        Integer overriddenReadTimeout = requestConfig.get(ReadTimeout);
+        if (overriddenReadTimeout != null) {
+            return overriddenReadTimeout;
+        }
+        return originalTimeout;
+    }
+
+    public IClientConfig getRequestClientConfig(HttpRequestMessage zuulRequest) {
+        IClientConfig overriddenClientConfig =
+                (IClientConfig) zuulRequest.getContext().get(CommonContextKeys.REST_CLIENT_CONFIG);
+        if (overriddenClientConfig == null) {
+            overriddenClientConfig = new DefaultClientConfigImpl();
+            zuulRequest.getContext().put(CommonContextKeys.REST_CLIENT_CONFIG, overriddenClientConfig);
+        }
+
+        return overriddenClientConfig;
+    }
+
+    public int computeReadTimeout(IClientConfig requestConfig, int attempt) {
+        Duration readTimeout = getReadTimeout(requestConfig, attempt);
+        return Math.toIntExact(readTimeout.toMillis());
+    }
+
+    /**
+     * Derives the read timeout from the configuration.  This implementation prefers the longer of either the origin
+     * timeout or the request timeout.
+     *
+     * @param requestConfig the config for the request.
+     * @param attemptNum    the attempt number, starting at 1.
+     */
+    protected Duration getReadTimeout(IClientConfig requestConfig, int attemptNum) {
+        Long noTimeout = null;
+        // TODO(carl-mastrangelo): getProperty is deprecated, and suggests using the typed overload `get`.   However,
+        //  the value is parsed using parseReadTimeoutMs, which supports String, implying not all timeouts are Integer.
+        //  Figure out where a string ReadTimeout is coming from and replace it.
+        Long originTimeout = parseReadTimeoutMs(getOriginReadTimeout(noTimeout));
+        Long requestTimeout = parseReadTimeoutMs(getRequestReadTimeout(requestConfig, noTimeout));
+
+        if (originTimeout == null && requestTimeout == null) {
+            return Duration.ofMillis(MAX_OUTBOUND_READ_TIMEOUT_MS.get());
+        } else if (originTimeout == null || requestTimeout == null) {
+            return Duration.ofMillis(originTimeout == null ? requestTimeout : originTimeout);
+        } else {
+            // return the greater of two timeouts
+            return Duration.ofMillis(originTimeout > requestTimeout ? originTimeout : requestTimeout);
+        }
+    }
+
+    /**
+     * An Integer is expected as an input, but supports parsing Long and String.  Returns {@code null} if no type is
+     * acceptable.
+     */
+    @Nullable
+    private Long parseReadTimeoutMs(Object p) {
+        if (p instanceof String && !Strings.isNullOrEmpty((String) p)) {
+            return Long.valueOf((String) p);
+        } else if (p instanceof Long) {
+            return (Long) p;
+        } else if (p instanceof Integer) {
+            return Long.valueOf((Integer) p);
+        } else {
+            return null;
+        }
+    }
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManager.java
@@ -26,6 +26,7 @@ import com.netflix.zuul.context.CommonContextKeys;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.origins.NettyOrigin;
 import java.time.Duration;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -39,7 +40,7 @@ public class OriginTimeoutManager {
     private final NettyOrigin origin;
 
     public OriginTimeoutManager(NettyOrigin origin) {
-        this.origin = origin;
+        this.origin = Objects.requireNonNull(origin);
     }
 
     private static final DynamicLongProperty MAX_OUTBOUND_READ_TIMEOUT_MS =

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOrigin.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOrigin.java
@@ -25,7 +25,6 @@ import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.config.CachedDynamicBooleanProperty;
 import com.netflix.config.CachedDynamicIntProperty;
-import com.netflix.loadbalancer.reactive.ExecutionContext;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
 import com.netflix.zuul.discovery.DiscoveryResult;
@@ -146,26 +145,6 @@ public class BasicNettyOrigin implements NettyOrigin {
     @Override
     public Registry getSpectatorRegistry() {
         return registry;
-    }
-
-    @Override
-    public ExecutionContext<?> getExecutionContext(HttpRequestMessage zuulRequest) {
-        ExecutionContext<?> execCtx = (ExecutionContext<?>) zuulRequest.getContext().get(CommonContextKeys.REST_EXECUTION_CONTEXT);
-        if (execCtx == null) {
-            IClientConfig overriddenClientConfig = (IClientConfig) zuulRequest.getContext().get(CommonContextKeys.REST_CLIENT_CONFIG);
-            if (overriddenClientConfig == null) {
-                overriddenClientConfig = new DefaultClientConfigImpl();
-                zuulRequest.getContext().put(CommonContextKeys.REST_CLIENT_CONFIG, overriddenClientConfig);
-            }
-
-            final ExecutionContext<?> context = new ExecutionContext<>(zuulRequest, overriddenClientConfig, this.config, null);
-            context.put("vip", getName().getTarget());
-            context.put("clientName", getName().getNiwsClientName());
-
-            zuulRequest.getContext().set(CommonContextKeys.REST_EXECUTION_CONTEXT, context);
-            execCtx = context;
-        }
-        return execCtx;
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/NettyOrigin.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/NettyOrigin.java
@@ -17,7 +17,6 @@
 package com.netflix.zuul.origins;
 
 import com.netflix.client.config.IClientConfig;
-import com.netflix.loadbalancer.reactive.ExecutionContext;
 import com.netflix.spectator.api.Registry;
 import com.netflix.zuul.discovery.DiscoveryResult;
 import com.netflix.zuul.context.SessionContext;

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/NettyOrigin.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/NettyOrigin.java
@@ -71,6 +71,4 @@ public interface NettyOrigin extends InstrumentedOrigin {
     IClientConfig getClientConfig();
 
     Registry getSpectatorRegistry();
-
-    ExecutionContext<?> getExecutionContext(HttpRequestMessage zuulRequest);
 }


### PR DESCRIPTION
This change is a stepping stone to revamping the timeout logic in `ProxyEndpoint`. I want to do it incrementally and also unblock removing `Ribbon` dependencies from `zuul-core`. 