### PR TITLE
[all] Upgrade to Netty 4.1.80

### DIFF
--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,26 +1,26 @@
 {
     "jmh": {
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         }
     },
     "jmhCompileClasspath": {
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         }
     },
     "jmhRuntimeClasspath": {
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 versions_groovy=3.0.9
 versions_ribbon=2.4.4
-versions_netty=4.1.79.Final
+versions_netty=4.1.80.Final
 versions_netty_io_uring=0.0.14.Final
 release.scope=patch
 release.version=2.3.1-SNAPSHOT

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -34,34 +34,34 @@
             "locked": "0.0.14.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -90,7 +90,7 @@
             "locked": "1.35"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         }
     },
     "jmhCompileClasspath": {
@@ -128,34 +128,34 @@
             "locked": "0.0.14.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -179,7 +179,7 @@
             "locked": "1.35"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.36"
@@ -250,37 +250,37 @@
             "locked": "0.0.14.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -304,7 +304,7 @@
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -313,7 +313,7 @@
             "locked": "1.35"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -384,37 +384,37 @@
             "locked": "0.0.14.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -479,34 +479,34 @@
             "locked": "0.0.14.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -530,7 +530,7 @@
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.36"
@@ -601,37 +601,37 @@
             "locked": "0.0.14.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -655,7 +655,7 @@
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-discovery/dependencies.lock
+++ b/zuul-discovery/dependencies.lock
@@ -24,10 +24,10 @@
     },
     "jmh": {
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         }
     },
     "jmhCompileClasspath": {
@@ -50,10 +50,10 @@
             "locked": "2.4.4"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.36"
@@ -85,13 +85,13 @@
             "locked": "4.13.2"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.36"
@@ -146,7 +146,7 @@
             "locked": "4.13.2"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.36"
@@ -178,7 +178,7 @@
             "locked": "4.13.2"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.36"

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -58,43 +58,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -114,10 +114,10 @@
     },
     "jmh": {
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         }
     },
     "jmhCompileClasspath": {
@@ -179,43 +179,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -227,10 +227,10 @@
             "locked": "3.0.9"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -332,67 +332,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -431,13 +431,13 @@
             "locked": "3.0.9"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -537,67 +537,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -702,43 +702,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -753,7 +753,7 @@
             "locked": "3.0.9"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -855,67 +855,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -954,7 +954,7 @@
             "locked": "3.0.9"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -61,43 +61,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -114,10 +114,10 @@
     },
     "jmh": {
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         }
     },
     "jmhCompileClasspath": {
@@ -182,43 +182,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -227,10 +227,10 @@
             "locked": "1.3.8"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -338,67 +338,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -434,13 +434,13 @@
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -546,67 +546,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -711,43 +711,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -759,7 +759,7 @@
             "locked": "4.13.2"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -867,67 +867,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -963,7 +963,7 @@
             "locked": "1.70"
         },
         "org.mockito:mockito-core": {
-            "locked": "4.6.1"
+            "locked": "4.7.0"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -58,43 +58,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -111,10 +111,10 @@
     },
     "jmh": {
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         }
     },
     "jmhCompileClasspath": {
@@ -176,43 +176,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -221,10 +221,10 @@
             "locked": "1.3.8"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -326,67 +326,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -422,10 +422,10 @@
             "locked": "1.70"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -525,67 +525,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -722,67 +722,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -884,43 +884,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1031,67 +1031,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -96,67 +96,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -267,43 +267,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -326,10 +326,10 @@
     },
     "jmh": {
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         }
     },
     "jmhCompileClasspath": {
@@ -403,43 +403,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -454,10 +454,10 @@
             "locked": "3.0.9"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -579,67 +579,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -684,10 +684,10 @@
             "locked": "3.0.9"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.35"
+            "locked": "1.29"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -810,67 +810,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -993,43 +993,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1163,67 +1163,67 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.53.Final"
+            "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.79.Final"
+            "locked": "4.1.80.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
Also bumps minor versions for jmh, mockito-core