### PR TITLE
Simplify read timeout functionality and move to using Duration

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -379,6 +379,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
             attemptToChosenHostMap = new HashMap<>();
         }
 
+        // the chosen server can be null in the case of a timeout exception that skips acquiring a new origin connection
         if (chosenServer.get() != null) {
             String ipAddr = origin.getIpAddrFromServer(chosenServer.get());
             if (ipAddr != null) {
@@ -405,7 +406,11 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
         try {
             attemptNum += 1;
 
-            // compute how much time we have left for this attempt
+            /*
+             * Before connecting to the origin, we need to compute how much time we have left for this attempt. This
+             * method is also intended to validate deadline and timeouts boundaries for the request as a whole and could
+             * throw an exception, skipping the logic below.
+             */
             timeLeftForAttempt = originTimeoutManager.computeReadTimeout(zuulRequest, attemptNum);
 
             currentRequestStat = createRequestStat();

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ClientTimeoutHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ClientTimeoutHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AttributeKey;
+import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +35,7 @@ import org.slf4j.LoggerFactory;
 public final class ClientTimeoutHandler {
     private static final Logger LOG = LoggerFactory.getLogger(ClientTimeoutHandler.class);
 
-    public static final AttributeKey<Integer> ORIGIN_RESPONSE_READ_TIMEOUT = AttributeKey.newInstance("originResponseReadTimeout");
+    public static final AttributeKey<Duration> ORIGIN_RESPONSE_READ_TIMEOUT = AttributeKey.newInstance("originResponseReadTimeout");
 
     public static final class InboundHandler extends ChannelInboundHandlerAdapter {
         @Override
@@ -55,10 +56,10 @@ public final class ClientTimeoutHandler {
         @Override
         public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
             try {
-                final Integer timeout = ctx.channel().attr(ORIGIN_RESPONSE_READ_TIMEOUT).get();
+                final Duration timeout = ctx.channel().attr(ORIGIN_RESPONSE_READ_TIMEOUT).get();
                 if (timeout != null && msg instanceof LastHttpContent) {
                     promise.addListener(e -> {
-                        LOG.debug("[{}] Adding read timeout handler: {}", ctx.channel().id(), timeout);
+                        LOG.debug("[{}] Adding read timeout handler: {}", ctx.channel().id(), timeout.toMillis());
                         PooledConnection.getFromChannel(ctx.channel()).startReadTimeoutHandler(timeout);
                     });
                 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PooledConnection.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PooledConnection.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.util.AttributeKey;
+import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -223,9 +224,10 @@ public class PooledConnection {
         }
     }
 
-    public void startReadTimeoutHandler(int readTimeout)
+    public void startReadTimeoutHandler(Duration readTimeout)
     {
-        channel.pipeline().addBefore("originNettyLogger", READ_TIMEOUT_HANDLER_NAME, new ReadTimeoutHandler(readTimeout, TimeUnit.MILLISECONDS));
+        channel.pipeline().addBefore("originNettyLogger", READ_TIMEOUT_HANDLER_NAME,
+                new ReadTimeoutHandler(readTimeout.toMillis(), TimeUnit.MILLISECONDS));
     }
 
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManager.java
@@ -16,9 +16,7 @@
 
 package com.netflix.zuul.netty.timeouts;
 
-import static com.netflix.client.config.CommonClientConfigKey.ReadTimeout;
-
-import com.google.common.base.Strings;
+import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.config.DynamicLongProperty;
@@ -27,6 +25,7 @@ import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.origins.NettyOrigin;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
@@ -46,7 +45,38 @@ public class OriginTimeoutManager {
     private static final DynamicLongProperty MAX_OUTBOUND_READ_TIMEOUT_MS =
             new DynamicLongProperty("zuul.origin.readtimeout.max", Duration.ofSeconds(90).toMillis());
 
+    /**
+     * Derives the read timeout from the configuration.  This implementation prefers the longer of either the origin
+     * timeout or the request timeout.
+     * <p>
+     * This method can also be used to validate timeout and deadline boundaries and throw exceptions as needed. If
+     * extending this method to do validation, you should extend {@link com.netflix.zuul.exception.OutboundException}
+     * and set the appropriate {@link com.netflix.zuul.exception.ErrorType}.
+     *
+     * @param request    the request.
+     * @param attemptNum the attempt number, starting at 1.
+     */
+    public Duration computeReadTimeout(HttpRequestMessage request, int attemptNum) {
+        IClientConfig clientConfig = getRequestClientConfig(request);
+        Long originTimeout = getOriginReadTimeout();
+        Long requestTimeout = getRequestReadTimeout(clientConfig);
 
+        if (originTimeout == null && requestTimeout == null) {
+            return Duration.ofMillis(MAX_OUTBOUND_READ_TIMEOUT_MS.get());
+        } else if (originTimeout == null || requestTimeout == null) {
+            return Duration.ofMillis(originTimeout == null ? requestTimeout : originTimeout);
+        } else {
+            // return the stricter (i.e. lower) of two timeouts
+            return Duration.ofMillis(originTimeout > requestTimeout ? requestTimeout : originTimeout);
+        }
+    }
+
+    /**
+     * This method will create a new client config or retrieve the existing one from the current request.
+     *
+     * @param zuulRequest - the request
+     * @return the config
+     */
     protected IClientConfig getRequestClientConfig(HttpRequestMessage zuulRequest) {
         IClientConfig overriddenClientConfig =
                 (IClientConfig) zuulRequest.getContext().get(CommonContextKeys.REST_CLIENT_CONFIG);
@@ -59,54 +89,22 @@ public class OriginTimeoutManager {
     }
 
     /**
-     * Derives the read timeout from the configuration.  This implementation prefers the longer of either the origin
-     * timeout or the request timeout.
-     *
-     * @param request the request.
-     * @param attemptNum the attempt number, starting at 1.
+     * This method makes the assumption that the timeout is a numeric value
      */
-    public Duration computeReadTimeout(HttpRequestMessage request, int attemptNum) {
-        Long noTimeout = null;
-        // TODO(carl-mastrangelo): getProperty is deprecated, and suggests using the typed overload `get`.   However,
-        //  the value is parsed using parseReadTimeoutMs, which supports String, implying not all timeouts are Integer.
-        //  Figure out where a string ReadTimeout is coming from and replace it.
-        Long originTimeout = parseReadTimeoutMs(getOriginReadTimeout(noTimeout));
-        Long requestTimeout = parseReadTimeoutMs(getRequestReadTimeout(request, noTimeout));
-
-        if (originTimeout == null && requestTimeout == null) {
-            return Duration.ofMillis(MAX_OUTBOUND_READ_TIMEOUT_MS.get());
-        } else if (originTimeout == null || requestTimeout == null) {
-            return Duration.ofMillis(originTimeout == null ? requestTimeout : originTimeout);
-        } else {
-            // return the greater of two timeouts
-            return Duration.ofMillis(originTimeout > requestTimeout ? originTimeout : requestTimeout);
-        }
+    @Nullable
+    private Long getRequestReadTimeout(IClientConfig clientConfig) {
+        return Optional.ofNullable(clientConfig.get(CommonClientConfigKey.ReadTimeout))
+                .map(Long::valueOf)
+                .orElse(null);
     }
 
     /**
-     * An Integer is expected as an input, but supports parsing Long and String.  Returns {@code null} if no type is
-     * acceptable.
+     * This method makes the assumption that the timeout is a numeric value
      */
     @Nullable
-    private Long parseReadTimeoutMs(Object p) {
-        if (p instanceof String && !Strings.isNullOrEmpty((String) p)) {
-            return Long.valueOf((String) p);
-        } else if (p instanceof Long) {
-            return (Long) p;
-        } else if (p instanceof Integer) {
-            return Long.valueOf((Integer) p);
-        } else {
-            return null;
-        }
-    }
-
-    @Nullable
-    private Object getRequestReadTimeout(HttpRequestMessage zuulRequest, Long defaultTimeout) {
-        return getRequestClientConfig(zuulRequest).getProperty(ReadTimeout, defaultTimeout);
-    }
-
-    @Nullable
-    private Object getOriginReadTimeout(Long noTimeout) {
-        return origin.getClientConfig().getProperty(ReadTimeout, noTimeout);
+    private Long getOriginReadTimeout() {
+        return Optional.ofNullable(origin.getClientConfig().get(CommonClientConfigKey.ReadTimeout))
+                .map(Long::valueOf)
+                .orElse(null);
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempt.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempt.java
@@ -55,7 +55,7 @@ public class RequestAttempt
     private String vip;
     private String region;
     private String availabilityZone;
-    private int readTimeout;
+    private long readTimeout;
     private int connectTimeout;
     private int maxRetries;
 
@@ -209,7 +209,7 @@ public class RequestAttempt
         return exceptionType;
     }
 
-    public int getReadTimeout()
+    public long getReadTimeout()
     {
         return readTimeout;
     }
@@ -279,7 +279,7 @@ public class RequestAttempt
         this.availabilityZone = availabilityZone;
     }
 
-    public void setReadTimeout(int readTimeout)
+    public void setReadTimeout(long readTimeout)
     {
         this.readTimeout = readTimeout;
     }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
@@ -115,12 +115,12 @@ public class OriginTimeoutManagerTest {
 
     @Test
     public void computeReadTimeout_bolth_requestLower() {
-        requestConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
+        requestConfig.set(CommonClientConfigKey.ReadTimeout, 100);
         originConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
 
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
 
-        assertEquals(1000, timeout.toMillis());
+        assertEquals(100, timeout.toMillis());
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
 package com.netflix.zuul.netty.timeouts;
 
 import static com.netflix.zuul.netty.timeouts.OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS;

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
@@ -1,0 +1,121 @@
+package com.netflix.zuul.netty.timeouts;
+
+import static com.netflix.zuul.netty.timeouts.OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.netflix.client.config.CommonClientConfigKey;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfig;
+import com.netflix.zuul.context.CommonContextKeys;
+import com.netflix.zuul.context.SessionContext;
+import com.netflix.zuul.message.http.HttpRequestMessage;
+import com.netflix.zuul.origins.NettyOrigin;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Origin Timeout Manager Test
+ *
+ * @author Arthur Gonigberg
+ * @since March 23, 2021
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class OriginTimeoutManagerTest {
+
+    @Mock
+    private NettyOrigin origin;
+    @Mock
+    private HttpRequestMessage request;
+
+    private SessionContext context;
+    private IClientConfig requestConfig;
+    private IClientConfig originConfig;
+
+    private OriginTimeoutManager originTimeoutManager;
+
+    @Before
+    public void before() {
+        originTimeoutManager = new OriginTimeoutManager(origin);
+
+        context = new SessionContext();
+        when(request.getContext()).thenReturn(context);
+
+        requestConfig = new DefaultClientConfigImpl();
+        originConfig = new DefaultClientConfigImpl();
+
+        context.put(CommonContextKeys.REST_CLIENT_CONFIG, requestConfig);
+        when(origin.getClientConfig()).thenReturn(originConfig);
+    }
+
+    @Test
+    public void computeReadTimeout_default() {
+        Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
+
+        assertEquals(MAX_OUTBOUND_READ_TIMEOUT_MS.get(), timeout.toMillis());
+    }
+
+    @Test
+    public void computeReadTimeout_requestOnly() {
+        requestConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
+
+        Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
+
+        assertEquals(1000, timeout.toMillis());
+    }
+
+    @Test
+    public void computeReadTimeout_originOnly() {
+        originConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
+
+        Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
+
+        assertEquals(1000, timeout.toMillis());
+    }
+
+    @Test
+    public void computeReadTimeout_bolth_equal() {
+        requestConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
+        originConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
+
+        Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
+
+        assertEquals(1000, timeout.toMillis());
+    }
+
+    @Test
+    public void computeReadTimeout_bolth_originLower() {
+        requestConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
+        originConfig.set(CommonClientConfigKey.ReadTimeout, 100);
+
+        Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
+
+        assertEquals(100, timeout.toMillis());
+    }
+
+    @Test
+    public void computeReadTimeout_bolth_requestLower() {
+        requestConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
+        originConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
+
+        Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
+
+        assertEquals(1000, timeout.toMillis());
+    }
+
+    @Test
+    public void computeReadTimeout_bolth_enforceMax() {
+        requestConfig.set(CommonClientConfigKey.ReadTimeout,
+                (int) MAX_OUTBOUND_READ_TIMEOUT_MS.get() + 1000);
+        originConfig.set(CommonClientConfigKey.ReadTimeout,
+                (int) MAX_OUTBOUND_READ_TIMEOUT_MS.get() + 10000);
+
+        Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
+
+        assertEquals(MAX_OUTBOUND_READ_TIMEOUT_MS.get(), timeout.toMillis());
+    }
+}


### PR DESCRIPTION
This is a fairly large refactoring of how timeouts work in `ProxyEndpoint`. I've simplified the logic by removing the ability to use `ExecutionListeners` (from Ribbon) to modify timeout settings. By removing that feature, we no longer need to set the timeout on the `ClientConfig` object repeatedly. Now, we can have a single `Duration` field that we re-compute on each attempt, with no machinery required to pull things in and out of the request config and origin config. In fact, those configs remain completely untouched through proxying, meaning we also don't have to reset them when we're done with each computation.