### PR TITLE
Fix ConcurrentModificationException when calling getBodyLength

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
@@ -17,6 +17,7 @@ package com.netflix.zuul.message;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.netflix.config.DynamicIntProperty;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.zuul.context.SessionContext;
@@ -167,7 +168,7 @@ public class ZuulMessageImpl implements ZuulMessage
     @Override
     public int getBodyLength() {
         int size = 0;
-        for (final HttpContent chunk : bodyChunks) {
+        for (final HttpContent chunk : ImmutableList.copyOf(bodyChunks)) {
             size += chunk.content().readableBytes();
         }
         return size;

--- a/zuul-core/src/test/java/com/netflix/zuul/message/ZuulMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/ZuulMessageImplTest.java
@@ -144,4 +144,18 @@ public class ZuulMessageImplTest {
         assertTrue(msg.hasCompleteBody());
         assertEquals("Goodbye World!", body);
     }
+
+    @Test
+    public void testGetBodyLength() {
+        final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
+        String body1 = "Hello World!";
+        msg.setBody(body1.getBytes());
+        assertTrue(msg.hasCompleteBody());
+        assertEquals(body1.getBytes().length, msg.getBodyLength());
+
+        String body2 = "Foobar";
+        msg.setBody(body2.getBytes());
+        assertTrue(msg.hasCompleteBody());
+        assertEquals(body2.getBytes().length, msg.getBodyLength());
+    }
 }


### PR DESCRIPTION
Calling ZuulMessageImpl.getBodyLength can sometimes trigger this exception. My assumption is that it happens when the `bodyChunks` list is modified while the method is iterating through it.

```
java.util.ConcurrentModificationException: 
  at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013)
  at java.util.ArrayList$Itr.next(ArrayList.java:967)
  at com.netflix.zuul.message.ZuulMessageImpl.getBodyLength(ZuulMessageImpl.java:170)
  at com.netflix.zuul.message.http.HttpRequestMessageImpl.getBodyLength(HttpRequestMessageImpl.java:218)
  ```

I didn't use `getBodyContents` because that wraps it in `Collections.unmodifiableList` which doesn't prevent ConcurrentModificationExceptions if the underlying list is modified.