### PR TITLE
Revert "[all] Netty update to 4.1.77, io_uring 0.0.14"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 versions_groovy=3.0.9
 versions_ribbon=2.4.4
-versions_netty=4.1.77.Final
-versions_netty_io_uring=0.0.14.Final
+versions_netty=4.1.74.Final
+versions_netty_io_uring=0.0.12.Final
 release.scope=patch
 release.version=2.3.1-SNAPSHOT

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -31,37 +31,37 @@
             "project": true
         },
         "io.netty.incubator:netty-incubator-transport-native-io_uring": {
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -125,37 +125,37 @@
             "project": true
         },
         "io.netty.incubator:netty-incubator-transport-native-io_uring": {
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -247,40 +247,40 @@
             "locked": "1.10"
         },
         "io.netty.incubator:netty-incubator-transport-native-io_uring": {
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -304,7 +304,7 @@
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -381,40 +381,40 @@
             "project": true
         },
         "io.netty.incubator:netty-incubator-transport-native-io_uring": {
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -476,37 +476,37 @@
             "locked": "1.10"
         },
         "io.netty.incubator:netty-incubator-transport-native-io_uring": {
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -530,7 +530,7 @@
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.36"
@@ -598,40 +598,40 @@
             "locked": "1.10"
         },
         "io.netty.incubator:netty-incubator-transport-native-io_uring": {
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -655,7 +655,7 @@
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-discovery/dependencies.lock
+++ b/zuul-discovery/dependencies.lock
@@ -85,7 +85,7 @@
             "locked": "4.13.2"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.25"
@@ -146,7 +146,7 @@
             "locked": "4.13.2"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.36"
@@ -178,7 +178,7 @@
             "locked": "4.13.2"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.36"

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -58,43 +58,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -179,43 +179,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -326,73 +326,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -431,7 +431,7 @@
             "locked": "3.0.9"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.25"
@@ -531,73 +531,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -702,43 +702,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -753,7 +753,7 @@
             "locked": "3.0.9"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -849,73 +849,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -954,7 +954,7 @@
             "locked": "3.0.9"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -61,43 +61,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -182,43 +182,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -332,73 +332,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -434,7 +434,7 @@
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.25"
@@ -540,73 +540,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -711,43 +711,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -759,7 +759,7 @@
             "locked": "4.13.2"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -861,73 +861,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -963,7 +963,7 @@
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.5.1"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -58,43 +58,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -176,43 +176,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -320,73 +320,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -519,73 +519,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -716,73 +716,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -884,43 +884,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1025,73 +1025,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -90,73 +90,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -267,43 +267,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -403,43 +403,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -573,73 +573,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -804,73 +804,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -993,43 +993,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1157,73 +1157,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "0.0.14.Final"
+            "locked": "0.0.12.Final"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.52.Final"
+            "locked": "2.0.48.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.77.Final"
+            "locked": "4.1.74.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
Reverts Netflix/zuul#1261

Reverting due to internal customer reported issue: 
SSLV3_ALERT_ILLEGAL_PARAMETER
