### PR TITLE
Bypass deflate content from gzip

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/common/GZipResponseFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/common/GZipResponseFilter.java
@@ -78,7 +78,7 @@ public class GZipResponseFilter extends HttpOutboundSyncFilter
 
         // Check the headers to see if response is already gzipped.
         final Headers respHeaders = response.getHeaders();
-        boolean isResponseGzipped = HttpUtils.isGzipped(respHeaders);
+        boolean isResponseGzipped = HttpUtils.isGzipped(respHeaders) || HttpUtils.isDeflated(respHeaders);
 
         // Decide what to do.;
         final boolean shouldGzip = isGzippableContentType(response) && isGzipRequested && !isResponseGzipped && isRightSizeForGzip(response);

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/common/GZipResponseFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/common/GZipResponseFilter.java
@@ -78,10 +78,10 @@ public class GZipResponseFilter extends HttpOutboundSyncFilter
 
         // Check the headers to see if response is already gzipped.
         final Headers respHeaders = response.getHeaders();
-        boolean isResponseGzipped = HttpUtils.isGzipped(respHeaders) || HttpUtils.isDeflated(respHeaders);
+        boolean isResponseCompressed = HttpUtils.isCompressed(respHeaders);
 
         // Decide what to do.;
-        final boolean shouldGzip = isGzippableContentType(response) && isGzipRequested && !isResponseGzipped && isRightSizeForGzip(response);
+        final boolean shouldGzip = isGzippableContentType(response) && isGzipRequested && !isResponseCompressed && isRightSizeForGzip(response);
         if (shouldGzip) {
             response.getContext().set(CommonContextKeys.GZIPPER, getGzipper());
         }

--- a/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
@@ -22,6 +22,7 @@ import com.netflix.zuul.message.http.HttpHeaderNames;
 import com.netflix.zuul.message.http.HttpRequestInfo;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -84,12 +85,21 @@ public class HttpUtils
      * @return true if the content-encoding param containg gzip
      */
     public static boolean isGzipped(String contentEncoding) {
-        return contentEncoding.contains("gzip");
+        return contentEncoding.contains(HttpHeaderValues.GZIP.toString());
+    }
+
+    public static boolean isDeflated(String contentEncoding) {
+        return contentEncoding.contains(HttpHeaderValues.DEFLATE.toString());
     }
 
     public static boolean isGzipped(Headers headers) {
         String ce = headers.getFirst(HttpHeaderNames.CONTENT_ENCODING);
         return ce != null && isGzipped(ce);
+    }
+
+    public static boolean isDeflated(Headers headers) {
+        String ce = headers.getFirst(HttpHeaderNames.CONTENT_ENCODING);
+        return ce != null && isDeflated(ce);
     }
 
     public static boolean acceptsGzip(Headers headers) {

--- a/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
@@ -15,6 +15,7 @@
  */
 package com.netflix.zuul.util;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.netflix.zuul.message.Headers;
 import com.netflix.zuul.message.ZuulMessage;
@@ -78,33 +79,22 @@ public class HttpUtils
         }
     }
 
