### PR TITLE
Set statuscategory explicitly for http pipelining

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/HttpLifecycleChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/HttpLifecycleChannelHandler.java
@@ -59,7 +59,6 @@ public abstract class HttpLifecycleChannelHandler {
                     "Closing the connection now. channel = " + channel.id().asLongText());
             channel.attr(ATTR_HTTP_PIPELINE_REJECT).set(Boolean.TRUE);
             channel.close();
-            ctx.pipeline().fireUserEventTriggered(new RejectedPipeliningEvent());
             return false;
         }
         
@@ -177,7 +176,5 @@ public abstract class HttpLifecycleChannelHandler {
             return response;
         }
     }
-    
-    public static class RejectedPipeliningEvent
-    {}
+
 }

--- a/zuul-core/src/main/java/com/netflix/netty/common/HttpLifecycleChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/HttpLifecycleChannelHandler.java
@@ -37,7 +37,8 @@ public abstract class HttpLifecycleChannelHandler {
 
     public static final AttributeKey<HttpRequest> ATTR_HTTP_REQ = AttributeKey.newInstance("_http_request");
     public static final AttributeKey<HttpResponse> ATTR_HTTP_RESP = AttributeKey.newInstance("_http_response");
-    
+    public static final AttributeKey<Boolean> ATTR_HTTP_PIPELINE_REJECT = AttributeKey.newInstance("_http_pipeline_reject");
+
     protected enum State {
         STARTED, COMPLETED
     }
@@ -56,6 +57,7 @@ public abstract class HttpLifecycleChannelHandler {
             // without waiting for the response from the first. And we don't support HTTP Pipelining.
             LOG.error("Received a http request on connection where we already have a request being processed. " +
                     "Closing the connection now. channel = " + channel.id().asLongText());
+            channel.attr(ATTR_HTTP_PIPELINE_REJECT).set(Boolean.TRUE);
             channel.close();
             ctx.pipeline().fireUserEventTriggered(new RejectedPipeliningEvent());
             return false;
@@ -105,7 +107,7 @@ public abstract class HttpLifecycleChannelHandler {
 //        IDLE,
         DISCONNECT,
         DEREGISTER,
-//        PIPELINE_REJECT,
+        PIPELINE_REJECT,
         EXCEPTION,
         CLOSE
 //        FAILURE_CLIENT_CANCELLED,

--- a/zuul-core/src/main/java/com/netflix/netty/common/HttpServerLifecycleChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/HttpServerLifecycleChannelHandler.java
@@ -107,9 +107,12 @@ public final class HttpServerLifecycleChannelHandler extends HttpLifecycleChanne
         public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception
         {
             addPassportState(ctx, PassportState.SERVER_CH_CLOSE);
-            
-            fireCompleteEventIfNotAlready(ctx, CompleteReason.CLOSE);
-
+            // This will likely expand based on more specific reasons for completion
+            if (ctx.channel().attr(HttpLifecycleChannelHandler.ATTR_HTTP_PIPELINE_REJECT).get() == null) {
+                fireCompleteEventIfNotAlready(ctx, CompleteReason.CLOSE);
+            } else {
+                fireCompleteEventIfNotAlready(ctx, CompleteReason.PIPELINE_REJECT);
+            }
             super.close(ctx, promise);
         }
 

--- a/zuul-core/src/main/java/com/netflix/netty/common/metrics/HttpMetricsChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/metrics/HttpMetricsChannelHandler.java
@@ -16,6 +16,8 @@
 
 package com.netflix.netty.common.metrics;
 
+import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
+import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
 import com.netflix.netty.common.HttpServerLifecycleChannelHandler;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Gauge;
@@ -84,13 +86,12 @@ public class HttpMetricsChannelHandler extends ChannelInboundHandlerAdapter
         if (evt instanceof HttpServerLifecycleChannelHandler.StartEvent) {
             incrementCurrentRequestsInFlight(ctx);
         }
+        else if (evt instanceof HttpServerLifecycleChannelHandler.CompleteEvent && ((CompleteEvent) evt).getReason() == CompleteReason.PIPELINE_REJECT ) {
+            unSupportedPipeliningCounter.increment();
+        }
         else if (evt instanceof HttpServerLifecycleChannelHandler.CompleteEvent) {
             decrementCurrentRequestsIfOneInflight(ctx);
         }
-        else if (evt instanceof HttpLifecycleChannelHandler.RejectedPipeliningEvent) {
-            unSupportedPipeliningCounter.increment();
-        }
-
         super.userEventTriggered(ctx, evt);
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
@@ -108,10 +108,6 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
             fireEndpointFinish(true);
             ctx.close();
         }
-        else if (evt instanceof HttpLifecycleChannelHandler.RejectedPipeliningEvent) {
-            sendResponse(FAILURE_CLIENT_PIPELINE_REJECT, 400, ctx);
-        }
-
         super.userEventTriggered(ctx, evt);
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -21,6 +21,7 @@ import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReaso
 import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason.SESSION_COMPLETE;
 import static com.netflix.zuul.netty.server.http2.Http2OrHttpHandler.PROTOCOL_NAME;
 
+import com.netflix.netty.common.HttpLifecycleChannelHandler;
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.netty.common.ssl.SslHandshakeInfo;
 import com.netflix.netty.common.throttle.RejectionUtils;
@@ -202,6 +203,10 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
             if (reason == CompleteReason.INACTIVE && zuulRequest != null) {
                 // Client closed connection prematurely.
                 StatusCategoryUtils.setStatusCategory(zuulRequest.getContext(), ZuulStatusCategory.FAILURE_CLIENT_CANCELLED);
+            }
+
+            if (reason == CompleteReason.PIPELINE_REJECT && zuulRequest != null) {
+                    StatusCategoryUtils.setStatusCategory(zuulRequest.getContext(), ZuulStatusCategory.FAILURE_CLIENT_PIPELINE_REJECT);
             }
 
             if (reason != SESSION_COMPLETE && zuulRequest != null) {


### PR DESCRIPTION
Currently, while we reject pipelining correctly, the propagation of the `close` fails to update the status category accurately.
This makes the original request category to default to `SUCCESS_LOCAL_NOTSET`, which is misleading.

This attempts to set an explicit category for when we reject a request, based on pipelining.