### PR TITLE
CurrentPassport.getState() NPE when there is no history

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/passport/CurrentPassport.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/passport/CurrentPassport.java
@@ -162,7 +162,8 @@ public class CurrentPassport
 
     public PassportState getState() {
         try (Unlocker ignored = lock()){
-            return history.peekLast().getState();
+            PassportItem passportItem = history.peekLast();
+            return passportItem != null ? passportItem.getState() : null;
         }
     }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/passport/CurrentPassportTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/passport/CurrentPassportTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static com.netflix.zuul.passport.PassportState.MISC_IO_START;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class CurrentPassportTest
 {
@@ -88,5 +89,10 @@ public class CurrentPassportTest
                 "CurrentPassport {start_ms=0, [+0=FILTERS_INBOUND_START, +50=IN_REQ_LAST_CONTENT_RECEIVED, +200=MISC_IO_START, +250=IN_REQ_HEADERS_RECEIVED, +1117794707=NOW]}");
 
         assertEquals(200, passport.findStateBackwards(MISC_IO_START).getTime());
+    }
+
+    @Test
+    public void testGetStateWithNoHistory() {
+        assertNull(CurrentPassport.create().getState());
     }
 }


### PR DESCRIPTION
I noticed a NPE on ssl handshake failures if a CurrentPassport is created for the first time:

```
java.lang.NullPointerException: Cannot invoke "com.netflix.zuul.passport.PassportItem.getState()" because the return value of "java.util.LinkedList.peekLast()" is null
	at com.netflix.zuul.passport.CurrentPassport.getState(CurrentPassport.java:165) ~[zuul-core-2.3.1-SNAPSHOT.jar:2.3.1-SNAPSHOT]
	at com.netflix.zuul.netty.server.ssl.SslHandshakeInfoHandler.userEventTriggered(SslHandshakeInfoHandler.java:107) ~[zuul-core-2.3.1-SNAPSHOT.jar:2.0]
```