-    /**
-     * return true if the client requested gzip content
-     *
-     * @param contentEncoding a <code>String</code> value
-     * @return true if the content-encoding param containg gzip
-     */
-    public static boolean isGzipped(String contentEncoding) {
-        return contentEncoding.contains(HttpHeaderValues.GZIP.toString());
+    @VisibleForTesting
+    static boolean isCompressed(String contentEncoding) {
+        return contentEncoding.contains(HttpHeaderValues.GZIP.toString()) ||
+                contentEncoding.contains(HttpHeaderValues.DEFLATE.toString()) ||
+                contentEncoding.contains(HttpHeaderValues.BR.toString()) ||
+                contentEncoding.contains(HttpHeaderValues.COMPRESS.toString());
     }
 
-    public static boolean isDeflated(String contentEncoding) {
-        return contentEncoding.contains(HttpHeaderValues.DEFLATE.toString());
-    }
-
-    public static boolean isGzipped(Headers headers) {
+    public static boolean isCompressed(Headers headers) {
         String ce = headers.getFirst(HttpHeaderNames.CONTENT_ENCODING);
-        return ce != null && isGzipped(ce);
-    }
-
-    public static boolean isDeflated(Headers headers) {
-        String ce = headers.getFirst(HttpHeaderNames.CONTENT_ENCODING);
-        return ce != null && isDeflated(ce);
+        return ce != null && isCompressed(ce);
     }
 
     public static boolean acceptsGzip(Headers headers) {
         String ae = headers.getFirst(HttpHeaderNames.ACCEPT_ENCODING);
-        return ae != null && isGzipped(ae);
+        return ae != null && ae.contains(HttpHeaderValues.GZIP.toString());
     }
 
     /**

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
@@ -27,6 +27,7 @@ import com.netflix.zuul.message.http.HttpHeaderNames;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpResponseMessage;
 import com.netflix.zuul.message.http.HttpResponseMessageImpl;
+import com.netflix.zuul.util.Gzipper;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
@@ -34,6 +35,7 @@ import io.netty.handler.codec.http.HttpContent;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -100,6 +102,65 @@ public class GZipResponseFilterTest {
 
         // Check Content-Length header has been removed
         assertEquals(0, result.getHeaders().getAll("Content-Length").size());
+    }
+
+    @Test
+    public void prepareResponseBody_NeedsGZipping_gzipDeflate() throws Exception {
+        originalRequestHeaders.set("Accept-Encoding", "gzip,deflate");
+
+        byte[] originBody = "blah".getBytes();
+        response.getHeaders().set("Content-Length", Integer.toString(originBody.length));
+        Mockito.when(filter.isRightSizeForGzip(response)).thenReturn(true); //Force GZip for small response
+        response.setHasBody(true);
+        assertTrue(filter.shouldFilter(response));
+
+        final HttpResponseMessage result = filter.apply(response);
+        final HttpContent hc1 = filter.processContentChunk(response, new DefaultHttpContent(Unpooled.wrappedBuffer(originBody)).retain());
+        final HttpContent hc2 = filter.processContentChunk(response, new DefaultLastHttpContent());
+        final byte[] body = new byte[hc1.content().readableBytes() + hc2.content().readableBytes()];
+        final int hc1Len = hc1.content().readableBytes();
+        final int hc2Len = hc2.content().readableBytes();
+        hc1.content().readBytes(body, 0, hc1Len);
+        hc2.content().readBytes(body, hc1Len, hc2Len);
+
+        String bodyStr;
+        // Check body is a gzipped version of the origin body.
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(body);
+                GZIPInputStream gzis = new GZIPInputStream(bais);
+                ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            int b;
+            while ((b = gzis.read()) != -1) {
+                baos.write(b);
+            }
+            bodyStr = baos.toString("UTF-8");
+        }
+        assertEquals("blah", bodyStr);
+        assertEquals("gzip", result.getHeaders().getFirst("Content-Encoding"));
+
+        // Check Content-Length header has been removed
+        assertEquals(0, result.getHeaders().getAll("Content-Length").size());
+    }
+
+    @Test
+    public void prepareResponseBody_alreadyZipped() throws Exception {
+        originalRequestHeaders.set("Accept-Encoding", "gzip,deflate");
+
+        byte[] originBody = "blah".getBytes();
+        response.getHeaders().set("Content-Length", Integer.toString(originBody.length));
+        response.getHeaders().set("Content-Encoding", "gzip");
+        response.setHasBody(true);
+        assertFalse(filter.shouldFilter(response));
+    }
+
+    @Test
+    public void prepareResponseBody_alreadyDeflated() throws Exception {
+        originalRequestHeaders.set("Accept-Encoding", "gzip,deflate");
+
+        byte[] originBody = "blah".getBytes();
+        response.getHeaders().set("Content-Length", Integer.toString(originBody.length));
+        response.getHeaders().set("Content-Encoding", "deflate");
+        response.setHasBody(true);
+        assertFalse(filter.shouldFilter(response));
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
@@ -27,7 +27,6 @@ import com.netflix.zuul.message.http.HttpHeaderNames;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpResponseMessage;
 import com.netflix.zuul.message.http.HttpResponseMessageImpl;
-import com.netflix.zuul.util.Gzipper;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
@@ -35,7 +34,6 @@ import io.netty.handler.codec.http.HttpContent;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -147,6 +145,7 @@ public class GZipResponseFilterTest {
 
         byte[] originBody = "blah".getBytes();
         response.getHeaders().set("Content-Length", Integer.toString(originBody.length));
+        response.getHeaders().set("Content-Type", "application/json");
         response.getHeaders().set("Content-Encoding", "gzip");
         response.setHasBody(true);
         assertFalse(filter.shouldFilter(response));
@@ -158,6 +157,7 @@ public class GZipResponseFilterTest {
 
         byte[] originBody = "blah".getBytes();
         response.getHeaders().set("Content-Length", Integer.toString(originBody.length));
+        response.getHeaders().set("Content-Type", "application/json");
         response.getHeaders().set("Content-Encoding", "deflate");
         response.setHasBody(true);
         assertFalse(filter.shouldFilter(response));

--- a/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.netflix.zuul.message.Headers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -33,17 +34,46 @@ public class HttpUtilsTest {
 
     @Test
     public void detectsGzip() {
-        assertTrue(HttpUtils.isGzipped("gzip"));
+        assertTrue(HttpUtils.isCompressed("gzip"));
+    }
+
+    @Test
+    public void detectsDeflate() {
+        assertTrue(HttpUtils.isCompressed("deflate"));
+    }
+
+    @Test
+    public void detectsCompress() {
+        assertTrue(HttpUtils.isCompressed("compress"));
+    }
+
+    @Test
+    public void detectsBR() {
+        assertTrue(HttpUtils.isCompressed("br"));
     }
 
     @Test
     public void detectsNonGzip() {
-        assertFalse(HttpUtils.isGzipped("identity"));
+        assertFalse(HttpUtils.isCompressed("identity"));
     }
 
     @Test
     public void detectsGzipAmongOtherEncodings() {
-        assertTrue(HttpUtils.isGzipped("gzip, deflate"));
+        assertTrue(HttpUtils.isCompressed("gzip, deflate"));
+    }
+
+    @Test
+    public void acceptsGzip() {
+        Headers headers = new Headers();
+        headers.add("Accept-Encoding", "gzip, deflate");
+        assertTrue(HttpUtils.acceptsGzip(headers));
+    }
+
+    @Test
+    public void acceptsGzip_only() {
+        Headers headers = new Headers();
+        headers.add("Accept-Encoding", "deflate");
+        assertFalse(HttpUtils.acceptsGzip(headers));
     }
 
     @Test


### PR DESCRIPTION
Fixes an issue where `deflate` encoded bodies would be gzipped, creating a double encoding.