### PR TITLE
Update to log4j 2.17.

### DIFF
--- a/zuul-sample/build.gradle
+++ b/zuul-sample/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'commons-configuration:commons-configuration:1.10'
     annotationProcessor project(":zuul-processor")
 
-    runtimeOnly 'org.apache.logging.log4j:log4j-core:2.16.0'
+    runtimeOnly 'org.apache.logging.log4j:log4j-core:2.17.0'
     runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
 
 }

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -624,7 +624,7 @@
             "locked": "1"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.16.0"
+            "locked": "2.17.0"
         },
         "org.apache.logging.log4j:log4j-slf4j-impl": {
             "locked": "2.15.0"
@@ -843,7 +843,7 @@
             "locked": "1"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.16.0"
+            "locked": "2.17.0"
         },
         "org.apache.logging.log4j:log4j-slf4j-impl": {
             "locked": "2.15.0"
@@ -1178,7 +1178,7 @@
             "locked": "1"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.16.0"
+            "locked": "2.17.0"
         },
         "org.apache.logging.log4j:log4j-slf4j-impl": {
             "locked": "2.15.0"


### PR DESCRIPTION
This fixes https://nvd.nist.gov/vuln/detail/CVE-2021-45105