### PR TITLE
all: upgrade to Netty 4.1.71

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 versions_groovy=3.0.9
 versions_ribbon=2.4.4
-versions_netty=4.1.69.Final
+versions_netty=4.1.71.Final
 release.scope=patch
 release.version=2.3.1-SNAPSHOT

--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -23,19 +23,18 @@ dependencies {
     api "com.netflix.eureka:eureka-client:1.9.18"
     api "io.reactivex:rxjava:1.3.8"
 
-    api platform("io.netty:netty-bom:${versions_netty}")
     // TODO(carl-mastrangelo): some of these could probably be implementation.   Do a deeper check.
-    api "io.netty:netty-common"
-    api "io.netty:netty-buffer"
-    api "io.netty:netty-codec-http"
-    api "io.netty:netty-codec-http2"
-    api "io.netty:netty-handler"
-    api "io.netty:netty-transport"
+    api "io.netty:netty-common:${versions_netty}"
+    api "io.netty:netty-buffer:${versions_netty}"
+    api "io.netty:netty-codec-http:${versions_netty}"
+    api "io.netty:netty-codec-http2:${versions_netty}"
+    api "io.netty:netty-handler:${versions_netty}"
+    api "io.netty:netty-transport:${versions_netty}"
 
-    implementation "io.netty:netty-codec-haproxy"
-    implementation "io.netty:netty-transport-native-epoll"
-    implementation "io.netty:netty-transport-native-kqueue"
-    runtimeOnly "io.netty:netty-tcnative-boringssl-static"
+    implementation "io.netty:netty-codec-haproxy:${versions_netty}"
+    implementation "io.netty:netty-transport-native-epoll:${versions_netty}:linux-x86_64"
+    implementation "io.netty:netty-transport-native-kqueue:${versions_netty}:osx-x86_64"
+    runtimeOnly "io.netty:netty-tcnative-boringssl-static:2.0.46.Final"
 
     implementation 'io.perfmark:perfmark-api:0.24.0'
     implementation 'javax.inject:javax.inject:1'

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -30,35 +30,32 @@
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
-        "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"
@@ -69,10 +66,10 @@
         "javax.inject:javax.inject": {
             "locked": "1"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "locked": "1.70"
         },
         "org.slf4j:slf4j-api": {
@@ -121,35 +118,32 @@
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
-        "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"
@@ -160,10 +154,10 @@
         "javax.inject:javax.inject": {
             "locked": "1"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "locked": "1.70"
         },
         "org.openjdk.jmh:jmh-core": {
@@ -237,38 +231,35 @@
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
-        "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"
@@ -282,10 +273,10 @@
         "junit:junit": {
             "locked": "4.13.2"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
@@ -365,38 +356,35 @@
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
-        "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"
@@ -407,10 +395,10 @@
         "javax.inject:javax.inject": {
             "locked": "1"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "locked": "1.70"
         },
         "org.slf4j:slf4j-api": {
@@ -454,35 +442,32 @@
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
-        "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"
@@ -496,10 +481,10 @@
         "junit:junit": {
             "locked": "4.13.2"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
@@ -567,38 +552,35 @@
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
-        "io.netty:netty-bom": {
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.24.0"
@@ -612,10 +594,10 @@
         "junit:junit": {
             "locked": "4.13.2"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -54,47 +54,41 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -175,47 +169,41 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -322,71 +310,65 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -408,6 +390,12 @@
         },
         "junit:junit": {
             "locked": "4.13.2"
+        },
+        "org.bouncycastle:bcpkix-jdk15on": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.70"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
@@ -515,71 +503,65 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -598,6 +580,12 @@
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1"
+        },
+        "org.bouncycastle:bcpkix-jdk15on": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.70"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
@@ -674,47 +662,41 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -821,71 +803,65 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -907,6 +883,12 @@
         },
         "junit:junit": {
             "locked": "4.13.2"
+        },
+        "org.bouncycastle:bcpkix-jdk15on": {
+            "firstLevelTransitive": [
+                "com.netflix.zuul:zuul-core"
+            ],
+            "locked": "1.70"
         },
         "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -57,47 +57,41 @@
         "commons-configuration:commons-configuration": {
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -178,47 +172,41 @@
         "commons-configuration:commons-configuration": {
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -328,71 +316,65 @@
         "commons-configuration:commons-configuration": {
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -415,13 +397,13 @@
         "junit:junit": {
             "locked": "4.13.2"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
@@ -530,71 +512,65 @@
         "commons-configuration:commons-configuration": {
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -614,13 +590,13 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
@@ -695,47 +671,41 @@
         "commons-configuration:commons-configuration": {
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -845,71 +815,65 @@
         "commons-configuration:commons-configuration": {
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -932,13 +896,13 @@
         "junit:junit": {
             "locked": "4.13.2"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -54,47 +54,41 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -172,47 +166,41 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -316,71 +304,65 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -403,13 +385,13 @@
         "junit:junit": {
             "locked": "4.13.2"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
@@ -509,71 +491,65 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -593,13 +569,13 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
@@ -700,71 +676,65 @@
         "com.netflix.zuul:zuul-processor": {
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -784,13 +754,13 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
@@ -862,47 +832,41 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1003,71 +967,65 @@
             ],
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1090,13 +1048,13 @@
         "junit:junit": {
             "locked": "4.13.2"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -86,71 +86,65 @@
         "com.netflix.zuul:zuul-processor": {
             "project": true
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -170,13 +164,13 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
@@ -257,47 +251,41 @@
         "commons-configuration:commons-configuration": {
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -393,47 +381,41 @@
         "commons-configuration:commons-configuration": {
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -563,71 +545,65 @@
             ],
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -653,13 +629,13 @@
         "org.apache.logging.log4j:log4j-slf4j-impl": {
             "locked": "2.14.1"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
@@ -788,71 +764,65 @@
             ],
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -878,13 +848,13 @@
         "org.apache.logging.log4j:log4j-slf4j-impl": {
             "locked": "2.14.1"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
@@ -971,47 +941,41 @@
         "commons-configuration:commons-configuration": {
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1135,71 +1099,65 @@
             ],
             "locked": "1.10"
         },
-        "io.netty:netty-bom": {
-            "firstLevelTransitive": [
-                "com.netflix.zuul:zuul-core"
-            ],
-            "locked": "4.1.69.Final"
-        },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.44.Final"
+            "locked": "2.0.46.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.69.Final"
+            "locked": "4.1.71.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1225,13 +1183,13 @@
         "org.apache.logging.log4j:log4j-slf4j-impl": {
             "locked": "2.14.1"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcprov-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],


### PR DESCRIPTION
This reverts the usage of BOM, since it causes a resolution issue with trying to reslove `io.netty:netty-tcnative-classes:2.0.44.Final.` which doesn't exist in Maven.
