### PR TITLE
Store remote address from ppv2 in new attribute

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/SourceAddressChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/SourceAddressChannelHandler.java
@@ -47,7 +47,13 @@ public final class SourceAddressChannelHandler extends ChannelInboundHandlerAdap
     public static final AttributeKey<SocketAddress> ATTR_REMOTE_ADDR = AttributeKey.newInstance("_remote_addr");
 
     /**
-     * Indicates the destination address received from Proxy Protocol. Not set otherwise
+     * Indicates the source (remote) address received from Proxy Protocol. Not set otherwise.
+     */
+    public static final AttributeKey<InetSocketAddress> ATTR_PROXY_PROTOCOL_REMOTE_ADDRESS =
+            AttributeKey.newInstance("_proxy_protocol_remote_address");
+
+    /**
+     * Indicates the destination address received from Proxy Protocol. Not set otherwise.
      */
     public static final AttributeKey<InetSocketAddress> ATTR_PROXY_PROTOCOL_DESTINATION_ADDRESS =
             AttributeKey.newInstance("_proxy_protocol_destination_address");

--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/HAProxyMessageChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/HAProxyMessageChannelHandler.java
@@ -99,8 +99,11 @@ public final class HAProxyMessageChannelHandler extends ChannelInboundHandlerAda
                             throw new IllegalArgumentException("unknown proxy protocl" + sourceAddress);
                         case TCP4:
                         case TCP6:
-                            addr = new InetSocketAddress(
+                            InetSocketAddress inetAddr = new InetSocketAddress(
                                     InetAddresses.forString(sourceAddress), hapm.sourcePort());
+                            addr = inetAddr;
+                            // setting PPv2 explicitly because SourceAddressChannelHandler.ATTR_REMOTE_ADDR could be PPv2 or not
+                            channel.attr(SourceAddressChannelHandler.ATTR_PROXY_PROTOCOL_REMOTE_ADDRESS).set(inetAddr);
                             break out;
                         case UNIX_STREAM: // TODO: implement
                         case UDP4:

--- a/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
@@ -61,7 +61,7 @@ public class CommonContextKeys {
     public static final String ORIGIN_VIP_SECURE = "origin_vip_secure";
 
     /**
-     * The original client destination address Zuul by a proxy running Proxy Protocol.
+     * The original client destination address reported to Zuul by a proxy running Proxy Protocol.
      * Will only be set if both Zuul and the connected proxy are both using set to use Proxy Protocol.
      */
     public static final String PROXY_PROTOCOL_DESTINATION_ADDRESS = "proxy_protocol_destination_address";


### PR DESCRIPTION
Adding a new channel attribute ATTR_PROXY_PROTOCOL_REMOTE_ADDRESS to store PPv2 client source (remote) address.
This can be used to pull information set via PPv2.