### PR TITLE
Use a metric instead of logging excessive filter execution time

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
@@ -85,7 +85,8 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
     private final Registry registry;
     private final Id filterExcessiveTimerId;
 
-    protected BaseZuulFilterRunner(FilterType filterType, FilterUsageNotifier usageNotifier, FilterRunner<O, ?> nextStage, Registry registry) {
+    protected BaseZuulFilterRunner(FilterType filterType, FilterUsageNotifier usageNotifier,
+                                   FilterRunner<O, ?> nextStage, Registry registry) {
         this.usageNotifier = Preconditions.checkNotNull(usageNotifier, "filter usage notifier");
         this.nextStage = nextStage;
         this.RUNNING_FILTER_IDX_SESSION_CTX_KEY = filterType + "RunningFilterIndex";

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulEndPointRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulEndPointRunner.java
@@ -18,6 +18,7 @@ package com.netflix.zuul.netty.filter;
 
 import com.google.common.base.Strings;
 import com.netflix.config.DynamicStringProperty;
+import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.impl.Preconditions;
 import com.netflix.zuul.FilterLoader;
 import com.netflix.zuul.FilterUsageNotifier;
@@ -59,8 +60,8 @@ public class ZuulEndPointRunner extends BaseZuulFilterRunner<HttpRequestMessage,
 
 
     public ZuulEndPointRunner(FilterUsageNotifier usageNotifier, FilterLoader filterLoader,
-                              FilterRunner<HttpResponseMessage, HttpResponseMessage> respFilters) {
-        super(FilterType.ENDPOINT, usageNotifier, respFilters);
+                              FilterRunner<HttpResponseMessage, HttpResponseMessage> respFilters, Registry registry) {
+        super(FilterType.ENDPOINT, usageNotifier, respFilters, registry);
         this.filterLoader = filterLoader;
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunner.java
@@ -16,6 +16,7 @@
 
 package com.netflix.zuul.netty.filter;
 
+import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.impl.Preconditions;
 import com.netflix.zuul.FilterUsageNotifier;
 import com.netflix.zuul.filters.ZuulFilter;
@@ -40,13 +41,14 @@ public class ZuulFilterChainRunner<T extends ZuulMessage> extends BaseZuulFilter
 
     private final ZuulFilter<T, T>[] filters;
 
-    public ZuulFilterChainRunner(ZuulFilter<T, T>[] zuulFilters, FilterUsageNotifier usageNotifier, FilterRunner<T, ?> nextStage) {
-        super(zuulFilters[0].filterType(), usageNotifier, nextStage);
+    public ZuulFilterChainRunner(ZuulFilter<T, T>[] zuulFilters, FilterUsageNotifier usageNotifier,
+                                 FilterRunner<T, ?> nextStage, Registry registry) {
+        super(zuulFilters[0].filterType(), usageNotifier, nextStage, registry);
         this.filters = zuulFilters;
     }
 
-    public ZuulFilterChainRunner(ZuulFilter<T, T>[] zuulFilters, FilterUsageNotifier usageNotifier) {
-        this(zuulFilters, usageNotifier, null);
+    public ZuulFilterChainRunner(ZuulFilter<T, T>[] zuulFilters, FilterUsageNotifier usageNotifier, Registry registry) {
+        this(zuulFilters, usageNotifier, null, registry);
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
@@ -336,18 +336,18 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
 
     protected ZuulEndPointRunner getEndpointRunner(ZuulFilterChainRunner<HttpResponseMessage> responseFilterChain,
                                                    FilterUsageNotifier filterUsageNotifier, FilterLoader filterLoader) {
-        return new ZuulEndPointRunner(filterUsageNotifier, filterLoader, responseFilterChain);
+        return new ZuulEndPointRunner(filterUsageNotifier, filterLoader, responseFilterChain, registry);
     }
 
     protected <T extends ZuulMessage> ZuulFilterChainRunner<T> getFilterChainRunner(ZuulFilter<T, T>[] filters,
                                                                                     FilterUsageNotifier filterUsageNotifier) {
-        return new ZuulFilterChainRunner<>(filters, filterUsageNotifier);
+        return new ZuulFilterChainRunner<>(filters, filterUsageNotifier, registry);
     }
 
     protected <T extends ZuulMessage, R extends ZuulMessage> ZuulFilterChainRunner<T> getFilterChainRunner(ZuulFilter<T, T>[] filters,
                                                                                     FilterUsageNotifier filterUsageNotifier,
                                                                                     FilterRunner<T, R> filterRunner) {
-        return new ZuulFilterChainRunner<>(filters, filterUsageNotifier, filterRunner);
+        return new ZuulFilterChainRunner<>(filters, filterUsageNotifier, filterRunner, registry);
     }
 
     @SuppressWarnings("unchecked") // For the conversion from getFiltersByType.  It's not safe, sorry.


### PR DESCRIPTION
The information logged here can be useful, but when Zuul slows down these messages will drown out more useful log entries (which may point at the root cause). This data is more useful as a metric.