### PR TITLE
log4j 2.15.0

### DIFF
--- a/zuul-sample/build.gradle
+++ b/zuul-sample/build.gradle
@@ -10,8 +10,8 @@ dependencies {
     implementation 'commons-configuration:commons-configuration:1.10'
     annotationProcessor project(":zuul-processor")
 
-    runtimeOnly 'org.apache.logging.log4j:log4j-core:2.14.0'
-    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.1'
+    runtimeOnly 'org.apache.logging.log4j:log4j-core:2.15.0'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
 
 }
 

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -624,10 +624,10 @@
             "locked": "1"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.14.1"
+            "locked": "2.15.0"
         },
         "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "locked": "2.14.1"
+            "locked": "2.15.0"
         },
         "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
@@ -843,10 +843,10 @@
             "locked": "1"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.14.1"
+            "locked": "2.15.0"
         },
         "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "locked": "2.14.1"
+            "locked": "2.15.0"
         },
         "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
@@ -1178,10 +1178,10 @@
             "locked": "1"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.14.1"
+            "locked": "2.15.0"
         },
         "org.apache.logging.log4j:log4j-slf4j-impl": {
-            "locked": "2.14.1"
+            "locked": "2.15.0"
         },
         "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [


### PR DESCRIPTION
https://logging.apache.org/log4j/2.x/security.html

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228

https://arstechnica.com/information-technology/2021/12/minecraft-and-other-apps-face-serious-threat-from-new-code-execution-bug/
