### PR TITLE
Replace JCenter with MavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ configurations.all {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Hi folks,

This is to stop using `jcenter()` as it is going away. `mavenCentral()` is preferred 