### PR TITLE
This fixes an issue where Zuul does not correctly handle absolute URIs from Netty

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -89,6 +89,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
     private static final String SCHEME_HTTPS = "https";
 
     // via @stephenhay https://mathiasbynens.be/demo/url-regex, groups added
+    // group 1: scheme, group 2: domain, group 3: path+query
     private static final Pattern URL_REGEX = Pattern.compile("^(https?)://([^\\s/$.?#].[^\\s/]*)([^\\s]*)$");
 
     private final SessionContextDecorator decorator;
@@ -387,7 +388,12 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
             // absolute uri
             if (m.matches()) {
                 String match = m.group(3);
-                path = match == null ? uri : match;
+                if (match == null) {
+                    // in case of no match, default to existing behavior
+                    path = uri;
+                } else {
+                    path = match;
+                }
             }
             // unknown value
             else {

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
@@ -79,6 +79,60 @@ public class ClientRequestReceiverTest {
     }
 
     @Test
+    public void parseUriFromNetty_relative() {
+
+        EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
+        channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
+        HttpRequestMessageImpl result;
+        {
+            channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+                    "/foo/bar/somePath/%5E1.0.0?param1=foo&param2=bar&param3=baz", Unpooled.buffer()));
+            result = channel.readInbound();
+            result.disposeBufferedBody();
+        }
+
+        assertEquals("/foo/bar/somePath/%5E1.0.0", result.getPath());
+
+        channel.close();
+    }
+
+    @Test
+    public void parseUriFromNetty_absolute() {
+
+        EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
+        channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
+        HttpRequestMessageImpl result;
+        {
+            channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+                    "https://www.netflix.com/foo/bar/somePath/%5E1.0.0?param1=foo&param2=bar&param3=baz", Unpooled.buffer()));
+            result = channel.readInbound();
+            result.disposeBufferedBody();
+        }
+
+        assertEquals("/foo/bar/somePath/%5E1.0.0", result.getPath());
+
+        channel.close();
+    }
+
+    @Test
+    public void parseUriFromNetty_unknown() {
+
+        EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
+        channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
+        HttpRequestMessageImpl result;
+        {
+            channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+                    "asdf", Unpooled.buffer()));
+            result = channel.readInbound();
+            result.disposeBufferedBody();
+        }
+
+        assertEquals("asdf", result.getPath());
+
+        channel.close();
+    }
+
+    @Test
     public void parseQueryParamsWithEncodedCharsInURI() {
 
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
@@ -86,7 +140,7 @@ public class ClientRequestReceiverTest {
         HttpRequestMessageImpl result;
         {
             channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
-                    "foo/bar/somePath/%5E1.0.0?param1=foo&param2=bar&param3=baz", Unpooled.buffer()));
+                    "/foo/bar/somePath/%5E1.0.0?param1=foo&param2=bar&param3=baz", Unpooled.buffer()));
             result = channel.readInbound();
             result.disposeBufferedBody();
         }


### PR DESCRIPTION
As per https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2 the path segment of an inbound request can have an absolute URI in it. This fixes an issue where Zuul assumes that it's always a relative URI.