### PR TITLE
Add check to remove PushConnection entry only when not stale

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushRegistrationHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushRegistrationHandler.java
@@ -71,7 +71,13 @@ public class PushRegistrationHandler extends ChannelInboundHandlerAdapter {
         if (! destroyed.get()) {
             destroyed.set(true);
             if (authEvent != null) {
-                pushConnectionRegistry.remove(authEvent.getClientIdentity());
+                // We should only remove the PushConnection entry from the registry if it's still this pushConnection.
+                String clientID = authEvent.getClientIdentity();
+                PushConnection savedPushConnection = pushConnectionRegistry.get(clientID);
+                if (savedPushConnection != null && savedPushConnection == pushConnection) {
+                    pushConnectionRegistry.remove(authEvent.getClientIdentity());
+                    logger.debug("Removed connection from registry for {}", authEvent);
+                }
                 logger.debug("Closing connection for {}", authEvent);
             }
         }


### PR DESCRIPTION
The PushConnectionRegistry relies on a 1:1 mapping between ClientID and connection. When a new WS connection is made, it is stored in the registry for that Client ID. 

If a client 1) creates a new WS connection while a previous one is open, then 2) closes the first connection, an odd timing issue can occur where the new connection is lost:

![image](https://user-images.githubusercontent.com/17228751/182498194-3edebe17-670b-4980-894f-eb4bd0663d70.png)

<!--
participant Client
participant "Push Server" as P

Client->P: Create Websocket Connection A\n with ClientID "foo"
note over P: (Note: PCR == PushConnectionRegistry)\n\nset\nPCR["foo"] = Connection A
Client->P: Create Websocket Connection B\n with same ClientID "foo"
note over P: set\nPCR["foo"] = Connection B
Client->P: Close WS Connection A
note over P: delete PCR["foo"]
abox over P:At this point, the Push server can no\nlonger look up the new connection to the\nclient via the Client ID
-->

Instead of automatically deleting the entry for the given client ID, we can instead first check to make sure that the pushConnection being deleted is the one that is disconnecting — if it isn't, we can assume it was a later connection with a separate handler.

This does mean that closing the newer connection when both are open would remove the entry for the Client ID, but it would have already overwritten the entry anyways. This seems to make more sense than the older one being able to remove new one.