### PR TITLE
Rework Filter category into an enum FilterCategory

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/Filter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/Filter.java
@@ -49,7 +49,7 @@ public @interface Filter {
     /**
      * Category of the filter.
      */
-    String category() default "zuul";
+    FilterCategory category() default FilterCategory.HTTP;
 
     /**
      * Indicates if this is a synchronous filter.

--- a/zuul-core/src/main/java/com/netflix/zuul/FilterCategory.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/FilterCategory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul;
+
+/**
+ * Categorization of filters.
+ */
+public enum FilterCategory {
+
+    ABUSE("abuse", "Abuse detection and protection filters, such as rate-limiting, malicious request detection, geo-blocking"),
+    ACCESS("access", "Authentication and authorization filters"),
+    ADMIN("admin", "Admin only filters providing operational support"),
+    CHAOS("chaos", "Failure injection testing and resilience support"),
+    CONTEXT_DECORATOR("context-decorator", "Decorate context based on request and detected client"),
+    HEALTHCHECK("healthcheck", "Support for healthcheck endpoints"),
+    HTTP("http", "Filter operating on HTTP request/response protocol features"),
+    ORIGIN("origin", "Origin connectivity filters"),
+    OBSERVABILITY("observability", "Filters providing observability features"),
+    OVERLOAD("overload", "Filters to respond on the server being in an overloaded state such as brownout"),
+    ROUTING("routing", "Filters which make routing decisions"),
+    ;
+    
+    private final String code;
+    private final String description;
+
+    FilterCategory(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String toString() {
+        return code;
+    }
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
@@ -16,6 +16,7 @@
 package com.netflix.zuul.filters;
 
 import com.netflix.zuul.Filter;
+import com.netflix.zuul.FilterCategory;
 import com.netflix.zuul.exception.ZuulFilterConcurrencyExceededException;
 import com.netflix.zuul.message.ZuulMessage;
 import io.netty.handler.codec.http.HttpContent;
@@ -65,9 +66,9 @@ public interface ZuulFilter<I extends ZuulMessage, O extends ZuulMessage> extend
     /**
      * Classify a filter by category.
      *
-     * @return String the classification of this filter
+     * @return FilterCategory the classification of this filter
      */
-    default String category() {
+    default FilterCategory category() {
         Filter f = getClass().getAnnotation(Filter.class);
         if (f != null) {
             return f.category();


### PR DESCRIPTION
Rework #1222 to be an enum `FilterCategory` rather than a freeform string.