### PR TITLE
Fix bug with updating server ref on origin connect failures

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -41,10 +41,10 @@ import com.netflix.config.DynamicIntegerSetProperty;
 import com.netflix.loadbalancer.reactive.ExecutionContext;
 import com.netflix.spectator.api.Counter;
 import com.netflix.zuul.Filter;
-import com.netflix.zuul.discovery.DiscoveryResult;
 import com.netflix.zuul.context.CommonContextKeys;
 import com.netflix.zuul.context.Debug;
 import com.netflix.zuul.context.SessionContext;
+import com.netflix.zuul.discovery.DiscoveryResult;
 import com.netflix.zuul.exception.ErrorType;
 import com.netflix.zuul.exception.OutboundErrorType;
 import com.netflix.zuul.exception.OutboundException;
@@ -468,7 +468,9 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
                 Integer readTimeout = null;
                 DiscoveryResult server = chosenServer.get();
 
-                // The discovery result lookup is EMPTY if the loadbalancer resolves no available servers.
+                /** TODO(argha-c): This reliance on mutable update of the `chosenServer` must be improved.
+                 * @see DiscoveryResult.EMPTY indicates that the loadbalancer found no available servers.
+                */
                 if (server != DiscoveryResult.EMPTY) {
                     if (currentRequestStat != null) {
                         currentRequestStat.server(server);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
@@ -326,13 +326,16 @@ public class DefaultClientChannelManager implements ClientChannelManager {
 
         // Choose the next load-balanced server.
         final DiscoveryResult chosenServer = dynamicServerResolver.resolve(key);
+
+        //(argha-c): Always ensure the selected server is updated, since the call chain relies on this mutation.
+        selectedServer.set(chosenServer);
         if (chosenServer == DiscoveryResult.EMPTY) {
             Promise<PooledConnection> promise = eventLoop.newPromise();
             promise.setFailure(new OriginConnectException("No servers available", OutboundErrorType.NO_AVAILABLE_SERVERS));
             return promise;
         }
 
-        selectedServer.set(chosenServer);
+
 
         // Now get the connection-pool for this server.
         IConnectionPool pool = perServerPools.computeIfAbsent(chosenServer, s -> {

--- a/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempt.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempt.java
@@ -104,7 +104,7 @@ public class RequestAttempt
         this.attempt = attemptNumber;
         this.readTimeout = readTimeout;
 
-        if (server != null) {
+        if (server != null && server != DiscoveryResult.EMPTY) {
             this.host = server.getHost();
             this.port = server.getPort();
             this.availabilityZone = server.getZone();

--- a/zuul-discovery/src/main/java/com/netflix/zuul/discovery/DiscoveryResult.java
+++ b/zuul-discovery/src/main/java/com/netflix/zuul/discovery/DiscoveryResult.java
@@ -56,6 +56,9 @@ public final class DiscoveryResult implements ResolverResult {
     }
 
     public Optional<String> getIPAddr() {
+        if (this == DiscoveryResult.EMPTY) {
+            return Optional.empty();
+        }
         if (server.getInstanceInfo() != null) {
             String ip = server.getInstanceInfo().getIPAddr();
             if (ip != null && !ip.isEmpty()) {


### PR DESCRIPTION
I believe this has been a long standing issue, for the case when there are no origin servers found.

While it's not clear how the previous null based checks hid this issue, the goal of this change is to ensure we always update the reference to the `chosenServer`, irrespective of origin connectivity results. 
With the recent changes, in case of origin connectivity failures, this value should be set to `DiscoveryResult.EMPTY` indicating an invalid discovery resolution result.