### PR TITLE
Add Typesafe session context accessors 

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
@@ -16,6 +16,9 @@
 
 package com.netflix.zuul.context;
 
+import com.netflix.zuul.niws.RequestAttempts;
+import com.netflix.zuul.stats.status.StatusCategory;
+
 /**
  * Common Context Keys
  *
@@ -24,10 +27,13 @@ package com.netflix.zuul.context;
  */
 public class CommonContextKeys {
 
-    public static final String STATUS_CATGEORY = "status_category";
-    public static final String ORIGIN_STATUS_CATEGORY = "origin_status_category";
-    public static final String ORIGIN_STATUS = "origin_status";
-    public static final String REQUEST_ATTEMPTS = "request_attempts";
+    public static final SessionContext.Key<StatusCategory> STATUS_CATGEORY =
+            SessionContext.newKey("status_category");
+    public static final SessionContext.Key<StatusCategory> ORIGIN_STATUS_CATEGORY =
+            SessionContext.newKey("origin_status_category");
+    public static final SessionContext.Key<Integer>  ORIGIN_STATUS = SessionContext.newKey("origin_status");
+    public static final SessionContext.Key<RequestAttempts> REQUEST_ATTEMPTS =
+            SessionContext.newKey("request_attempts");
 
     public static final String REST_CLIENT_CONFIG = "rest_client_config";
     public static final String REST_EXECUTION_CONTEXT = "rest_exec_ctx";

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -827,7 +827,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
         // Collect some info about the received response.
         origin.recordFinalResponse(zuulResponse);
         origin.recordFinalError(zuulRequest, ex);
-        zuulCtx.set(CommonContextKeys.STATUS_CATGEORY, statusCategory);
+        zuulCtx.put(CommonContextKeys.STATUS_CATGEORY, statusCategory);
         zuulCtx.setError(ex);
         zuulCtx.put("origin_http_status", Integer.toString(respStatus));
 
@@ -1082,7 +1082,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
     private void verifyOrigin(SessionContext context, HttpRequestMessage request, String restClientName, Origin primaryOrigin) {
         if (primaryOrigin == null) {
             // If no origin found then add specific error-cause metric tag, and throw an exception with 404 status.
-            context.set(CommonContextKeys.STATUS_CATGEORY, SUCCESS_LOCAL_NO_ROUTE);
+            context.put(CommonContextKeys.STATUS_CATGEORY, SUCCESS_LOCAL_NO_ROUTE);
             String causeName = "RESTCLIENT_NOTFOUND";
             originNotFound(context, causeName);
             ZuulException ze = new ZuulException("No origin found for request. name=" + restClientName

--- a/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempts.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempts.java
@@ -56,7 +56,7 @@ public class RequestAttempts extends ArrayList<RequestAttempt>
 
     public static RequestAttempts getFromSessionContext(SessionContext ctx)
     {
-        return (RequestAttempts) ctx.get(CommonContextKeys.REQUEST_ATTEMPTS);
+        return ctx.get(CommonContextKeys.REQUEST_ATTEMPTS);
     }
 
     public static RequestAttempts parse(String attemptsJson) throws IOException

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOrigin.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOrigin.java
@@ -158,8 +158,8 @@ public class BasicNettyOrigin implements NettyOrigin {
         // Choose StatusCategory based on the ErrorType.
         final ErrorType et = requestAttemptFactory.mapNettyToOutboundErrorType(throwable);
         final StatusCategory nfs = et.getStatusCategory();
-        zuulCtx.set(CommonContextKeys.STATUS_CATGEORY, nfs);
-        zuulCtx.set(CommonContextKeys.ORIGIN_STATUS_CATEGORY, nfs);
+        zuulCtx.put(CommonContextKeys.STATUS_CATGEORY, nfs);
+        zuulCtx.put(CommonContextKeys.ORIGIN_STATUS_CATEGORY, nfs);
 
         zuulCtx.setError(throwable);
     }
@@ -171,7 +171,7 @@ public class BasicNettyOrigin implements NettyOrigin {
 
             // Store the status code of final attempt response.
             int originStatusCode = resp.getStatus();
-            zuulCtx.set(CommonContextKeys.ORIGIN_STATUS, originStatusCode);
+            zuulCtx.put(CommonContextKeys.ORIGIN_STATUS, originStatusCode);
 
             // Mark origin StatusCategory based on http status code.
             StatusCategory originNfs = SUCCESS;
@@ -181,7 +181,7 @@ public class BasicNettyOrigin implements NettyOrigin {
             else if (StatusCategoryUtils.isResponseHttpErrorStatus(originStatusCode)) {
                 originNfs = FAILURE_ORIGIN;
             }
-            zuulCtx.set(CommonContextKeys.ORIGIN_STATUS_CATEGORY, originNfs);
+            zuulCtx.put(CommonContextKeys.ORIGIN_STATUS_CATEGORY, originNfs);
             // Choose the zuul StatusCategory based on the origin one...
             // ... but only if existing one has not already been set to a non-success value.
             StatusCategoryUtils.storeStatusCategoryIfNotAlreadyFailure(zuulCtx, originNfs);

--- a/zuul-core/src/main/java/com/netflix/zuul/stats/status/StatusCategoryUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/stats/status/StatusCategoryUtils.java
@@ -20,6 +20,7 @@ import com.netflix.zuul.context.CommonContextKeys;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.ZuulMessage;
 import com.netflix.zuul.message.http.HttpResponseMessage;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,16 +36,18 @@ public class StatusCategoryUtils {
         return getStatusCategory(msg.getContext());
     }
 
+    @Nullable
     public static StatusCategory getStatusCategory(SessionContext ctx) {
-        return (StatusCategory) ctx.get(CommonContextKeys.STATUS_CATGEORY);
+        return ctx.get(CommonContextKeys.STATUS_CATGEORY);
     }
 
     public static void setStatusCategory(SessionContext ctx, StatusCategory statusCategory) {
-        ctx.set(CommonContextKeys.STATUS_CATGEORY, statusCategory);
+        ctx.put(CommonContextKeys.STATUS_CATGEORY, statusCategory);
     }
 
+    @Nullable
     public static StatusCategory getOriginStatusCategory(SessionContext ctx) {
-        return (StatusCategory) ctx.get(CommonContextKeys.ORIGIN_STATUS_CATEGORY);
+        return ctx.get(CommonContextKeys.ORIGIN_STATUS_CATEGORY);
     }
 
     public static boolean isResponseHttpErrorStatus(HttpResponseMessage response) {
@@ -60,11 +63,12 @@ public class StatusCategoryUtils {
         return (status < 100 || status >= 500);
     }
 
-    public static void storeStatusCategoryIfNotAlreadyFailure(final SessionContext context, final StatusCategory statusCategory) {
+    public static void storeStatusCategoryIfNotAlreadyFailure(
+            final SessionContext context, final StatusCategory statusCategory) {
         if (statusCategory != null) {
-            final StatusCategory nfs = (StatusCategory) context.get(CommonContextKeys.STATUS_CATGEORY);
+            final StatusCategory nfs = context.get(CommonContextKeys.STATUS_CATGEORY);
             if (nfs == null || nfs.getGroup().getId() == ZuulStatusCategoryGroup.SUCCESS.getId()) {
-                context.set(CommonContextKeys.STATUS_CATGEORY, statusCategory);
+                context.put(CommonContextKeys.STATUS_CATGEORY, statusCategory);
             }
         }
     }

--- a/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
@@ -16,7 +16,11 @@
 package com.netflix.zuul.context;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
+import com.google.common.truth.Truth;
+import com.netflix.zuul.context.SessionContext.Key;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -29,5 +33,65 @@ public class SessionContextTest {
         SessionContext context = new SessionContext();
         assertEquals(context.getBoolean("boolean_test"), Boolean.FALSE);
         assertEquals(context.getBoolean("boolean_test", true), true);
+    }
+
+    @Test
+    public void keysAreUnique() {
+        SessionContext context = new SessionContext();
+        Key<String> key1 = SessionContext.newKey("foo");
+        context.put(key1, "bar");
+        Key<String> key2 = SessionContext.newKey("foo");
+        context.put(key2, "baz");
+
+        Truth.assertThat(context.keys()).containsExactly(key1, key2);
+    }
+
+    @Test
+    public void newKeyFailsOnNull() {
+        assertThrows(NullPointerException.class, () -> SessionContext.newKey(null));
+    }
+
+    @Test
+    public void putFailsOnNull() {
+        SessionContext context = new SessionContext();
+        Key<String> key = SessionContext.newKey("foo");
+
+        assertThrows(NullPointerException.class, () -> context.put(key, null));
+    }
+
+    @Test
+    public void putReplacesOld() {
+        SessionContext context = new SessionContext();
+        Key<String> key = SessionContext.newKey("foo");
+        context.put(key, "bar");
+        context.put(key, "baz");
+
+        assertEquals("baz", context.get(key));
+        Truth.assertThat(context.keys()).containsExactly(key);
+    }
+
+    @Test
+    public void getReturnsNull() {
+        SessionContext context = new SessionContext();
+        Key<String> key = SessionContext.newKey("foo");
+
+        assertNull(context.get(key));
+    }
+
+    @Test
+    public void getOrDefault_picksDefault() {
+        SessionContext context = new SessionContext();
+        Key<String> key = SessionContext.newKey("foo");
+
+        assertEquals("bar", context.getOrDefault(key, "bar"));
+    }
+
+    @Test
+    public void getOrDefault_failsOnNullDefault() {
+        SessionContext context = new SessionContext();
+        Key<String> key = SessionContext.newKey("foo");
+        context.put(key, "bar");
+
+        assertThrows(NullPointerException.class, () -> context.getOrDefault(key, null));
     }
 }


### PR DESCRIPTION
These accessors are more typesafe than the string based ones, and make cross referencing usage easier.  In addition they are strict about null safety, making it hard for unexpected nulls to be present in the session context.