### PR TITLE
zuul-guice: update to Guice 5

### DIFF
--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -271,7 +271,7 @@
             "locked": "1.68"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.29"
@@ -473,7 +473,7 @@
             "locked": "1.68"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25"
@@ -583,7 +583,7 @@
             "locked": "1.68"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-discovery/dependencies.lock
+++ b/zuul-discovery/dependencies.lock
@@ -85,7 +85,7 @@
             "locked": "4.13"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.21"
@@ -146,7 +146,7 @@
             "locked": "4.13"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25"
@@ -178,7 +178,7 @@
             "locked": "4.13"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25"

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -401,7 +401,7 @@
             "locked": "3.0.3"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.21"
@@ -699,7 +699,7 @@
             "locked": "3.0.3"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -882,7 +882,7 @@
             "locked": "3.0.3"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-guice/build.gradle
+++ b/zuul-guice/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "java-library"
 
 dependencies {
     implementation project(":zuul-core")
-    api(group: 'com.google.inject', name: 'guice', version: "4.2.3", classifier: "no_aop")
+    api(group: 'com.google.inject', name: 'guice', version: "5.0.1")
     implementation 'commons-configuration:commons-configuration:1.8'
 
     testImplementation libraries.junit,

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -7,7 +7,7 @@
             "locked": "2.12.1"
         },
         "com.google.inject:guice": {
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -122,7 +122,7 @@
             "locked": "2.12.1"
         },
         "com.google.inject:guice": {
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -245,10 +245,10 @@
                 "com.netflix.zuul:zuul-core",
                 "com.netflix.zuul:zuul-discovery"
             ],
-            "locked": "29.0-jre"
+            "locked": "30.1-jre"
         },
         "com.google.inject:guice": {
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.google.truth:truth": {
             "locked": "1.0.1"
@@ -404,7 +404,7 @@
             "locked": "1.68"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.21"
@@ -438,10 +438,10 @@
                 "com.netflix.zuul:zuul-core",
                 "com.netflix.zuul:zuul-discovery"
             ],
-            "locked": "29.0-jre"
+            "locked": "30.1-jre"
         },
         "com.google.inject:guice": {
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -606,7 +606,7 @@
             "locked": "2.12.1"
         },
         "com.google.inject:guice": {
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.google.truth:truth": {
             "locked": "1.0.1"
@@ -705,7 +705,7 @@
             "locked": "4.13.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -732,10 +732,10 @@
                 "com.netflix.zuul:zuul-core",
                 "com.netflix.zuul:zuul-discovery"
             ],
-            "locked": "29.0-jre"
+            "locked": "30.1-jre"
         },
         "com.google.inject:guice": {
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.google.truth:truth": {
             "locked": "1.0.1"
@@ -891,7 +891,7 @@
             "locked": "1.68"
         },
         "org.mockito:mockito-core": {
-            "locked": "3.8.0"
+            "locked": "3.9.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -189,7 +189,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-guice"
             ],
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -319,7 +319,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-guice"
             ],
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -455,13 +455,13 @@
                 "com.netflix.zuul:zuul-discovery",
                 "com.netflix.zuul:zuul-groovy"
             ],
-            "locked": "29.0-jre"
+            "locked": "30.1-jre"
         },
         "com.google.inject:guice": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-guice"
             ],
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -668,13 +668,13 @@
                 "com.netflix.zuul:zuul-discovery",
                 "com.netflix.zuul:zuul-groovy"
             ],
-            "locked": "29.0-jre"
+            "locked": "30.1-jre"
         },
         "com.google.inject:guice": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-guice"
             ],
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -867,7 +867,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-guice"
             ],
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -997,13 +997,13 @@
                 "com.netflix.zuul:zuul-discovery",
                 "com.netflix.zuul:zuul-groovy"
             ],
-            "locked": "29.0-jre"
+            "locked": "30.1-jre"
         },
         "com.google.inject:guice": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-guice"
             ],
-            "locked": "4.2.3"
+            "locked": "5.0.1"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [


### PR DESCRIPTION
This is needed to run on later JDKs than 11, as it uses a better maintained classfile generator.   From my reading, it is API compatible with Guice 4.2.

"