### PR TITLE
Track unreleased bytebufs

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ByteBufFollower.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ByteBufFollower.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
 package com.netflix.zuul.monitoring;
 
 import com.netflix.config.DynamicBooleanProperty;

--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ByteBufFollower.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ByteBufFollower.java
@@ -1,0 +1,83 @@
+package com.netflix.zuul.monitoring;
+
+import com.netflix.config.DynamicBooleanProperty;
+import com.netflix.zuul.netty.SpectatorUtils;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.ReferenceCountUtil;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ByteBufFollower
+ *
+ * @author Arthur Gonigberg
+ * @since October 13, 2022
+ */
+public class ByteBufFollower {
+
+    private static final Logger log = LoggerFactory.getLogger(ByteBufFollower.class);
+
+    private static final List<SeenBuf> buffs = Collections.synchronizedList(new ArrayList<>());
+
+    private static final DynamicBooleanProperty SHOULD_RELEASE =
+            new DynamicBooleanProperty("zuul.bytebuf.follower.release", false);
+
+    public static void trackByteBuf(String entry, Object bytebuf) {
+        // last content frames are never allocated or released but will have refCnt = 1
+        if (bytebuf instanceof LastHttpContent) {
+            return;
+        }
+
+        // only track if ref-counted and unreleased
+        if (ReferenceCountUtil.refCnt(bytebuf) > 0) {
+            buffs.add(new SeenBuf(entry, bytebuf));
+        }
+    }
+
+    static {
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
+            Iterator<SeenBuf> iterator = buffs.iterator();
+            while (iterator.hasNext()) {
+                SeenBuf next = iterator.next();
+                // was already released in the time we've been watching it
+                if (ReferenceCountUtil.refCnt(next.bytebuf) <= 0) {
+                    iterator.remove();
+                } else {
+                    log.warn("Tracking unclosed ByteBuf: {}", next);
+                    SpectatorUtils.newCounter("zuul.bytebuf.follower", next.bytebuf.getClass().toString())
+                            .increment();
+
+                    if (SHOULD_RELEASE.get()) {
+                        ReferenceCountUtil.safeRelease(next.bytebuf);
+                    }
+                }
+            }
+        }, 30, 30, TimeUnit.SECONDS);
+    }
+
+    private static class SeenBuf {
+
+        private final String entry;
+        private final Object bytebuf;
+
+        public SeenBuf(String entry, Object bytebuf) {
+            this.entry = entry;
+            this.bytebuf = bytebuf;
+        }
+
+        @Override
+        public String toString() {
+            return "SeenBuf{" +
+                    "entry='" + entry + '\'' +
+                    ", clazz=" + bytebuf.getClass() +
+                    ", count=" + ReferenceCountUtil.refCnt(bytebuf) +
+                    '}';
+        }
+    }
+}


### PR DESCRIPTION
This is an experiment more than something I think we need to merge into the codebase. I think we could track unclosed bodies through the 4 legs of proxying and see what happens. There's also a property we can enable that will then close them, but ideally, this would lead us in the right direction in terms of investigating rather than a general-purpose body closer. 