### PR TITLE
Do not propagate exception once context has been closed in PushRegistrationHandler

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushRegistrationHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushRegistrationHandler.java
@@ -95,10 +95,9 @@ public class PushRegistrationHandler extends ChannelInboundHandlerAdapter {
     }
 
     @Override
-    public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         logger.error("Exception caught, closing push channel for " + authEvent, cause);
         ctx.close();
-        super.exceptionCaught(ctx, cause);
     }
 
     protected final void forceCloseConnectionFromServerSide() {


### PR DESCRIPTION
Because PushRegistrationHandler handles the exception and closes the context, it does not need to pass the exception on past itself.

Also removed the `final` so it can be overridden.