### PR TITLE
restore io_uring unit test

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: 8
           cache: 'gradle'
       - name: Build snapshot
-        run: ./gradlew build snapshot
+        run: sudo -E env "PATH=$PATH" bash -c "ulimit -l 65536 && ./gradlew --no-daemon build snapshot"
         env:
           NETFLIX_OSS_SIGNING_KEY: ${{ secrets.ORG_SIGNING_KEY }}
           NETFLIX_OSS_SIGNING_PASSWORD: ${{ secrets.ORG_SIGNING_PASSWORD }}

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/IoUringTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/IoUringTest.java
@@ -41,7 +41,6 @@ import java.util.*;
 
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +55,6 @@ import static org.awaitility.Awaitility.await;
       4) verify that the server stops
 
  */
-@Disabled
 public class IoUringTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(IoUringTest.class);
     private static final boolean IS_OS_LINUX = "linux".equals(PlatformDependent.normalizedOs());


### PR DESCRIPTION
Let's try using 'sudo -E' in the snapshot workflow

# Reference

https://man7.org/linux/man-pages/man8/sudo.8.html

```
-E

Indicates to the security policy that the user wishes 
to preserve their existing environment variables.
```
