### PR TITLE
netty 4.1.71

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 versions_groovy=3.0.9
 versions_ribbon=2.4.4
-versions_netty=4.1.69.Final
+versions_netty=4.1.71.Final
 release.scope=patch
 release.version=2.3.1-SNAPSHOT

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -31,34 +31,34 @@
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"
@@ -122,34 +122,34 @@
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"
@@ -238,37 +238,37 @@
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.44.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"
@@ -366,37 +366,37 @@
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.44.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"
@@ -455,34 +455,34 @@
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"
@@ -568,37 +568,37 @@
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.44.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -58,43 +58,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -179,43 +179,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -326,43 +326,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -374,19 +374,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -519,43 +519,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -567,19 +567,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -678,43 +678,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -825,43 +825,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -873,19 +873,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -61,43 +61,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -182,43 +182,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -332,43 +332,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -380,19 +380,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -534,43 +534,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -582,19 +582,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -699,43 +699,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -849,43 +849,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -897,19 +897,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -58,43 +58,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -176,43 +176,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -320,43 +320,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -368,19 +368,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -513,43 +513,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -561,19 +561,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -704,43 +704,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -752,19 +752,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -866,43 +866,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1007,43 +1007,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1055,19 +1055,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -90,43 +90,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -138,19 +138,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -261,43 +261,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -397,43 +397,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -567,43 +567,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -615,19 +615,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -792,43 +792,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -840,19 +840,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -975,43 +975,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1139,43 +1139,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1187,19 +1187,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION

https://netty.io/news/2021/12/09/4-1-71-Final.html

```
This is mainly a bug-fix release but also contains a fix
for HTTP-request-smuggling and fixes a regression in SslHandler. 
Because of this we urge everyone to upgrade as soon as possible.
```

https://twitter.com/normanmaurer/status/1468959477760102412

