### PR TITLE
typo: rename BAse to base

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
@@ -23,7 +23,7 @@ import io.netty.handler.codec.http.HttpContent;
 import rx.Observable;
 
 /**
- * BAse interface for ZuulFilters
+ * Base interface for ZuulFilters
  *
  * @author Mikey Cohen
  *         Date: 10/27/11


### PR DESCRIPTION
## Changes

A trivial correction of typo in the javadoc, from `BAse` to `Base`.

