### PR TITLE
migrate from JUnit 4 to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,9 @@ subprojects {
     ext {
         libraries = [
                 guava: "com.google.guava:guava:31.1-jre",
-                junit: "junit:junit:4.13.2",
+                jupiterApi: 'org.junit.jupiter:junit-jupiter-api:5.+',
+                jupiterEngine: 'org.junit.jupiter:junit-jupiter-engine:5.+',
+                jupiterMockito: 'org.mockito:mockito-junit-jupiter:4.+',
                 mockito: 'org.mockito:mockito-core:4.+',
                 slf4j: "org.slf4j:slf4j-api:1.7.36",
                 truth: 'com.google.truth:truth:1.1.3',
@@ -74,6 +76,7 @@ subprojects {
     }
 
     test {
+        useJUnitPlatform()
         testLogging {
             showStandardStreams = true
         }

--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation 'io.perfmark:perfmark-api:0.25.0'
     implementation 'javax.inject:javax.inject:1'
 
-    testImplementation libraries.junit,
+    testImplementation libraries.jupiterApi, libraries.jupiterEngine, libraries.jupiterMockito,
             libraries.mockito,
             libraries.truth,
             libraries.awaitility

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -291,9 +291,6 @@
         "javax.inject:javax.inject": {
             "locked": "1"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
-        },
         "org.awaitility:awaitility": {
             "locked": "4.2.0"
         },
@@ -303,7 +300,16 @@
         "org.bouncycastle:bcprov-jdk15on": {
             "locked": "1.70"
         },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
+        },
         "org.mockito:mockito-core": {
+            "locked": "4.8.0"
+        },
+        "org.mockito:mockito-junit-jupiter": {
             "locked": "4.8.0"
         },
         "org.openjdk.jmh:jmh-core": {
@@ -517,9 +523,6 @@
         "javax.inject:javax.inject": {
             "locked": "1"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
-        },
         "org.awaitility:awaitility": {
             "locked": "4.2.0"
         },
@@ -529,7 +532,16 @@
         "org.bouncycastle:bcprov-jdk15on": {
             "locked": "1.70"
         },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
+        },
         "org.mockito:mockito-core": {
+            "locked": "4.8.0"
+        },
+        "org.mockito:mockito-junit-jupiter": {
             "locked": "4.8.0"
         },
         "org.slf4j:slf4j-api": {
@@ -642,9 +654,6 @@
         "javax.inject:javax.inject": {
             "locked": "1"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
-        },
         "org.awaitility:awaitility": {
             "locked": "4.2.0"
         },
@@ -654,7 +663,16 @@
         "org.bouncycastle:bcprov-jdk15on": {
             "locked": "1.70"
         },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
+        },
         "org.mockito:mockito-core": {
+            "locked": "4.8.0"
+        },
+        "org.mockito:mockito-junit-jupiter": {
             "locked": "4.8.0"
         },
         "org.slf4j:slf4j-api": {

--- a/zuul-core/src/test/java/com/netflix/netty/common/CloseOnIdleStateHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/CloseOnIdleStateHandlerTest.java
@@ -17,32 +17,30 @@
 package com.netflix.netty.common;
 
 import static io.netty.handler.timeout.IdleStateEvent.ALL_IDLE_STATE_EVENT;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.zuul.netty.server.http2.DummyChannelHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class CloseOnIdleStateHandlerTest {
 
     private Registry registry = new DefaultRegistry();
     private Id counterId;
     private final String listener = "test-idle-state";
 
-    @Before
+    @BeforeEach
     public void setup() {
         counterId = registry.createId("server.connections.idle.timeout").withTags("id", listener);
     }
 
     @Test
-    public void incrementCounterOnIdleStateEvent() {
+    void incrementCounterOnIdleStateEvent() {
         final EmbeddedChannel channel = new EmbeddedChannel();
         channel.pipeline().addLast(new DummyChannelHandler());
         channel.pipeline().addLast(new CloseOnIdleStateHandler(registry, listener));

--- a/zuul-core/src/test/java/com/netflix/netty/common/HttpServerLifecycleChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/HttpServerLifecycleChannelHandlerTest.java
@@ -17,7 +17,6 @@
 package com.netflix.netty.common;
 
 import static com.netflix.netty.common.HttpLifecycleChannelHandler.ATTR_HTTP_PIPELINE_REJECT;
-import static org.junit.Assert.fail;
 import com.google.common.truth.Truth;
 import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
 import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
@@ -34,7 +33,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.ReferenceCountUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class HttpServerLifecycleChannelHandlerTest {
 
@@ -54,7 +53,7 @@ public class HttpServerLifecycleChannelHandlerTest {
     }
 
     @Test
-    public void completionEventReasonIsUpdatedOnPipelineReject() {
+    void completionEventReasonIsUpdatedOnPipelineReject() {
 
         final EmbeddedChannel channel = new EmbeddedChannel(new HttpServerLifecycleOutboundChannelHandler());
         final AssertReasonHandler reasonHandler = new AssertReasonHandler();
@@ -70,7 +69,7 @@ public class HttpServerLifecycleChannelHandlerTest {
     }
 
     @Test
-    public void completionEventReasonIsCloseByDefault() {
+    void completionEventReasonIsCloseByDefault() {
 
         final EmbeddedChannel channel = new EmbeddedChannel(new HttpServerLifecycleOutboundChannelHandler());
         final AssertReasonHandler reasonHandler = new AssertReasonHandler();
@@ -84,7 +83,7 @@ public class HttpServerLifecycleChannelHandlerTest {
     }
 
     @Test
-    public void pipelineRejectReleasesIfNeeded() {
+    void pipelineRejectReleasesIfNeeded() {
 
         EmbeddedChannel channel = new EmbeddedChannel(new HttpServerLifecycleInboundChannelHandler());
 
@@ -99,7 +98,7 @@ public class HttpServerLifecycleChannelHandlerTest {
             Truth.assertThat(channel.attr(ATTR_HTTP_PIPELINE_REJECT).get()).isEqualTo(Boolean.TRUE);
             Truth.assertThat(buffer.refCnt()).isEqualTo(0);
         } finally {
-            if(buffer.refCnt() != 0) {
+            if (buffer.refCnt() != 0) {
                 ReferenceCountUtil.release(buffer);
             }
         }

--- a/zuul-core/src/test/java/com/netflix/netty/common/SourceAddressChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/SourceAddressChannelHandlerTest.java
@@ -16,9 +16,7 @@
 
 package com.netflix.netty.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -29,22 +27,19 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Assume;
 import org.junit.AssumptionViolatedException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link SourceAddressChannelHandler}.
  */
-@RunWith(JUnit4.class)
 public class SourceAddressChannelHandlerTest {
 
     @Test
-    public void ipv6AddressScopeIdRemoved() throws Exception {
+    void ipv6AddressScopeIdRemoved() throws Exception {
         Inet6Address address =
-                Inet6Address.getByAddress("localhost", new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 2);
+                Inet6Address.getByAddress("localhost", new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 2);
         assertEquals(2, address.getScopeId());
 
         String addressString = SourceAddressChannelHandler.getHostAddress(new InetSocketAddress(address, 8080));
@@ -53,8 +48,8 @@ public class SourceAddressChannelHandlerTest {
     }
 
     @Test
-    public void ipv4AddressString() throws Exception {
-        InetAddress address = Inet4Address.getByAddress("localhost", new byte[] {127, 0, 0, 1});
+    void ipv4AddressString() throws Exception {
+        InetAddress address = Inet4Address.getByAddress("localhost", new byte[]{127, 0, 0, 1});
 
         String addressString = SourceAddressChannelHandler.getHostAddress(new InetSocketAddress(address, 8080));
 
@@ -62,7 +57,7 @@ public class SourceAddressChannelHandlerTest {
     }
 
     @Test
-    public void failsOnUnresolved() {
+    void failsOnUnresolved() {
         InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", 8080);
 
         String addressString = SourceAddressChannelHandler.getHostAddress(address);
@@ -71,11 +66,11 @@ public class SourceAddressChannelHandlerTest {
     }
 
     @Test
-    public void mapsIpv4AddressFromIpv6Address() throws Exception {
+    void mapsIpv4AddressFromIpv6Address() throws Exception {
         // Can't think of a reason why this would ever come up, but testing it just in case.
         // ::ffff:127.0.0.1
         Inet6Address address = Inet6Address.getByAddress(
-                "localhost", new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xFF, (byte) 0xFF, 127, 0, 0, 1}, -1);
+                "localhost", new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xFF, (byte) 0xFF, 127, 0, 0, 1}, -1);
         assertEquals(0, address.getScopeId());
 
         String addressString = SourceAddressChannelHandler.getHostAddress(new InetSocketAddress(address, 8080));
@@ -84,9 +79,9 @@ public class SourceAddressChannelHandlerTest {
     }
 
     @Test
-    public void ipv6AddressScopeNameRemoved() throws Exception {
+    void ipv6AddressScopeNameRemoved() throws Exception {
         List<NetworkInterface> nics = Collections.list(NetworkInterface.getNetworkInterfaces());
-        Assume.assumeTrue("No network interfaces", !nics.isEmpty());
+        Assumptions.assumeTrue(!nics.isEmpty(), "No network interfaces");
 
 
         List<Throwable> failures = new ArrayList<>();
@@ -94,14 +89,14 @@ public class SourceAddressChannelHandlerTest {
             Inet6Address address;
             try {
                 address = Inet6Address.getByAddress(
-                        "localhost", new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, nic);
+                        "localhost", new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, nic);
             } catch (UnknownHostException e) {
                 // skip, the nic doesn't match
                 failures.add(e);
                 continue;
             }
 
-            assertTrue(address.toString(), address.toString().contains("%"));
+            assertTrue(address.toString().contains("%"), address.toString());
 
             String addressString = SourceAddressChannelHandler.getHostAddress(new InetSocketAddress(address, 8080));
 

--- a/zuul-core/src/test/java/com/netflix/netty/common/metrics/InstrumentedResourceLeakDetectorTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/metrics/InstrumentedResourceLeakDetectorTest.java
@@ -16,26 +16,26 @@
 
 package com.netflix.netty.common.metrics;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.netty.buffer.ByteBuf;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class InstrumentedResourceLeakDetectorTest {
 
     InstrumentedResourceLeakDetector<Object> leakDetector;
 
-    @Before
+    @BeforeEach
     public void setup() {
         leakDetector = new InstrumentedResourceLeakDetector<>(ByteBuf.class, 1);
     }
 
     @Test
-    public void test() {
+    void test() {
         leakDetector.reportTracedLeak("test", "test");
         assertEquals(leakDetector.leakCounter.get(), 1);
 

--- a/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandlerTest.java
@@ -16,10 +16,7 @@
 
 package com.netflix.netty.common.proxyprotocol;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,14 +34,14 @@ import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ElbProxyProtocolChannelHandlerTest {
 
     @Mock
@@ -52,13 +49,13 @@ public class ElbProxyProtocolChannelHandlerTest {
     @Mock
     private Counter counter;
 
-    @Before
+    @BeforeEach
     public void setup() {
         when(registry.counter("zuul.hapm.failure")).thenReturn(counter);
     }
 
     @Test
-    public void noProxy() {
+    void noProxy() {
         EmbeddedChannel channel = new EmbeddedChannel();
         // This is normally done by Server.
         channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
@@ -83,7 +80,7 @@ public class ElbProxyProtocolChannelHandlerTest {
     }
 
     @Test
-    public void extraDataForwarded() {
+    void extraDataForwarded() {
         EmbeddedChannel channel = new EmbeddedChannel();
         // This is normally done by Server.
         channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
@@ -102,7 +99,7 @@ public class ElbProxyProtocolChannelHandlerTest {
     }
 
     @Test
-    public void passThrough_ProxyProtocolEnabled_nonProxyBytes() {
+    void passThrough_ProxyProtocolEnabled_nonProxyBytes() {
         EmbeddedChannel channel = new EmbeddedChannel();
         // This is normally done by Server.
         channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
@@ -128,7 +125,7 @@ public class ElbProxyProtocolChannelHandlerTest {
     }
 
     @Test
-    public void incrementCounterWhenPPEnabledButNonHAPMMessage() {
+    void incrementCounterWhenPPEnabledButNonHAPMMessage() {
         EmbeddedChannel channel = new EmbeddedChannel();
         // This is normally done by Server.
         channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
@@ -146,9 +143,9 @@ public class ElbProxyProtocolChannelHandlerTest {
         verify(counter, times(1)).increment();
     }
 
-    @Ignore
+    @Disabled
     @Test
-    public void detectsSplitPpv1Message() {
+    void detectsSplitPpv1Message() {
         EmbeddedChannel channel = new EmbeddedChannel();
         // This is normally done by Server.
         channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
@@ -172,7 +169,7 @@ public class ElbProxyProtocolChannelHandlerTest {
     }
 
     @Test
-    public void negotiateProxy_ppv1_ipv4() {
+    void negotiateProxy_ppv1_ipv4() {
         EmbeddedChannel channel = new EmbeddedChannel();
         // This is normally done by Server.
         channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
@@ -201,7 +198,7 @@ public class ElbProxyProtocolChannelHandlerTest {
     }
 
     @Test
-    public void negotiateProxy_ppv1_ipv6() {
+    void negotiateProxy_ppv1_ipv6() {
         EmbeddedChannel channel = new EmbeddedChannel();
         // This is normally done by Server.
         channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
@@ -232,7 +229,7 @@ public class ElbProxyProtocolChannelHandlerTest {
     }
 
     @Test
-    public void negotiateProxy_ppv2_ipv4() {
+    void negotiateProxy_ppv2_ipv4() {
         EmbeddedChannel channel = new EmbeddedChannel();
         // This is normally done by Server.
         channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());

--- a/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/HAProxyMessageChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/HAProxyMessageChannelHandlerTest.java
@@ -16,8 +16,9 @@
 
 package com.netflix.netty.common.proxyprotocol;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.zuul.Attrs;
 import com.netflix.zuul.netty.server.Server;
@@ -27,15 +28,12 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class HAProxyMessageChannelHandlerTest {
 
     @Test
-    public void setClientDestPortForHAPM() {
+    void setClientDestPortForHAPM() {
         EmbeddedChannel channel = new EmbeddedChannel();
         // This is normally done by Server.
         channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());

--- a/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
@@ -17,7 +17,7 @@
 package com.netflix.netty.common.proxyprotocol;
 
 import static com.netflix.zuul.netty.server.ssl.SslHandshakeInfoHandler.ATTR_SSL_INFO;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -35,11 +35,13 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.util.AttributeKey;
 import io.netty.util.DefaultAttributeMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 /**
  * Strip Untrusted Proxy Headers Handler Test
@@ -47,7 +49,8 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author Arthur Gonigberg
  * @since May 27, 2020
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class StripUntrustedProxyHeadersHandlerTest {
 
     @Mock
@@ -61,7 +64,7 @@ public class StripUntrustedProxyHeadersHandlerTest {
     private SslHandshakeInfo sslHandshakeInfo;
 
 
-    @Before
+    @BeforeEach
     public void before() {
         when(channelHandlerContext.channel()).thenReturn(channel);
 
@@ -75,7 +78,7 @@ public class StripUntrustedProxyHeadersHandlerTest {
     }
 
     @Test
-    public void allow_never() throws Exception {
+    void allow_never() throws Exception {
         StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.NEVER);
 
         stripHandler.channelRead(channelHandlerContext, msg);
@@ -84,7 +87,7 @@ public class StripUntrustedProxyHeadersHandlerTest {
     }
 
     @Test
-    public void allow_always() throws Exception {
+    void allow_always() throws Exception {
         StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.ALWAYS);
 
         stripHandler.channelRead(channelHandlerContext, msg);
@@ -94,7 +97,7 @@ public class StripUntrustedProxyHeadersHandlerTest {
     }
 
     @Test
-    public void allow_mtls_noCert() throws Exception {
+    void allow_mtls_noCert() throws Exception {
         StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
 
         stripHandler.channelRead(channelHandlerContext, msg);
@@ -103,7 +106,7 @@ public class StripUntrustedProxyHeadersHandlerTest {
     }
 
     @Test
-    public void allow_mtls_cert() throws Exception {
+    void allow_mtls_cert() throws Exception {
         StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
         when(sslHandshakeInfo.getClientAuthRequirement()).thenReturn(ClientAuth.REQUIRE);
 
@@ -114,7 +117,7 @@ public class StripUntrustedProxyHeadersHandlerTest {
     }
 
     @Test
-    public void blacklist_noMatch() {
+    void blacklist_noMatch() {
         StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
 
         stripHandler.checkBlacklist(msg, ImmutableList.of("netflix.net"));
@@ -123,7 +126,7 @@ public class StripUntrustedProxyHeadersHandlerTest {
     }
 
     @Test
-    public void blacklist_match() {
+    void blacklist_match() {
         StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
 
         stripHandler.checkBlacklist(msg, ImmutableList.of("netflix.com"));
@@ -132,7 +135,7 @@ public class StripUntrustedProxyHeadersHandlerTest {
     }
 
     @Test
-    public void blacklist_match_casing() {
+    void blacklist_match_casing() {
         StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
 
         stripHandler.checkBlacklist(msg, ImmutableList.of("NeTfLiX.cOm"));
@@ -141,7 +144,7 @@ public class StripUntrustedProxyHeadersHandlerTest {
     }
 
     @Test
-    public void strip_match() {
+    void strip_match() {
         StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
 
         headers.add("x-forwarded-for", "abcd");

--- a/zuul-core/src/test/java/com/netflix/netty/common/throttle/MaxInboundConnectionsHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/throttle/MaxInboundConnectionsHandlerTest.java
@@ -17,8 +17,9 @@
 package com.netflix.netty.common.throttle;
 
 import static com.netflix.netty.common.throttle.MaxInboundConnectionsHandler.ATTR_CH_THROTTLED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Id;
@@ -27,25 +28,22 @@ import com.netflix.zuul.netty.server.http2.DummyChannelHandler;
 import com.netflix.zuul.passport.CurrentPassport;
 import com.netflix.zuul.passport.PassportState;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class MaxInboundConnectionsHandlerTest {
 
     private Registry registry = new DefaultRegistry();
     private String listener = "test-throttled";
     private Id counterId;
 
-    @Before
+    @BeforeEach
     public void setup() {
         counterId = registry.createId("server.connections.throttled").withTags("id", listener);
     }
 
     @Test
-    public void verifyPassportStateAndAttrs() {
+    void verifyPassportStateAndAttrs() {
 
         final EmbeddedChannel channel = new EmbeddedChannel();
         channel.pipeline().addLast(new DummyChannelHandler());

--- a/zuul-core/src/test/java/com/netflix/zuul/AttrsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/AttrsTest.java
@@ -16,20 +16,15 @@
 
 package com.netflix.zuul;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.truth.Truth;
 import com.netflix.zuul.Attrs.Key;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class AttrsTest {
     @Test
-    public void keysAreUnique() {
+    void keysAreUnique() {
         Attrs attrs = Attrs.newInstance();
         Key<String> key1 = Attrs.newKey("foo");
         key1.put(attrs, "bar");
@@ -40,12 +35,12 @@ public class AttrsTest {
     }
 
     @Test
-    public void newKeyFailsOnNull() {
+    void newKeyFailsOnNull() {
         assertThrows(NullPointerException.class, () -> Attrs.newKey(null));
     }
 
     @Test
-    public void attrsPutFailsOnNull() {
+    void attrsPutFailsOnNull() {
         Attrs attrs = Attrs.newInstance();
         Key<String> key = Attrs.newKey("foo");
 
@@ -53,7 +48,7 @@ public class AttrsTest {
     }
 
     @Test
-    public void attrsPutReplacesOld() {
+    void attrsPutReplacesOld() {
         Attrs attrs = Attrs.newInstance();
         Key<String> key = Attrs.newKey("foo");
         key.put(attrs, "bar");
@@ -64,7 +59,7 @@ public class AttrsTest {
     }
 
     @Test
-    public void getReturnsNull() {
+    void getReturnsNull() {
         Attrs attrs = Attrs.newInstance();
         Key<String> key = Attrs.newKey("foo");
 
@@ -72,7 +67,7 @@ public class AttrsTest {
     }
 
     @Test
-    public void getOrDefault_picksDefault() {
+    void getOrDefault_picksDefault() {
         Attrs attrs = Attrs.newInstance();
         Key<String> key = Attrs.newKey("foo");
 
@@ -80,7 +75,7 @@ public class AttrsTest {
     }
 
     @Test
-    public void getOrDefault_failsOnNullDefault() {
+    void getOrDefault_failsOnNullDefault() {
         Attrs attrs = Attrs.newInstance();
         Key<String> key = Attrs.newKey("foo");
         key.put(attrs, "bar");

--- a/zuul-core/src/test/java/com/netflix/zuul/DynamicFilterLoaderTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/DynamicFilterLoaderTest.java
@@ -15,9 +15,7 @@
  */
 package com.netflix.zuul;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -30,14 +28,11 @@ import com.netflix.zuul.message.ZuulMessage;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-@RunWith(JUnit4.class)
 public class DynamicFilterLoaderTest {
 
     @Mock
@@ -54,7 +49,7 @@ public class DynamicFilterLoaderTest {
 
     private final TestZuulFilter filter = new TestZuulFilter();
 
-    @Before
+    @BeforeEach
     public void before() throws Exception
     {
         MockitoAnnotations.initMocks(this);
@@ -66,7 +61,7 @@ public class DynamicFilterLoaderTest {
     }
 
     @Test
-    public void testGetFilterFromFile() throws Exception {
+    void testGetFilterFromFile() throws Exception {
         assertTrue(loader.putFilter(file));
 
         Collection<ZuulFilter<?, ?>> filters = registry.getAllFilters();
@@ -74,7 +69,7 @@ public class DynamicFilterLoaderTest {
     }
 
     @Test
-    public void testPutFiltersForClasses() throws Exception {
+    void testPutFiltersForClasses() throws Exception {
         loader.putFiltersForClasses(new String[]{TestZuulFilter.class.getName()});
 
         Collection<ZuulFilter<?, ?>> filters = registry.getAllFilters();
@@ -82,7 +77,7 @@ public class DynamicFilterLoaderTest {
     }
 
     @Test
-    public void testPutFiltersForClassesException() throws Exception {
+    void testPutFiltersForClassesException() throws Exception {
         Exception caught = null;
         try {
             loader.putFiltersForClasses(new String[]{"asdf"});
@@ -96,7 +91,7 @@ public class DynamicFilterLoaderTest {
     }
 
     @Test
-    public void testGetFiltersByType() throws Exception {
+    void testGetFiltersByType() throws Exception {
         assertTrue(loader.putFilter(file));
 
         Collection<ZuulFilter<?, ?>> filters = registry.getAllFilters();
@@ -104,20 +99,20 @@ public class DynamicFilterLoaderTest {
 
         Collection<ZuulFilter<?, ?>> list = loader.getFiltersByType(FilterType.INBOUND);
         assertTrue(list != null);
-        assertTrue(list.size() == 1);
+        assertEquals(list.size(), 1);
         ZuulFilter<?, ?> filter = list.iterator().next();
         assertTrue(filter != null);
-        assertTrue(filter.filterType().equals(FilterType.INBOUND));
+        assertEquals(filter.filterType(), FilterType.INBOUND);
     }
 
     @Test
-    public void testGetFilterFromString() throws Exception {
+    void testGetFilterFromString() throws Exception {
         String string = "";
         doReturn(TestZuulFilter.class).when(compiler).compile(string, string);
         ZuulFilter filter = loader.getFilter(string, string);
 
         assertNotNull(filter);
-        assertTrue(filter.getClass() == TestZuulFilter.class);
+        assertEquals(filter.getClass(), TestZuulFilter.class);
 //            assertTrue(loader.filterInstanceMapSize() == 1);
     }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/FilterFileManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/FilterFileManagerTest.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.zuul;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
@@ -24,17 +24,17 @@ import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.FilenameFilter;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Tests for {@link FilterFileManager}.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FilterFileManagerTest {
     @Mock
     private File nonGroovyFile;
@@ -45,19 +45,19 @@ public class FilterFileManagerTest {
     @Mock
     private FilterLoader filterLoader;
 
-    @Before
+    @BeforeEach
     public void before() {
         MockitoAnnotations.initMocks(this);
     }
 
     @Test
-    public void testFileManagerInit() throws Exception {
+    void testFileManagerInit() throws Exception {
         FilterFileManager.FilterFileManagerConfig config =
-            new FilterFileManager.FilterFileManagerConfig(
-                new String[]{"test", "test1"},
-                new String[]{"com.netflix.blah.SomeFilter"},
-                1,
-               (dir, name) -> false);
+                new FilterFileManager.FilterFileManagerConfig(
+                        new String[]{"test", "test1"},
+                        new String[]{"com.netflix.blah.SomeFilter"},
+                        1,
+                        (dir, name) -> false);
         FilterFileManager manager = new FilterFileManager(config, filterLoader);
 
         manager = spy(manager);

--- a/zuul-core/src/test/java/com/netflix/zuul/StaticFilterLoaderTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/StaticFilterLoaderTest.java
@@ -25,17 +25,14 @@ import com.netflix.zuul.message.http.HttpRequestMessage;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class StaticFilterLoaderTest {
 
     private static final FilterFactory factory = new DefaultFilterFactory();
 
     @Test
-    public void getFiltersByType() {
+    void getFiltersByType() {
         StaticFilterLoader filterLoader =
                 new StaticFilterLoader(factory,
                         ImmutableSet.of(DummyFilter2.class, DummyFilter1.class, DummyFilter22.class));
@@ -50,7 +47,7 @@ public class StaticFilterLoaderTest {
     }
 
     @Test
-    public void getFilterByNameAndType() {
+    void getFilterByNameAndType() {
         StaticFilterLoader filterLoader =
                 new StaticFilterLoader(factory, ImmutableSet.of(DummyFilter2.class, DummyFilter1.class));
 

--- a/zuul-core/src/test/java/com/netflix/zuul/com/netflix/zuul/netty/server/push/PushConnectionTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/com/netflix/zuul/netty/server/push/PushConnectionTest.java
@@ -16,10 +16,12 @@
 
 package com.netflix.zuul.com.netflix.zuul.netty.server.push;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.netflix.zuul.netty.server.push.PushConnection;
 import com.netflix.zuul.netty.server.push.PushProtocol;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Author: Susheel Aroskar
@@ -28,55 +30,55 @@ import org.junit.Test;
 public class PushConnectionTest {
 
     @Test
-    public void testOneMessagePerSecond() throws InterruptedException{
+    void testOneMessagePerSecond() throws InterruptedException {
         final PushConnection conn = new PushConnection(PushProtocol.WEBSOCKET, null);
-        for (int i=0; i < 5; i ++) {
-            Assert.assertFalse(conn.isRateLimited());
+        for (int i = 0; i < 5; i++) {
+            assertFalse(conn.isRateLimited());
             Thread.sleep(1000);
         }
     }
 
     @Test
-    public void testThreeMessagesInSuccession() {
+    void testThreeMessagesInSuccession() {
         final PushConnection conn = new PushConnection(PushProtocol.WEBSOCKET, null);
-        Assert.assertFalse(conn.isRateLimited());
-        Assert.assertFalse(conn.isRateLimited());
-        Assert.assertFalse(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
     }
 
     @Test
-    public void testFourMessagesInSuccession() {
+    void testFourMessagesInSuccession() {
         final PushConnection conn = new PushConnection(PushProtocol.WEBSOCKET, null);
-        Assert.assertFalse(conn.isRateLimited());
-        Assert.assertFalse(conn.isRateLimited());
-        Assert.assertFalse(conn.isRateLimited());
-        Assert.assertTrue(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
+        assertTrue(conn.isRateLimited());
     }
 
     @Test
-    public void testFirstThreeMessagesSuccess() {
+    void testFirstThreeMessagesSuccess() {
         final PushConnection conn = new PushConnection(PushProtocol.WEBSOCKET, null);
-        for (int i=0; i < 10; i ++) {
+        for (int i = 0; i < 10; i++) {
             if (i < 3) {
-                Assert.assertFalse(conn.isRateLimited());
+                assertFalse(conn.isRateLimited());
             } else {
-                Assert.assertTrue(conn.isRateLimited());
+                assertTrue(conn.isRateLimited());
             }
         }
     }
 
     @Test
-    public void testMessagesInBatches() throws InterruptedException{
+    void testMessagesInBatches() throws InterruptedException {
         final PushConnection conn = new PushConnection(PushProtocol.WEBSOCKET, null);
-        Assert.assertFalse(conn.isRateLimited());
-        Assert.assertFalse(conn.isRateLimited());
-        Assert.assertFalse(conn.isRateLimited());
-        Assert.assertTrue(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
+        assertTrue(conn.isRateLimited());
         Thread.sleep(2000);
-        Assert.assertFalse(conn.isRateLimited());
-        Assert.assertFalse(conn.isRateLimited());
-        Assert.assertFalse(conn.isRateLimited());
-        Assert.assertTrue(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
+        assertFalse(conn.isRateLimited());
+        assertTrue(conn.isRateLimited());
     }
 
 

--- a/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
@@ -23,9 +23,8 @@ import static com.netflix.zuul.context.Debug.getRequestDebug;
 import static com.netflix.zuul.context.Debug.getRoutingDebug;
 import static com.netflix.zuul.context.Debug.setDebugRequest;
 import static com.netflix.zuul.context.Debug.setDebugRouting;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.truth.Truth;
 import com.netflix.zuul.message.Headers;
@@ -37,12 +36,9 @@ import com.netflix.zuul.message.http.HttpResponseMessageImpl;
 import com.netflix.zuul.message.util.HttpRequestBuilder;
 import io.netty.handler.codec.http.HttpMethod;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class DebugTest {
 
     private SessionContext ctx;
@@ -51,7 +47,7 @@ public class DebugTest {
     private HttpRequestMessage request;
     private HttpResponseMessage response;
 
-    @Before
+    @BeforeEach
     public void setup() {
         ctx = new SessionContext();
 
@@ -73,7 +69,7 @@ public class DebugTest {
     }
 
     @Test
-    public void testRequestDebug() {
+    void testRequestDebug() {
         assertFalse(debugRouting(ctx));
         assertFalse(debugRequest(ctx));
         setDebugRouting(ctx, true);
@@ -89,7 +85,7 @@ public class DebugTest {
     }
 
     @Test
-    public void testWriteInboundRequestDebug() {
+    void testWriteInboundRequestDebug() {
         ctx.setDebugRequest(true);
         ctx.setDebugRequestHeadersOnly(true);
         Debug.writeDebugRequest(ctx, request, true).toBlocking().single();
@@ -102,7 +98,7 @@ public class DebugTest {
     }
 
     @Test
-    public void testWriteOutboundRequestDebug() {
+    void testWriteOutboundRequestDebug() {
         ctx.setDebugRequest(true);
         ctx.setDebugRequestHeadersOnly(true);
         Debug.writeDebugRequest(ctx, request, false).toBlocking().single();
@@ -115,7 +111,7 @@ public class DebugTest {
     }
 
     @Test
-    public void testWriteRequestDebug_WithBody() {
+    void testWriteRequestDebug_WithBody() {
         ctx.setDebugRequest(true);
         ctx.setDebugRequestHeadersOnly(false);
         Debug.writeDebugRequest(ctx, request, true).toBlocking().single();
@@ -129,7 +125,7 @@ public class DebugTest {
     }
 
     @Test
-    public void testWriteInboundResponseDebug() {
+    void testWriteInboundResponseDebug() {
         ctx.setDebugRequest(true);
         ctx.setDebugRequestHeadersOnly(true);
         Debug.writeDebugResponse(ctx, response, true).toBlocking().single();
@@ -142,7 +138,7 @@ public class DebugTest {
     }
 
     @Test
-    public void testWriteOutboundResponseDebug() {
+    void testWriteOutboundResponseDebug() {
         ctx.setDebugRequest(true);
         ctx.setDebugRequestHeadersOnly(true);
         Debug.writeDebugResponse(ctx, response, false).toBlocking().single();
@@ -155,7 +151,7 @@ public class DebugTest {
     }
 
     @Test
-    public void testWriteResponseDebug_WithBody() {
+    void testWriteResponseDebug_WithBody() {
         ctx.setDebugRequest(true);
         ctx.setDebugRequestHeadersOnly(false);
         Debug.writeDebugResponse(ctx, response, true).toBlocking().single();
@@ -169,7 +165,7 @@ public class DebugTest {
     }
 
     @Test
-    public void testNoCMEWhenComparingContexts() {
+    void testNoCMEWhenComparingContexts() {
         final SessionContext context = new SessionContext();
         final SessionContext copy = new SessionContext();
 

--- a/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
@@ -15,28 +15,26 @@
  */
 package com.netflix.zuul.context;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.truth.Truth;
 import com.netflix.zuul.context.SessionContext.Key;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SessionContextTest {
 
     @Test
-    public void testBoolean() {
+    void testBoolean() {
         SessionContext context = new SessionContext();
         assertEquals(context.getBoolean("boolean_test"), Boolean.FALSE);
         assertEquals(context.getBoolean("boolean_test", true), true);
     }
 
     @Test
-    public void keysAreUnique() {
+    void keysAreUnique() {
         SessionContext context = new SessionContext();
         Key<String> key1 = SessionContext.newKey("foo");
         context.put(key1, "bar");
@@ -47,12 +45,12 @@ public class SessionContextTest {
     }
 
     @Test
-    public void newKeyFailsOnNull() {
+    void newKeyFailsOnNull() {
         assertThrows(NullPointerException.class, () -> SessionContext.newKey(null));
     }
 
     @Test
-    public void putFailsOnNull() {
+    void putFailsOnNull() {
         SessionContext context = new SessionContext();
         Key<String> key = SessionContext.newKey("foo");
 
@@ -60,7 +58,7 @@ public class SessionContextTest {
     }
 
     @Test
-    public void putReplacesOld() {
+    void putReplacesOld() {
         SessionContext context = new SessionContext();
         Key<String> key = SessionContext.newKey("foo");
         context.put(key, "bar");
@@ -71,7 +69,7 @@ public class SessionContextTest {
     }
 
     @Test
-    public void getReturnsNull() {
+    void getReturnsNull() {
         SessionContext context = new SessionContext();
         Key<String> key = SessionContext.newKey("foo");
 
@@ -79,7 +77,7 @@ public class SessionContextTest {
     }
 
     @Test
-    public void getOrDefault_picksDefault() {
+    void getOrDefault_picksDefault() {
         SessionContext context = new SessionContext();
         Key<String> key = SessionContext.newKey("foo");
 
@@ -87,7 +85,7 @@ public class SessionContextTest {
     }
 
     @Test
-    public void getOrDefault_failsOnNullDefault() {
+    void getOrDefault_failsOnNullDefault() {
         SessionContext context = new SessionContext();
         Key<String> key = SessionContext.newKey("foo");
         context.put(key, "bar");
@@ -96,7 +94,7 @@ public class SessionContextTest {
     }
 
     @Test
-    public void remove() {
+    void remove() {
         SessionContext context = new SessionContext();
         Key<String> key = SessionContext.newKey("foo");
         context.put(key, "bar");

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/BaseFilterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/BaseFilterTest.java
@@ -19,10 +19,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.netflix.zuul.message.ZuulMessage;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -30,7 +28,6 @@ import org.mockito.MockitoAnnotations;
  * Tests for {@link BaseFilter}.   Currently named BaseFilter2Test as there is an existing
  * class named BaseFilterTest.
  */
-@RunWith(JUnit4.class)
 public class BaseFilterTest {
 
     @Mock
@@ -40,13 +37,13 @@ public class BaseFilterTest {
     @Mock
     private ZuulMessage req;
 
-    @Before
+    @BeforeEach
     public void before() {
         MockitoAnnotations.initMocks(this);
     }
 
     @Test
-    public void testShouldFilter() {
+    void testShouldFilter() {
         class TestZuulFilter extends BaseSyncFilter
         {
             @Override

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
@@ -16,9 +16,7 @@
 
 package com.netflix.zuul.filters.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import com.netflix.zuul.context.SessionContext;
@@ -34,14 +32,14 @@ import io.netty.handler.codec.http.HttpContent;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.zip.GZIPInputStream;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GZipResponseFilterTest {
     private final SessionContext context = new SessionContext();
     private final Headers originalRequestHeaders = new Headers();
@@ -54,7 +52,7 @@ public class GZipResponseFilterTest {
     GZipResponseFilter filter;
     HttpResponseMessage response;
 
-    @Before
+    @BeforeEach
     public void setup() {
         //when(request.getContext()).thenReturn(context);
         when(originalRequest.getHeaders()).thenReturn(originalRequestHeaders);
@@ -66,7 +64,7 @@ public class GZipResponseFilterTest {
     }
 
     @Test
-    public void prepareResponseBody_NeedsGZipping() throws Exception {
+    void prepareResponseBody_NeedsGZipping() throws Exception {
         originalRequestHeaders.set("Accept-Encoding", "gzip");
 
         byte[] originBody = "blah".getBytes();
@@ -103,7 +101,7 @@ public class GZipResponseFilterTest {
     }
 
     @Test
-    public void prepareResponseBody_NeedsGZipping_gzipDeflate() throws Exception {
+    void prepareResponseBody_NeedsGZipping_gzipDeflate() throws Exception {
         originalRequestHeaders.set("Accept-Encoding", "gzip,deflate");
 
         byte[] originBody = "blah".getBytes();
@@ -140,7 +138,7 @@ public class GZipResponseFilterTest {
     }
 
     @Test
-    public void prepareResponseBody_alreadyZipped() throws Exception {
+    void prepareResponseBody_alreadyZipped() throws Exception {
         originalRequestHeaders.set("Accept-Encoding", "gzip,deflate");
 
         byte[] originBody = "blah".getBytes();
@@ -152,7 +150,7 @@ public class GZipResponseFilterTest {
     }
 
     @Test
-    public void prepareResponseBody_alreadyDeflated() throws Exception {
+    void prepareResponseBody_alreadyDeflated() throws Exception {
         originalRequestHeaders.set("Accept-Encoding", "gzip,deflate");
 
         byte[] originBody = "blah".getBytes();
@@ -164,7 +162,7 @@ public class GZipResponseFilterTest {
     }
 
     @Test
-    public void prepareResponseBody_NeedsGZipping_butTooSmall() throws Exception {
+    void prepareResponseBody_NeedsGZipping_butTooSmall() throws Exception {
         originalRequestHeaders.set("Accept-Encoding", "gzip");
         byte[] originBody = "blah".getBytes();
         response.getHeaders().set("Content-Length", Integer.toString(originBody.length));
@@ -173,7 +171,7 @@ public class GZipResponseFilterTest {
     }
 
     @Test
-    public void prepareChunkedEncodedResponseBody_NeedsGZipping() throws Exception {
+    void prepareChunkedEncodedResponseBody_NeedsGZipping() throws Exception {
         originalRequestHeaders.set("Accept-Encoding", "gzip");
         response.getHeaders().set("Transfer-Encoding", "chunked");
         response.setHasBody(true);

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/ProxyEndpointTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/ProxyEndpointTest.java
@@ -31,22 +31,22 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.local.LocalAddress;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ProxyEndpointTest {
 
     ProxyEndpoint proxyEndpoint;
     HttpRequestMessage request;
 
-    @Before
+    @BeforeEach
     public void setup() {
         ChannelHandlerContext chc = mock(ChannelHandlerContext.class);
         NettyRequestAttemptFactory attemptFactory = mock(NettyRequestAttemptFactory.class);
@@ -63,7 +63,7 @@ public class ProxyEndpointTest {
     }
 
     @Test
-    public void testRetryWillResetBodyReader() {
+    void testRetryWillResetBodyReader() {
 
         assertEquals("Hello There", new String(request.getBody()));
 

--- a/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
@@ -16,10 +16,7 @@
 
 package com.netflix.zuul.message;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.common.truth.Truth;
 import com.netflix.zuul.exception.ZuulException;
@@ -32,18 +29,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link Headers}.
  */
-@RunWith(JUnit4.class)
 public class HeadersTest {
 
     @Test
-    public void copyOf() {
+    void copyOf() {
         Headers headers = new Headers();
         headers.set("Content-Length", "5");
         Headers headers2 = Headers.copyOf(headers);
@@ -55,7 +49,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void getFirst_normalizesName() {
+    void getFirst_normalizesName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -65,7 +59,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void getFirst_headerName_normalizesName() {
+    void getFirst_headerName_normalizesName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -75,7 +69,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void getFirst_returnsNull() {
+    void getFirst_returnsNull() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -85,7 +79,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void getFirst_headerName_returnsNull() {
+    void getFirst_headerName_returnsNull() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -95,7 +89,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void getFirst_returnsDefault() {
+    void getFirst_returnsDefault() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -105,7 +99,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void getFirst_headerName_returnsDefault() {
+    void getFirst_headerName_returnsDefault() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -115,7 +109,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void forEachNormalised() {
+    void forEachNormalised() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -130,7 +124,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void getAll() {
+    void getAll() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -140,7 +134,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void getAll_headerName() {
+    void getAll_headerName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -151,7 +145,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setClearsExisting() {
+    void setClearsExisting() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -164,7 +158,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setClearsExisting_headerName() {
+    void setClearsExisting_headerName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -177,7 +171,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setNullIsEmtpy() {
+    void setNullIsEmtpy() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -190,7 +184,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setNullIsEmtpy_headerName() {
+    void setNullIsEmtpy_headerName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -203,7 +197,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfValidNullIsEmtpy() {
+    void setIfValidNullIsEmtpy() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -216,7 +210,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfValidNullIsEmtpy_headerName() {
+    void setIfValidNullIsEmtpy_headerName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -229,7 +223,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfValidIgnoresInvalidValues() {
+    void setIfValidIgnoresInvalidValues() {
         Headers headers = new Headers();
         headers.add("X-Valid-K1", "abc-xyz");
         headers.add("X-Valid-K2", "def-xyz");
@@ -246,7 +240,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfValidIgnoresInvalidValues_headerName() {
+    void setIfValidIgnoresInvalidValues_headerName() {
         Headers headers = new Headers();
         headers.add("X-Valid-K1", "abc-xyz");
         headers.add("X-Valid-K2", "def-xyz");
@@ -263,7 +257,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfValidIgnoresInvalidKey() {
+    void setIfValidIgnoresInvalidKey() {
         Headers headers = new Headers();
         headers.add("X-Valid-K1", "abc-xyz");
 
@@ -279,7 +273,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfValidIgnoresInvalidKey_headerName() {
+    void setIfValidIgnoresInvalidKey_headerName() {
         Headers headers = new Headers();
         headers.add("X-Valid-K1", "abc-xyz");
 
@@ -295,7 +289,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfAbsentKeepsExisting() {
+    void setIfAbsentKeepsExisting() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -307,7 +301,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfAbsentKeepsExisting_headerName() {
+    void setIfAbsentKeepsExisting_headerName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -319,7 +313,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfAbsentFailsOnNull() {
+    void setIfAbsentFailsOnNull() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -329,7 +323,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfAbsentFailsOnNull_headerName() {
+    void setIfAbsentFailsOnNull_headerName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -339,7 +333,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfAbsent() {
+    void setIfAbsent() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -351,7 +345,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfAbsent_headerName() {
+    void setIfAbsent_headerName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -363,7 +357,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfAbsentAndValid() {
+    void setIfAbsentAndValid() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -377,7 +371,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void setIfAbsentAndValidIgnoresInvalidValues() {
+    void setIfAbsentAndValidIgnoresInvalidValues() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
 
@@ -393,7 +387,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void add() {
+    void add() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -405,7 +399,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void add_headerName() {
+    void add_headerName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -417,7 +411,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void addIfValid() {
+    void addIfValid() {
         Headers headers = new Headers();
         headers.addIfValid("Via", "duct");
         headers.addIfValid("Cookie", "abc=def");
@@ -429,7 +423,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void addIfValid_headerName() {
+    void addIfValid_headerName() {
         Headers headers = new Headers();
         headers.addIfValid("Via", "duct");
         headers.addIfValid("Cookie", "abc=def");
@@ -441,7 +435,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void addIfValidIgnoresInvalidValues() {
+    void addIfValidIgnoresInvalidValues() {
         Headers headers = new Headers();
         headers.addIfValid("Via", "duct");
         headers.addIfValid("Cookie", "abc=def");
@@ -458,7 +452,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void putAll() {
+    void putAll() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -478,7 +472,7 @@ public class HeadersTest {
 
 
     @Test
-    public void remove() {
+    void remove() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -494,7 +488,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void remove_headerName() {
+    void remove_headerName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -510,7 +504,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void removeEmpty() {
+    void removeEmpty() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -526,7 +520,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void removeEmpty_headerName() {
+    void removeEmpty_headerName() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -542,7 +536,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void removeIf() {
+    void removeIf() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("Cookie", "this=that");
@@ -557,7 +551,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void keySet() {
+    void keySet() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("COOKie", "this=that");
@@ -577,7 +571,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void contains() {
+    void contains() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("COOKie", "this=that");
@@ -591,7 +585,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void containsValue() {
+    void containsValue() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
         headers.add("COOKie", "this=that");
@@ -606,7 +600,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void testCaseInsensitiveKeys_Set() {
+    void testCaseInsensitiveKeys_Set() {
         Headers headers = new Headers();
         headers.set("Content-Length", "5");
         headers.set("content-length", "10");
@@ -617,7 +611,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void testCaseInsensitiveKeys_Add() {
+    void testCaseInsensitiveKeys_Add() {
         Headers headers = new Headers();
         headers.add("Content-Length", "5");
         headers.add("content-length", "10");
@@ -629,7 +623,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void testCaseInsensitiveKeys_SetIfAbsent() {
+    void testCaseInsensitiveKeys_SetIfAbsent() {
         Headers headers = new Headers();
         headers.set("Content-Length", "5");
         headers.setIfAbsent("content-length", "10");
@@ -640,7 +634,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void testCaseInsensitiveKeys_PutAll() {
+    void testCaseInsensitiveKeys_PutAll() {
         Headers headers = new Headers();
         headers.add("Content-Length", "5");
         headers.add("content-length", "10");
@@ -655,7 +649,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void testSanitizeValues_CRLF() {
+    void testSanitizeValues_CRLF() {
         Headers headers = new Headers();
 
         assertThrows(ZuulException.class, () -> headers.addAndValidate("x-test-break1", "a\r\nb\r\nc"));
@@ -663,7 +657,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void testSanitizeValues_LF() {
+    void testSanitizeValues_LF() {
         Headers headers = new Headers();
 
         assertThrows(ZuulException.class, () -> headers.addAndValidate("x-test-break1", "a\nb\nc"));
@@ -671,7 +665,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void testSanitizeValues_ISO88591Value() {
+    void testSanitizeValues_ISO88591Value() {
         Headers headers = new Headers();
 
         headers.addAndValidate("x-test-ISO-8859-1", "P Venkmän");
@@ -684,7 +678,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void testSanitizeValues_UTF8Value() {
+    void testSanitizeValues_UTF8Value() {
         // Ideally Unicode characters should not appear in the Header values.
         Headers headers = new Headers();
 
@@ -704,7 +698,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void testSanitizeValues_addSetHeaderName() {
+    void testSanitizeValues_addSetHeaderName() {
         Headers headers = new Headers();
 
         assertThrows(ZuulException.class, () -> headers.setAndValidate(new HeaderName("x-test-break1"), "a\nb\nc"));
@@ -712,7 +706,7 @@ public class HeadersTest {
     }
 
     @Test
-    public void testSanitizeValues_nameCRLF() {
+    void testSanitizeValues_nameCRLF() {
         Headers headers = new Headers();
 
         assertThrows(ZuulException.class, () -> headers.addAndValidate("x-test-br\r\neak1", "a\r\nb\r\nc"));

--- a/zuul-core/src/test/java/com/netflix/zuul/message/ZuulMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/ZuulMessageImplTest.java
@@ -21,19 +21,19 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ZuulMessageImplTest {
     private static final String TEXT1 = "Hello World!";
     private static final String TEXT2 = "Goodbye World!";
 
     @Test
-    public void testClone() {
+    void testClone() {
         SessionContext ctx1 = new SessionContext();
         ctx1.set("k1", "v1");
         Headers headers1 = new Headers();
@@ -55,7 +55,7 @@ public class ZuulMessageImplTest {
     }
 
     @Test
-    public void testBufferBody2GetBody() {
+    void testBufferBody2GetBody() {
         final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("Hello ".getBytes())));
         msg.bufferBodyContents(new DefaultLastHttpContent(Unpooled.copiedBuffer("World!".getBytes())));
@@ -67,7 +67,7 @@ public class ZuulMessageImplTest {
     }
 
     @Test
-    public void testBufferBody3GetBody() {
+    void testBufferBody3GetBody() {
         final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("Hello ".getBytes())));
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("World!".getBytes())));
@@ -80,7 +80,7 @@ public class ZuulMessageImplTest {
     }
 
     @Test
-    public void testBufferBody3GetBodyAsText() {
+    void testBufferBody3GetBodyAsText() {
         final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("Hello ".getBytes())));
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("World!".getBytes())));
@@ -93,7 +93,7 @@ public class ZuulMessageImplTest {
     }
 
     @Test
-    public void testSetBodyGetBody() {
+    void testSetBodyGetBody() {
         final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.setBody(TEXT1.getBytes());
         final String body = new String(msg.getBody());
@@ -103,7 +103,7 @@ public class ZuulMessageImplTest {
     }
 
     @Test
-    public void testSetBodyAsTextGetBody() {
+    void testSetBodyAsTextGetBody() {
         final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.setBodyAsText(TEXT1);
         final String body = new String(msg.getBody());
@@ -115,7 +115,7 @@ public class ZuulMessageImplTest {
     }
 
     @Test
-    public void testSetBodyAsTextGetBodyAsText() {
+    void testSetBodyAsTextGetBodyAsText() {
         final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.setBodyAsText(TEXT1);
         final String body = msg.getBodyAsText();
@@ -127,7 +127,7 @@ public class ZuulMessageImplTest {
     }
 
     @Test
-    public void testMultiSetBodyAsTextGetBody() {
+    void testMultiSetBodyAsTextGetBody() {
         final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.setBodyAsText(TEXT1);
         String body = new String(msg.getBody());
@@ -147,7 +147,7 @@ public class ZuulMessageImplTest {
     }
 
     @Test
-    public void testMultiSetBodyGetBody() {
+    void testMultiSetBodyGetBody() {
         final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.setBody(TEXT1.getBytes());
         String body = new String(msg.getBody());
@@ -167,7 +167,7 @@ public class ZuulMessageImplTest {
     }
 
     @Test
-    public void testResettingBodyReaderIndex() {
+    void testResettingBodyReaderIndex() {
         final ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("Hello ".getBytes())));
         msg.bufferBodyContents(new DefaultLastHttpContent(Unpooled.copiedBuffer("World!".getBytes())));
@@ -177,7 +177,7 @@ public class ZuulMessageImplTest {
             c.content().readerIndex(c.content().capacity());
         }
 
-        assertArrayEquals("body should be empty as readerIndex at end of buffers", new byte[0], msg.getBody());
+        assertArrayEquals(new byte[0], msg.getBody(), "body should be empty as readerIndex at end of buffers");
         msg.resetBodyReader();
         assertEquals("Hello World!", new String(msg.getBody()));
     }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpQueryParamsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpQueryParamsTest.java
@@ -17,18 +17,19 @@
 package com.netflix.zuul.message.http;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import java.util.Locale;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(MockitoJUnitRunner.class)
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 public class HttpQueryParamsTest {
 
     @Test
-    public void testMultiples() {
+    void testMultiples() {
         HttpQueryParams qp = new HttpQueryParams();
         qp.add("k1", "v1");
         qp.add("k1", "v2");
@@ -38,7 +39,7 @@ public class HttpQueryParamsTest {
     }
 
     @Test
-    public void testToEncodedString() {
+    void testToEncodedString() {
         HttpQueryParams qp = new HttpQueryParams();
         qp.add("k'1", "v1&");
         assertEquals("k%271=v1%26", qp.toEncodedString());
@@ -49,7 +50,7 @@ public class HttpQueryParamsTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         HttpQueryParams qp = new HttpQueryParams();
         qp.add("k'1", "v1&");
         assertEquals("k'1=v1&", qp.toString());
@@ -60,7 +61,7 @@ public class HttpQueryParamsTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         HttpQueryParams qp1 = new HttpQueryParams();
         qp1.add("k1", "v1");
         qp1.add("k2", "v2");
@@ -72,7 +73,7 @@ public class HttpQueryParamsTest {
     }
 
     @Test
-    public void parseKeysWithoutValues() {
+    void parseKeysWithoutValues() {
         HttpQueryParams expected = new HttpQueryParams();
         expected.add("k1", "");
         expected.add("k2", "v2");
@@ -86,7 +87,7 @@ public class HttpQueryParamsTest {
     }
 
     @Test
-    public void parseKeyWithoutValueEquals() {
+    void parseKeyWithoutValueEquals() {
         HttpQueryParams expected = new HttpQueryParams();
         expected.add("k1", "");
 
@@ -98,7 +99,7 @@ public class HttpQueryParamsTest {
     }
 
     @Test
-    public void parseKeyWithoutValue() {
+    void parseKeyWithoutValue() {
         HttpQueryParams expected = new HttpQueryParams();
         expected.add("k1", "");
 
@@ -110,7 +111,7 @@ public class HttpQueryParamsTest {
     }
 
     @Test
-    public void parseKeyWithoutValueShort() {
+    void parseKeyWithoutValueShort() {
         HttpQueryParams expected = new HttpQueryParams();
         expected.add("=", "");
 
@@ -122,7 +123,7 @@ public class HttpQueryParamsTest {
     }
 
     @Test
-    public void parseKeysWithoutValuesMixedTrailers() {
+    void parseKeysWithoutValuesMixedTrailers() {
         HttpQueryParams expected = new HttpQueryParams();
         expected.add("k1", "");
         expected.add("k2", "v2");
@@ -137,7 +138,7 @@ public class HttpQueryParamsTest {
     }
 
     @Test
-    public void parseKeysIgnoreCase() {
+    void parseKeysIgnoreCase() {
         String camelCaseKey = "keyName";
         HttpQueryParams queryParams = new HttpQueryParams();
         queryParams.add("foo", "bar");

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
@@ -16,10 +16,7 @@
 
 package com.netflix.zuul.message.http;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -39,25 +36,24 @@ import java.net.URISyntaxException;
 import java.util.Optional;
 
 import org.apache.commons.configuration.AbstractConfiguration;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HttpRequestMessageImplTest {
 
     HttpRequestMessageImpl request;
     private final AbstractConfiguration config = ConfigurationManager.getConfigInstance();
 
-    @After
+    @AfterEach
     public void resetConfig() {
         config.clearProperty("zuul.HttpRequestMessage.host.header.strict.validation");
     }
 
     @Test
-    public void testOriginalRequestInfo() {
+    void testOriginalRequestInfo() {
         HttpQueryParams queryParams = new HttpQueryParams();
         queryParams.add("flag", "5");
         Headers headers = new Headers();
@@ -69,25 +65,25 @@ public class HttpRequestMessageImplTest {
         request.storeInboundRequest();
         HttpRequestInfo originalRequest = request.getInboundRequest();
 
-        Assert.assertEquals(request.getPort(), originalRequest.getPort());
-        Assert.assertEquals(request.getPath(), originalRequest.getPath());
-        Assert.assertEquals(request.getQueryParams().getFirst("flag"),
+        assertEquals(request.getPort(), originalRequest.getPort());
+        assertEquals(request.getPath(), originalRequest.getPath());
+        assertEquals(request.getQueryParams().getFirst("flag"),
                 originalRequest.getQueryParams().getFirst("flag"));
-        Assert.assertEquals(request.getHeaders().getFirst("Host"), originalRequest.getHeaders().getFirst("Host"));
+        assertEquals(request.getHeaders().getFirst("Host"), originalRequest.getHeaders().getFirst("Host"));
 
         request.setPort(8080);
         request.setPath("/another/place");
         request.getQueryParams().set("flag", "20");
         request.getHeaders().set("Host", "wah.netflix.com");
 
-        Assert.assertEquals(7002, originalRequest.getPort());
-        Assert.assertEquals("/some/where", originalRequest.getPath());
-        Assert.assertEquals("5", originalRequest.getQueryParams().getFirst("flag"));
-        Assert.assertEquals("blah.netflix.com", originalRequest.getHeaders().getFirst("Host"));
+        assertEquals(7002, originalRequest.getPort());
+        assertEquals("/some/where", originalRequest.getPath());
+        assertEquals("5", originalRequest.getQueryParams().getFirst("flag"));
+        assertEquals("blah.netflix.com", originalRequest.getHeaders().getFirst("Host"));
     }
 
     @Test
-    public void testReconstructURI() {
+    void testReconstructURI() {
         HttpQueryParams queryParams = new HttpQueryParams();
         queryParams.add("flag", "5");
         Headers headers = new Headers();
@@ -95,7 +91,7 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("https://blah.netflix.com:7002/some/where?flag=5", request.reconstructURI());
+        assertEquals("https://blah.netflix.com:7002/some/where?flag=5", request.reconstructURI());
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -104,7 +100,7 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "http", 7002, "localhost");
-        Assert.assertEquals("http://place.netflix.com/some/where", request.reconstructURI());
+        assertEquals("http://place.netflix.com/some/where", request.reconstructURI());
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -114,14 +110,14 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "http", 7002, "localhost");
-        Assert.assertEquals("https://place.netflix.com/some/where", request.reconstructURI());
+        assertEquals("https://place.netflix.com/some/where", request.reconstructURI());
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "http", 7002, "localhost");
-        Assert.assertEquals("http://localhost:7002/some/where", request.reconstructURI());
+        assertEquals("http://localhost:7002/some/where", request.reconstructURI());
 
         queryParams = new HttpQueryParams();
         queryParams.add("flag", "5");
@@ -130,32 +126,34 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some%20where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("https://localhost:7002/some%20where?flag=5&flag+B=9", request.reconstructURI());
+        assertEquals("https://localhost:7002/some%20where?flag=5&flag+B=9", request.reconstructURI());
     }
 
     @Test
-    public void testReconstructURI_immutable() {
+    void testReconstructURI_immutable() {
         HttpQueryParams queryParams = new HttpQueryParams();
         queryParams.add("flag", "5");
         Headers headers = new Headers();
         headers.add("Host", "blah.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
-                "192.168.0.2", "https", 7002, "localhost", new SocketAddress() {}, true);
+                "192.168.0.2", "https", 7002, "localhost", new SocketAddress() {
+                }, true);
 
         // Check it's the same value 2nd time.
-        Assert.assertEquals("https://blah.netflix.com:7002/some/where?flag=5", request.reconstructURI());
-        Assert.assertEquals("https://blah.netflix.com:7002/some/where?flag=5", request.reconstructURI());
+        assertEquals("https://blah.netflix.com:7002/some/where?flag=5", request.reconstructURI());
+        assertEquals("https://blah.netflix.com:7002/some/where?flag=5", request.reconstructURI());
 
         // Check that cached on 1st usage.
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
-                "192.168.0.2", "https", 7002, "localhost",new SocketAddress() {}, true);
+                "192.168.0.2", "https", 7002, "localhost", new SocketAddress() {
+                }, true);
         request = spy(request);
         when(request._reconstructURI()).thenReturn("http://testhost/blah");
         verify(request, times(1))._reconstructURI();
-        Assert.assertEquals("http://testhost/blah", request.reconstructURI());
-        Assert.assertEquals("http://testhost/blah", request.reconstructURI());
+        assertEquals("http://testhost/blah", request.reconstructURI());
+        assertEquals("http://testhost/blah", request.reconstructURI());
 
         // Check that throws exception if we try to mutate it.
         try {
@@ -167,7 +165,7 @@ public class HttpRequestMessageImplTest {
     }
 
     @Test
-    public void testPathAndQuery() {
+    void testPathAndQuery() {
         HttpQueryParams queryParams = new HttpQueryParams();
         queryParams.add("flag", "5");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
@@ -175,45 +173,47 @@ public class HttpRequestMessageImplTest {
                 "192.168.0.2", "https", 7002, "localhost");
 
         // Check that value changes.
-        Assert.assertEquals("/some/where?flag=5", request.getPathAndQuery());
+        assertEquals("/some/where?flag=5", request.getPathAndQuery());
         request.getQueryParams().add("k", "v");
-        Assert.assertEquals("/some/where?flag=5&k=v", request.getPathAndQuery());
+        assertEquals("/some/where?flag=5&k=v", request.getPathAndQuery());
         request.setPath("/other");
-        Assert.assertEquals("/other?flag=5&k=v", request.getPathAndQuery());
+        assertEquals("/other?flag=5&k=v", request.getPathAndQuery());
     }
 
     @Test
-    public void testPathAndQuery_immutable() {
+    void testPathAndQuery_immutable() {
         HttpQueryParams queryParams = new HttpQueryParams();
         queryParams.add("flag", "5");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 new Headers(),
-                "192.168.0.2", "https", 7002, "localhost", new SocketAddress() {}, true);
+                "192.168.0.2", "https", 7002, "localhost", new SocketAddress() {
+                }, true);
 
         // Check it's the same value 2nd time.
-        Assert.assertEquals("/some/where?flag=5", request.getPathAndQuery());
-        Assert.assertEquals("/some/where?flag=5", request.getPathAndQuery());
+        assertEquals("/some/where?flag=5", request.getPathAndQuery());
+        assertEquals("/some/where?flag=5", request.getPathAndQuery());
 
         // Check that cached on 1st usage.
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 new Headers(),
-                "192.168.0.2", "https", 7002, "localhost", new SocketAddress() {}, true);
+                "192.168.0.2", "https", 7002, "localhost", new SocketAddress() {
+                }, true);
         request = spy(request);
         when(request.generatePathAndQuery()).thenReturn("/blah");
         verify(request, times(1)).generatePathAndQuery();
-        Assert.assertEquals("/blah", request.getPathAndQuery());
-        Assert.assertEquals("/blah", request.getPathAndQuery());
+        assertEquals("/blah", request.getPathAndQuery());
+        assertEquals("/blah", request.getPathAndQuery());
     }
 
     @Test
-    public void testGetOriginalHost() {
+    void testGetOriginalHost() {
         HttpQueryParams queryParams = new HttpQueryParams();
         Headers headers = new Headers();
         headers.add("Host", "blah.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("blah.netflix.com", request.getOriginalHost());
+        assertEquals("blah.netflix.com", request.getOriginalHost());
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -221,7 +221,7 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("0.0.0.1", request.getOriginalHost());
+        assertEquals("0.0.0.1", request.getOriginalHost());
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -229,7 +229,7 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("0.0.0.1", request.getOriginalHost());
+        assertEquals("0.0.0.1", request.getOriginalHost());
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -237,7 +237,7 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("[::2]", request.getOriginalHost());
+        assertEquals("[::2]", request.getOriginalHost());
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -245,7 +245,7 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("[::2]", request.getOriginalHost());
+        assertEquals("[::2]", request.getOriginalHost());
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com");
@@ -253,25 +253,25 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("foo.netflix.com", request.getOriginalHost());
+        assertEquals("foo.netflix.com", request.getOriginalHost());
 
         headers = new Headers();
         headers.add("X-Forwarded-Host", "foo.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("foo.netflix.com", request.getOriginalHost());
+        assertEquals("foo.netflix.com", request.getOriginalHost());
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com:8080");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("blah.netflix.com", request.getOriginalHost());
+        assertEquals("blah.netflix.com", request.getOriginalHost());
     }
 
     @Test
-    public void testGetOriginalHost_handlesNonRFC2396Hostnames() {
+    void testGetOriginalHost_handlesNonRFC2396Hostnames() {
         config.setProperty("zuul.HttpRequestMessage.host.header.strict.validation", false);
 
         HttpQueryParams queryParams = new HttpQueryParams();
@@ -280,32 +280,32 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("my_underscore_endpoint.netflix.com", request.getOriginalHost());
+        assertEquals("my_underscore_endpoint.netflix.com", request.getOriginalHost());
 
         headers = new Headers();
         headers.add("Host", "my_underscore_endpoint.netflix.com:8080");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("my_underscore_endpoint.netflix.com", request.getOriginalHost());
+        assertEquals("my_underscore_endpoint.netflix.com", request.getOriginalHost());
 
         headers = new Headers();
         headers.add("Host", "my_underscore_endpoint^including~more-chars.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("my_underscore_endpoint^including~more-chars.netflix.com", request.getOriginalHost());
+        assertEquals("my_underscore_endpoint^including~more-chars.netflix.com", request.getOriginalHost());
 
         headers = new Headers();
         headers.add("Host", "hostname%5Ewith-url-encoded.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("hostname%5Ewith-url-encoded.netflix.com", request.getOriginalHost());
+        assertEquals("hostname%5Ewith-url-encoded.netflix.com", request.getOriginalHost());
     }
 
     @Test
-    public void getOriginalHost_failsOnUnbracketedIpv6Address() {
+    void getOriginalHost_failsOnUnbracketedIpv6Address() {
         HttpQueryParams queryParams = new HttpQueryParams();
         Headers headers = new Headers();
         headers.add("Host", "ba::dd");
@@ -317,7 +317,7 @@ public class HttpRequestMessageImplTest {
     }
 
     @Test
-    public void getOriginalHost_fallsBackOnUnbracketedIpv6Address_WithNonStrictValidation() {
+    void getOriginalHost_fallsBackOnUnbracketedIpv6Address_WithNonStrictValidation() {
         config.setProperty("zuul.HttpRequestMessage.host.header.strict.validation", false);
 
         HttpQueryParams queryParams = new HttpQueryParams();
@@ -327,17 +327,17 @@ public class HttpRequestMessageImplTest {
                 headers,
                 "192.168.0.2", "https", 7002, "server");
 
-        Assert.assertEquals("server", request.getOriginalHost());
+        assertEquals("server", request.getOriginalHost());
     }
 
     @Test
-    public void testGetOriginalPort() {
+    void testGetOriginalPort() {
         HttpQueryParams queryParams = new HttpQueryParams();
         Headers headers = new Headers();
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals(7002, request.getOriginalPort());
+        assertEquals(7002, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com");
@@ -345,42 +345,42 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals(443, request.getOriginalPort());
+        assertEquals(443, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com:443");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals(443, request.getOriginalPort());
+        assertEquals(443, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "127.0.0.2:443");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals(443, request.getOriginalPort());
+        assertEquals(443, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "127.0.0.2");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals(7002, request.getOriginalPort());
+        assertEquals(7002, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "[::2]:443");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals(443, request.getOriginalPort());
+        assertEquals(443, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "[::2]");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals(7002, request.getOriginalPort());
+        assertEquals(7002, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com:443");
@@ -388,18 +388,18 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals(7005, request.getOriginalPort());
+        assertEquals(7005, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "host_with_underscores.netflix.com:8080");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals("should fallback to server port", 7002, request.getOriginalPort());
+        assertEquals(7002, request.getOriginalPort(), "should fallback to server port");
     }
 
     @Test
-    public void testGetOriginalPort_NonStrictValidation() {
+    void testGetOriginalPort_NonStrictValidation() {
         config.setProperty("zuul.HttpRequestMessage.host.header.strict.validation", false);
 
         HttpQueryParams queryParams = new HttpQueryParams();
@@ -408,25 +408,25 @@ public class HttpRequestMessageImplTest {
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals(8080, request.getOriginalPort());
+        assertEquals(8080, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "host-with-carrots^1.0.0.netflix.com:8080");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals(8080, request.getOriginalPort());
+        assertEquals(8080, request.getOriginalPort());
 
         headers = new Headers();
         headers.add("Host", "host-with-carrots-no-port^1.0.0.netflix.com");
         request = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST", "/some/where", queryParams,
                 headers,
                 "192.168.0.2", "https", 7002, "localhost");
-        Assert.assertEquals(7002, request.getOriginalPort());
+        assertEquals(7002, request.getOriginalPort());
     }
 
     @Test
-    public void getOriginalPort_fallsBackOnUnbracketedIpv6Address() throws URISyntaxException {
+    void getOriginalPort_fallsBackOnUnbracketedIpv6Address() throws URISyntaxException {
         Headers headers = new Headers();
         headers.add("Host", "ba::33");
 
@@ -434,7 +434,7 @@ public class HttpRequestMessageImplTest {
     }
 
     @Test
-    public void getOriginalPort_EmptyXFFPort() throws URISyntaxException {
+    void getOriginalPort_EmptyXFFPort() throws URISyntaxException {
         Headers headers = new Headers();
         headers.add(HttpHeaderNames.X_FORWARDED_PORT, "");
 
@@ -443,7 +443,7 @@ public class HttpRequestMessageImplTest {
     }
 
     @Test
-    public void getOriginalPort_respectsProxyProtocol() throws URISyntaxException {
+    void getOriginalPort_respectsProxyProtocol() throws URISyntaxException {
         SessionContext context = new SessionContext();
         context.set(CommonContextKeys.PROXY_PROTOCOL_DESTINATION_ADDRESS,
                 new InetSocketAddress(InetAddresses.forString("1.1.1.1"), 443));
@@ -453,7 +453,7 @@ public class HttpRequestMessageImplTest {
     }
 
     @Test
-    public void testCleanCookieHeaders() {
+    void testCleanCookieHeaders() {
         assertEquals("BlahId=12345; something=67890;",
                 HttpRequestMessageImpl.cleanCookieHeader("BlahId=12345; Secure, something=67890;"));
         assertEquals("BlahId=12345; something=67890;",
@@ -464,7 +464,7 @@ public class HttpRequestMessageImplTest {
     }
 
     @Test
-    public void shouldPreferClientDestPortWhenInitialized() {
+    void shouldPreferClientDestPortWhenInitialized() {
         HttpRequestMessageImpl message = new HttpRequestMessageImpl(new SessionContext(), "HTTP/1.1", "POST",
                 "/some/where", new HttpQueryParams(), new Headers(),
                 "192.168.0.2", "https", 7002, "localhost", new InetSocketAddress("api.netflix.com", 443), true);

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpResponseMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpResponseMessageImplTest.java
@@ -16,24 +16,22 @@
 
 package com.netflix.zuul.message.http;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.Headers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.charset.StandardCharsets;
 
 /**
  * Unit tests for {@link HttpResponseMessageImpl}.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HttpResponseMessageImplTest {
     private static final String TEXT1 = "Hello World!";
     private static final String TEXT2 = "Goodbye World!";
@@ -43,13 +41,13 @@ public class HttpResponseMessageImplTest {
 
     private HttpResponseMessageImpl response;
 
-    @Before
+    @BeforeEach
     public void setup() {
         response = new HttpResponseMessageImpl(new SessionContext(), new Headers(), request, 200);
     }
 
     @Test
-    public void testHasSetCookieWithName() {
+    void testHasSetCookieWithName() {
         response.getHeaders().add("Set-Cookie", "c1=1234; Max-Age=-1; Expires=Tue, 01 Sep 2015 22:49:57 GMT; Path=/; Domain=.netflix.com");
         response.getHeaders().add("Set-Cookie", "c2=4567; Max-Age=-1; Expires=Tue, 01 Sep 2015 22:49:57 GMT; Path=/; Domain=.netflix.com");
 
@@ -59,7 +57,7 @@ public class HttpResponseMessageImplTest {
     }
 
     @Test
-    public void testRemoveExistingSetCookie() {
+    void testRemoveExistingSetCookie() {
         response.getHeaders().add("Set-Cookie", "c1=1234; Max-Age=-1; Expires=Tue, 01 Sep 2015 22:49:57 GMT; Path=/; Domain=.netflix.com");
         response.getHeaders().add("Set-Cookie", "c2=4567; Max-Age=-1; Expires=Tue, 01 Sep 2015 22:49:57 GMT; Path=/; Domain=.netflix.com");
 
@@ -71,7 +69,7 @@ public class HttpResponseMessageImplTest {
     }
 
     @Test
-    public void testContentLengthHeaderHasCorrectValue() {
+    void testContentLengthHeaderHasCorrectValue() {
         assertEquals(0, response.getHeaders().getAll("Content-Length").size());
 
         response.setBodyAsText(TEXT1);

--- a/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
@@ -16,8 +16,8 @@
 
 package com.netflix.zuul.monitoring;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Gauge;
@@ -25,14 +25,11 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.zuul.Attrs;
 import com.netflix.zuul.netty.server.Server;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class ConnCounterTest {
     @Test
-    public void record() {
+    void record() {
         EmbeddedChannel chan = new EmbeddedChannel();
         Attrs attrs = Attrs.newInstance();
         chan.attr(Server.CONN_DIMENSIONS).set(attrs);
@@ -58,7 +55,7 @@ public class ConnCounterTest {
     }
 
     @Test
-    public void activeConnsCount() {
+    void activeConnsCount() {
         EmbeddedChannel channel = new EmbeddedChannel();
         Attrs attrs = Attrs.newInstance();
         channel.attr(Server.CONN_DIMENSIONS).set(attrs);

--- a/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnTimerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnTimerTest.java
@@ -16,8 +16,8 @@
 
 package com.netflix.zuul.monitoring;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
@@ -25,14 +25,11 @@ import com.netflix.spectator.api.histogram.PercentileTimer;
 import com.netflix.zuul.Attrs;
 import com.netflix.zuul.netty.server.Server;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class ConnTimerTest {
     @Test
-    public void record() {
+    void record() {
         EmbeddedChannel chan = new EmbeddedChannel();
         Attrs attrs = Attrs.newInstance();
         chan.attr(Server.CONN_DIMENSIONS).set(attrs);

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManagerTest.java
@@ -16,9 +16,7 @@
 
 package com.netflix.zuul.netty.connectionpool;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -46,19 +44,16 @@ import java.net.SocketAddress;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link DefaultClientChannelManager}.  These tests don't use IPv6 addresses because {@link InstanceInfo} is
  * not capable of expressing them.
  */
-@RunWith(JUnit4.class)
 public class DefaultClientChannelManagerTest {
 
     @Test
-    public void pickAddressInternal_discovery() {
+    void pickAddressInternal_discovery() {
         InstanceInfo instanceInfo =
                 Builder.newBuilder().setAppName("app").setHostName("192.168.0.1").setPort(443).build();
         DiscoveryResult s = DiscoveryResult.from(instanceInfo, true);
@@ -72,7 +67,7 @@ public class DefaultClientChannelManagerTest {
     }
 
     @Test
-    public void pickAddressInternal_discovery_unresolved() {
+    void pickAddressInternal_discovery_unresolved() {
         InstanceInfo instanceInfo =
                 Builder.newBuilder().setAppName("app").setHostName("localhost").setPort(443).build();
         DiscoveryResult s = DiscoveryResult.from(instanceInfo, true);
@@ -82,12 +77,12 @@ public class DefaultClientChannelManagerTest {
         Truth.assertThat(addr).isInstanceOf(InetSocketAddress.class);
         InetSocketAddress socketAddress = (InetSocketAddress) addr;
 
-        assertTrue(socketAddress.toString(), socketAddress.getAddress().isLoopbackAddress());
+        assertTrue(socketAddress.getAddress().isLoopbackAddress(), socketAddress.toString());
         assertEquals(443, socketAddress.getPort());
     }
 
     @Test
-    public void pickAddressInternal_nonDiscovery() {
+    void pickAddressInternal_nonDiscovery() {
         NonDiscoveryServer s = new NonDiscoveryServer("192.168.0.1", 443);
 
         SocketAddress addr = DefaultClientChannelManager.pickAddressInternal(s, OriginName.fromVip("vip"));
@@ -99,7 +94,7 @@ public class DefaultClientChannelManagerTest {
     }
 
     @Test
-    public void pickAddressInternal_nonDiscovery_unresolved() {
+    void pickAddressInternal_nonDiscovery_unresolved() {
         NonDiscoveryServer s = new NonDiscoveryServer("localhost", 443);
 
         SocketAddress addr = DefaultClientChannelManager.pickAddressInternal(s, OriginName.fromVip("vip"));
@@ -107,12 +102,12 @@ public class DefaultClientChannelManagerTest {
         Truth.assertThat(addr).isInstanceOf(InetSocketAddress.class);
         InetSocketAddress socketAddress = (InetSocketAddress) addr;
 
-        assertTrue(socketAddress.toString(), socketAddress.getAddress().isLoopbackAddress());
+        assertTrue(socketAddress.getAddress().isLoopbackAddress(), socketAddress.toString());
         assertEquals(443, socketAddress.getPort());
     }
 
     @Test
-    public void updateServerRefOnEmptyDiscoveryResult() {
+    void updateServerRefOnEmptyDiscoveryResult() {
         OriginName originName = OriginName.fromVip("vip", "test");
         final DefaultClientConfigImpl clientConfig = new DefaultClientConfigImpl();
         final DynamicServerResolver resolver = mock(DynamicServerResolver.class);
@@ -132,7 +127,7 @@ public class DefaultClientChannelManagerTest {
     }
 
     @Test
-    public void updateServerRefOnValidDiscoveryResult() {
+    void updateServerRefOnValidDiscoveryResult() {
         OriginName originName = OriginName.fromVip("vip", "test");
         final DefaultClientConfigImpl clientConfig = new DefaultClientConfigImpl();
 
@@ -158,7 +153,7 @@ public class DefaultClientChannelManagerTest {
     }
 
     @Test
-    public void initializeAndShutdown() throws Exception {
+    void initializeAndShutdown() throws Exception {
         final String appName = "app-" + UUID.randomUUID();
         final ServerSocket serverSocket = new ServerSocket(0);
         final InetSocketAddress serverSocketAddress = (InetSocketAddress) serverSocket.getLocalSocketAddress();

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulEndPointRunnerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulEndPointRunnerTest.java
@@ -34,10 +34,8 @@ import com.netflix.zuul.message.http.HttpRequestMessageImpl;
 import com.netflix.zuul.message.http.HttpResponseMessage;
 import com.netflix.zuul.message.http.HttpResponseMessageImpl;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -47,13 +45,12 @@ import rx.Observable;
 import static com.netflix.zuul.context.CommonContextKeys.NETTY_SERVER_CHANNEL_HANDLER_CONTEXT;
 import static com.netflix.zuul.context.CommonContextKeys.ZUUL_ENDPOINT;
 import static com.netflix.zuul.netty.filter.ZuulEndPointRunner.DEFAULT_ERROR_ENDPOINT;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(JUnit4.class)
 public class ZuulEndPointRunnerTest {
     private static final String BASIC_ENDPOINT = "basicEndpoint";
     private ZuulEndPointRunner endpointRunner;
@@ -63,7 +60,7 @@ public class ZuulEndPointRunnerTest {
     private Registry registry;
     private HttpRequestMessageImpl request;
 
-    @Before
+    @BeforeEach
     public void beforeEachTest() {
         usageNotifier = mock(FilterUsageNotifier.class);
 
@@ -87,7 +84,7 @@ public class ZuulEndPointRunnerTest {
     }
 
     @Test
-    public void nonErrorEndpoint() {
+    void nonErrorEndpoint() {
         request.getContext().setShouldSendErrorResponse(false);
         request.getContext().setEndpoint(BASIC_ENDPOINT);
         assertNull(request.getContext().get(ZUUL_ENDPOINT));
@@ -104,7 +101,7 @@ public class ZuulEndPointRunnerTest {
     }
 
     @Test
-    public void errorEndpoint() {
+    void errorEndpoint() {
         request.getContext().setShouldSendErrorResponse(true);
         assertNull(request.getContext().get(ZUUL_ENDPOINT));
         endpointRunner.filter(request);

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunnerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunnerTest.java
@@ -43,20 +43,16 @@ import com.netflix.zuul.message.http.HttpResponseMessageImpl;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import rx.Observable;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-
-@RunWith(JUnit4.class)
 public class ZuulFilterChainRunnerTest {
     private HttpRequestMessage request;
     private HttpResponseMessage response;
 
-    @Before
+    @BeforeEach
     public void before() {
         SessionContext context = new SessionContext();
         Headers headers = new Headers();
@@ -69,11 +65,11 @@ public class ZuulFilterChainRunnerTest {
     }
 
     @Test
-    public void testInboundFilterChain() {
+    void testInboundFilterChain() {
         final SimpleInboundFilter inbound1 = spy(new SimpleInboundFilter(true));
         final SimpleInboundFilter inbound2 = spy(new SimpleInboundFilter(false));
 
-        final ZuulFilter[] filters = new ZuulFilter[] { inbound1, inbound2 };
+        final ZuulFilter[] filters = new ZuulFilter[]{inbound1, inbound2};
 
         final FilterUsageNotifier notifier = mock(FilterUsageNotifier.class);
         final Registry registry = mock(Registry.class);
@@ -94,11 +90,11 @@ public class ZuulFilterChainRunnerTest {
     }
 
     @Test
-    public void testOutboundFilterChain() {
+    void testOutboundFilterChain() {
         final SimpleOutboundFilter outbound1 = spy(new SimpleOutboundFilter(true));
         final SimpleOutboundFilter outbound2 = spy(new SimpleOutboundFilter(false));
 
-        final ZuulFilter[] filters = new ZuulFilter[] { outbound1, outbound2 };
+        final ZuulFilter[] filters = new ZuulFilter[]{outbound1, outbound2};
 
         final FilterUsageNotifier notifier = mock(FilterUsageNotifier.class);
         final Registry registry = mock(Registry.class);

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/insights/ServerStateHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/insights/ServerStateHandlerTest.java
@@ -16,7 +16,8 @@
 
 package com.netflix.zuul.netty.insights;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Gauge;
@@ -27,12 +28,9 @@ import com.netflix.zuul.netty.server.http2.DummyChannelHandler;
 import com.netflix.zuul.passport.CurrentPassport;
 import com.netflix.zuul.passport.PassportState;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class ServerStateHandlerTest {
 
     private Registry registry;
@@ -43,7 +41,7 @@ public class ServerStateHandlerTest {
 
     final String listener = "test-conn-throttled";
 
-    @Before
+    @BeforeEach
     public void init() {
         registry = new DefaultRegistry();
         currentConnsId = registry.createId("server.connections.current").withTags("id", listener);
@@ -53,7 +51,7 @@ public class ServerStateHandlerTest {
     }
 
     @Test
-    public void verifyConnMetrics() {
+    void verifyConnMetrics() {
 
         final EmbeddedChannel channel = new EmbeddedChannel();
         channel.pipeline().addLast(new DummyChannelHandler());
@@ -79,7 +77,7 @@ public class ServerStateHandlerTest {
     }
 
     @Test
-    public void setPassportStateOnConnect() {
+    void setPassportStateOnConnect() {
 
         final EmbeddedChannel channel = new EmbeddedChannel();
         channel.pipeline().addLast(new DummyChannelHandler());
@@ -91,7 +89,7 @@ public class ServerStateHandlerTest {
     }
 
     @Test
-    public void setPassportStateOnDisconnect() {
+    void setPassportStateOnDisconnect() {
         final EmbeddedChannel channel = new EmbeddedChannel();
         channel.pipeline().addLast(new DummyChannelHandler());
         channel.pipeline().addLast(new InboundHandler(registry, listener));

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializerTest.java
@@ -16,7 +16,8 @@
 
 package com.netflix.zuul.netty.server;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.netty.common.channel.config.ChannelConfig;
 import com.netflix.netty.common.channel.config.CommonChannelConfigKeys;
@@ -31,18 +32,15 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
 import io.netty.util.concurrent.GlobalEventExecutor;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link BaseZuulChannelInitializer}.
  */
-@RunWith(JUnit4.class)
 public class BaseZuulChannelInitializerTest {
 
     @Test
-    public void tcpHandlersAdded() {
+    void tcpHandlersAdded() {
         ChannelConfig channelConfig = new ChannelConfig();
         ChannelConfig channelDependencies = new ChannelConfig();
         channelDependencies.set(ZuulDependencyKeys.registry, new NoopRegistry());
@@ -54,9 +52,10 @@ public class BaseZuulChannelInitializerTest {
         BaseZuulChannelInitializer init =
                 new BaseZuulChannelInitializer("1234", channelConfig, channelDependencies, channelGroup) {
 
-            @Override
-            protected void initChannel(Channel ch) {}
-        };
+                    @Override
+                    protected void initChannel(Channel ch) {
+                    }
+                };
         EmbeddedChannel channel = new EmbeddedChannel();
 
         init.addTcpRelatedHandlers(channel.pipeline());
@@ -68,7 +67,7 @@ public class BaseZuulChannelInitializerTest {
     }
 
     @Test
-    public void tcpHandlersAdded_withProxyProtocol() {
+    void tcpHandlersAdded_withProxyProtocol() {
         ChannelConfig channelConfig = new ChannelConfig();
         channelConfig.set(CommonChannelConfigKeys.withProxyProtocol, true);
         ChannelConfig channelDependencies = new ChannelConfig();
@@ -82,7 +81,8 @@ public class BaseZuulChannelInitializerTest {
                 new BaseZuulChannelInitializer("1234", channelConfig, channelDependencies, channelGroup) {
 
                     @Override
-                    protected void initChannel(Channel ch) {}
+                    protected void initChannel(Channel ch) {
+                    }
                 };
         EmbeddedChannel channel = new EmbeddedChannel();
 
@@ -95,7 +95,7 @@ public class BaseZuulChannelInitializerTest {
     }
 
     @Test
-    public void serverStateHandlerAdded() {
+    void serverStateHandlerAdded() {
         ChannelConfig channelConfig = new ChannelConfig();
         ChannelConfig channelDependencies = new ChannelConfig();
         channelDependencies.set(ZuulDependencyKeys.registry, new NoopRegistry());
@@ -109,7 +109,8 @@ public class BaseZuulChannelInitializerTest {
                 new BaseZuulChannelInitializer("1234", channelConfig, channelDependencies, channelGroup) {
 
                     @Override
-                    protected void initChannel(Channel ch) {}
+                    protected void initChannel(Channel ch) {
+                    }
                 };
         EmbeddedChannel channel = new EmbeddedChannel();
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
@@ -16,11 +16,8 @@
 
 package com.netflix.zuul.netty.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.google.common.net.InetAddresses;
 import com.netflix.netty.common.HttpLifecycleChannelHandler;
 import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
@@ -46,18 +43,18 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpVersion;
 import java.net.InetSocketAddress;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit tests for {@link ClientRequestReceiver}.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ClientRequestReceiverTest {
 
     @Test
-    public void proxyProtocol_portSetInSessionContextAndInHttpRequestMessageImpl() {
+    void proxyProtocol_portSetInSessionContextAndInHttpRequestMessageImpl() {
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
         InetSocketAddress hapmDestinationAddress = new InetSocketAddress(InetAddresses.forString("2.2.2.2"), 444);
@@ -79,7 +76,7 @@ public class ClientRequestReceiverTest {
     }
 
     @Test
-    public void parseUriFromNetty_relative() {
+    void parseUriFromNetty_relative() {
 
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
@@ -97,7 +94,7 @@ public class ClientRequestReceiverTest {
     }
 
     @Test
-    public void parseUriFromNetty_absolute() {
+    void parseUriFromNetty_absolute() {
 
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
@@ -115,7 +112,7 @@ public class ClientRequestReceiverTest {
     }
 
     @Test
-    public void parseUriFromNetty_unknown() {
+    void parseUriFromNetty_unknown() {
 
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
@@ -133,7 +130,7 @@ public class ClientRequestReceiverTest {
     }
 
     @Test
-    public void parseQueryParamsWithEncodedCharsInURI() {
+    void parseQueryParamsWithEncodedCharsInURI() {
 
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
@@ -153,7 +150,7 @@ public class ClientRequestReceiverTest {
     }
 
     @Test
-    public void largeResponse_atLimit() {
+    void largeResponse_atLimit() {
         ClientRequestReceiver receiver = new ClientRequestReceiver(null);
         EmbeddedChannel channel = new EmbeddedChannel(receiver);
         // Required for messages
@@ -184,7 +181,7 @@ public class ClientRequestReceiverTest {
     }
 
     @Test
-    public void largeResponse_aboveLimit() {
+    void largeResponse_aboveLimit() {
         ClientRequestReceiver receiver = new ClientRequestReceiver(null);
         EmbeddedChannel channel = new EmbeddedChannel(receiver);
         // Required for messages
@@ -216,7 +213,7 @@ public class ClientRequestReceiverTest {
     }
 
     @Test
-    public void maxHeaderSizeExceeded_setBadRequestStatus() {
+    void maxHeaderSizeExceeded_setBadRequestStatus() {
 
         int maxInitialLineLength = BaseZuulChannelInitializer.MAX_INITIAL_LINE_LENGTH.get();
         int maxHeaderSize = 10;
@@ -255,7 +252,7 @@ public class ClientRequestReceiverTest {
     }
 
     @Test
-    public void multipleHostHeaders_setBadRequestStatus() {
+    void multipleHostHeaders_setBadRequestStatus() {
         ClientRequestReceiver receiver = new ClientRequestReceiver(null);
         EmbeddedChannel channel = new EmbeddedChannel(new HttpRequestEncoder());
         PassportLoggingHandler loggingHandler = new PassportLoggingHandler(new DefaultRegistry());
@@ -284,7 +281,7 @@ public class ClientRequestReceiverTest {
     }
 
     @Test
-    public void setStatusCategoryForHttpPipelining() {
+    void setStatusCategoryForHttpPipelining() {
 
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/IoUringTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/IoUringTest.java
@@ -17,10 +17,7 @@
 package com.netflix.zuul.netty.server;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import com.netflix.config.ConfigurationManager;
@@ -43,11 +40,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import org.apache.commons.configuration.AbstractConfiguration;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import static org.awaitility.Awaitility.await;
@@ -61,13 +56,12 @@ import static org.awaitility.Awaitility.await;
       4) verify that the server stops
 
  */
-@RunWith(JUnit4.class)
-@Ignore
+@Disabled
 public class IoUringTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(IoUringTest.class);
     private static final boolean IS_OS_LINUX = "linux".equals(PlatformDependent.normalizedOs());
 
-    @Before
+    @BeforeEach
     public void beforeTest() {
         final AbstractConfiguration config = ConfigurationManager.getConfigInstance();
         config.setProperty("zuul.server.netty.socket.force_io_uring", "true");
@@ -75,7 +69,7 @@ public class IoUringTest {
     }
 
     @Test
-    public void testIoUringServer() throws Exception {
+    void testIoUringServer() throws Exception {
         LOGGER.info("IOUring.isAvailable: {}", IOUring.isAvailable());
         LOGGER.info("IS_OS_LINUX: {}", IS_OS_LINUX);
 
@@ -150,7 +144,7 @@ public class IoUringTest {
         assertEquals(2, ioUringChannels.size());
 
         for (IOUringSocketChannel ch : ioUringChannels) {
-            assertTrue("isShutdown", ch.isShutdown());
+            assertTrue(ch.isShutdown(), "isShutdown");
         }
     }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ServerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ServerTest.java
@@ -18,10 +18,7 @@ package com.netflix.zuul.netty.server;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 import com.netflix.config.ConfigurationManager;
@@ -46,21 +43,18 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.configuration.AbstractConfiguration;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Tests for {@link Server}.
  */
-@RunWith(JUnit4.class)
 public class ServerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ServerTest.class);
 
-    @Before
+    @BeforeEach
     public void beforeTest() {
         final AbstractConfiguration config = ConfigurationManager.getConfigInstance();
         config.setProperty("zuul.server.netty.socket.force_nio", "true");
@@ -68,7 +62,7 @@ public class ServerTest {
     }
 
     @Test
-    public void getListeningSockets() throws Exception {
+    void getListeningSockets() throws Exception {
         ServerStatusManager ssm = mock(ServerStatusManager.class);
         Map<NamedSocketAddress, ChannelInitializer<?>> initializers = new HashMap<>();
         final List<NioSocketChannel> nioChannels = Collections.synchronizedList(new ArrayList<NioSocketChannel>());
@@ -82,7 +76,7 @@ public class ServerTest {
                         + ", isOpen="
                         + ch.isOpen());
                 if (ch instanceof NioSocketChannel) {
-                    nioChannels.add((NioSocketChannel)ch);
+                    nioChannels.add((NioSocketChannel) ch);
                 }
             }
         };
@@ -93,7 +87,7 @@ public class ServerTest {
                 new ClientConnectionsShutdown(
                         new DefaultChannelGroup(GlobalEventExecutor.INSTANCE),
                         GlobalEventExecutor.INSTANCE,
-                        /* discoveryClient= */ null);
+                                /* discoveryClient= */ null);
         EventLoopGroupMetrics elgm = new EventLoopGroupMetrics(Spectator.globalRegistry());
         EventLoopConfig elc = new EventLoopConfig() {
             @Override
@@ -111,7 +105,7 @@ public class ServerTest {
 
         List<NamedSocketAddress> addrs = s.getListeningAddresses();
         assertEquals(2, addrs.size());
-        for (NamedSocketAddress address: addrs) {
+        for (NamedSocketAddress address : addrs) {
             assertTrue(address.unwrap() instanceof InetSocketAddress);
             final int port = ((InetSocketAddress) address.unwrap()).getPort();
             assertNotEquals(port, 0);
@@ -127,7 +121,7 @@ public class ServerTest {
         assertEquals(2, nioChannels.size());
 
         for (NioSocketChannel ch : nioChannels) {
-            assertTrue("isShutdown", ch.isShutdown());
+            assertTrue(ch.isShutdown(), "isShutdown");
         }
     }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/SocketAddressPropertyTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/SocketAddressPropertyTest.java
@@ -22,10 +22,7 @@ import static com.netflix.zuul.netty.server.SocketAddressProperty.BindType.IPV4_
 import static com.netflix.zuul.netty.server.SocketAddressProperty.BindType.IPV4_LOCAL;
 import static com.netflix.zuul.netty.server.SocketAddressProperty.BindType.IPV6_ANY;
 import static com.netflix.zuul.netty.server.SocketAddressProperty.BindType.IPV6_LOCAL;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.netflix.zuul.netty.server.SocketAddressProperty.BindType;
 import io.netty.channel.unix.DomainSocketAddress;
@@ -34,15 +31,12 @@ import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class SocketAddressPropertyTest {
 
     @Test
-    public void defaultValueWorks() {
+    void defaultValueWorks() {
         SocketAddressProperty prop = new SocketAddressProperty("com.netflix.zuul.netty.server.testprop", "=7001");
 
         SocketAddress address = prop.getValue();
@@ -53,7 +47,7 @@ public class SocketAddressPropertyTest {
     }
 
     @Test
-    public void bindTypeWorks_any() {
+    void bindTypeWorks_any() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("ANY=7001");
 
         assertEquals(InetSocketAddress.class, address.getClass());
@@ -63,7 +57,7 @@ public class SocketAddressPropertyTest {
     }
 
     @Test
-    public void bindTypeWorks_blank() {
+    void bindTypeWorks_blank() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("=7001");
 
         assertEquals(InetSocketAddress.class, address.getClass());
@@ -73,7 +67,7 @@ public class SocketAddressPropertyTest {
     }
 
     @Test
-    public void bindTypeWorks_ipv4Any() {
+    void bindTypeWorks_ipv4Any() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("IPV4_ANY=7001");
 
         assertEquals(InetSocketAddress.class, address.getClass());
@@ -85,7 +79,7 @@ public class SocketAddressPropertyTest {
     }
 
     @Test
-    public void bindTypeWorks_ipv6Any() {
+    void bindTypeWorks_ipv6Any() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("IPV6_ANY=7001");
 
         assertEquals(InetSocketAddress.class, address.getClass());
@@ -97,7 +91,7 @@ public class SocketAddressPropertyTest {
     }
 
     @Test
-    public void bindTypeWorks_anyLocal() {
+    void bindTypeWorks_anyLocal() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("ANY_LOCAL=7001");
 
         assertEquals(InetSocketAddress.class, address.getClass());
@@ -108,7 +102,7 @@ public class SocketAddressPropertyTest {
     }
 
     @Test
-    public void bindTypeWorks_ipv4Local() {
+    void bindTypeWorks_ipv4Local() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("IPV4_LOCAL=7001");
 
         assertEquals(InetSocketAddress.class, address.getClass());
@@ -120,7 +114,7 @@ public class SocketAddressPropertyTest {
     }
 
     @Test
-    public void bindTypeWorks_ipv6Local() {
+    void bindTypeWorks_ipv6Local() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("IPV6_LOCAL=7001");
 
         assertEquals(InetSocketAddress.class, address.getClass());
@@ -132,7 +126,7 @@ public class SocketAddressPropertyTest {
     }
 
     @Test
-    public void bindTypeWorks_uds() {
+    void bindTypeWorks_uds() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("UDS=/var/run/zuul.sock");
 
         assertEquals(DomainSocketAddress.class, address.getClass());
@@ -141,7 +135,7 @@ public class SocketAddressPropertyTest {
     }
 
     @Test
-    public void bindTypeWorks_udsWithEquals() {
+    void bindTypeWorks_udsWithEquals() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("UDS=/var/run/zuul=.sock");
 
         assertEquals(DomainSocketAddress.class, address.getClass());
@@ -150,14 +144,14 @@ public class SocketAddressPropertyTest {
     }
 
     @Test
-    public void failsOnMissingEqual() {
+    void failsOnMissingEqual() {
         assertThrows(IllegalArgumentException.class, () -> {
             SocketAddressProperty.Decoder.INSTANCE.apply("ANY");
         });
     }
 
     @Test
-    public void failsOnBadPort() {
+    void failsOnBadPort() {
         for (BindType type : Arrays.asList(ANY, IPV4_ANY, IPV6_ANY, ANY_LOCAL, IPV4_LOCAL, IPV6_LOCAL)) {
             IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
                 SocketAddressProperty.Decoder.INSTANCE.apply(type.name() + "=bogus");

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2ContentLengthEnforcingHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2ContentLengthEnforcingHandlerTest.java
@@ -30,15 +30,12 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.Http2ResetFrame;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class Http2ContentLengthEnforcingHandlerTest {
 
     @Test
-    public void failsOnMultipleContentLength() {
+    void failsOnMultipleContentLength() {
         EmbeddedChannel chan = new EmbeddedChannel();
         chan.pipeline().addLast(new Http2ContentLengthEnforcingHandler());
 
@@ -53,7 +50,7 @@ public class Http2ContentLengthEnforcingHandlerTest {
     }
 
     @Test
-    public void failsOnMixedContentLengthAndChunked() {
+    void failsOnMixedContentLengthAndChunked() {
         EmbeddedChannel chan = new EmbeddedChannel();
         chan.pipeline().addLast(new Http2ContentLengthEnforcingHandler());
 
@@ -69,7 +66,7 @@ public class Http2ContentLengthEnforcingHandlerTest {
     }
 
     @Test
-    public void failsOnShortContentLength() {
+    void failsOnShortContentLength() {
         EmbeddedChannel chan = new EmbeddedChannel();
         chan.pipeline().addLast(new Http2ContentLengthEnforcingHandler());
 
@@ -97,7 +94,7 @@ public class Http2ContentLengthEnforcingHandlerTest {
     }
 
     @Test
-    public void failsOnShortContent() {
+    void failsOnShortContent() {
         EmbeddedChannel chan = new EmbeddedChannel();
         chan.pipeline().addLast(new Http2ContentLengthEnforcingHandler());
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2OrHttpHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2OrHttpHandlerTest.java
@@ -17,7 +17,8 @@
 package com.netflix.zuul.netty.server.http2;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.netflix.netty.common.Http2ConnectionCloseHandler;
 import com.netflix.netty.common.Http2ConnectionExpiryHandler;
 import com.netflix.netty.common.channel.config.ChannelConfig;
@@ -30,20 +31,17 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http2.Http2FrameCodec;
 import io.netty.handler.codec.http2.Http2MultiplexHandler;
 import io.netty.handler.ssl.ApplicationProtocolNames;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Argha C
  * @since November 18, 2020
  */
 
-@RunWith(JUnit4.class)
 public class Http2OrHttpHandlerTest {
 
     @Test
-    public void swapInHttp2HandlerBasedOnALPN() throws Exception {
+    void swapInHttp2HandlerBasedOnALPN() throws Exception {
         EmbeddedChannel channel = new EmbeddedChannel();
         final NoopRegistry registry = new NoopRegistry();
         final ChannelConfig channelConfig = new ChannelConfig();

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushAuthHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushAuthHandlerTest.java
@@ -23,14 +23,14 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PushAuthHandlerTest {
     @Test
-    public void testIsInvalidOrigin() {
+    void testIsInvalidOrigin() {
         ZuulPushAuthHandlerTest authHandler = new ZuulPushAuthHandlerTest();
 
         final DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushRegistrationHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushRegistrationHandlerTest.java
@@ -15,10 +15,7 @@
  */
 package com.netflix.zuul.netty.server.push;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -39,10 +36,10 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -80,17 +77,17 @@ public class PushRegistrationHandlerTest {
     private DefaultEventLoop eventLoopSpy;
     private TestAuth successfulAuth;
 
-    @BeforeClass
+    @BeforeAll
     public static void classSetup() {
         EXECUTOR = Executors.newSingleThreadExecutor();
     }
 
-    @AfterClass
+    @AfterAll
     public static void classCleanup() {
         MoreExecutors.shutdownAndAwaitTermination(EXECUTOR, 5, TimeUnit.SECONDS);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         MockitoAnnotations.openMocks(this);
         registry = new PushConnectionRegistry();
@@ -105,7 +102,7 @@ public class PushRegistrationHandlerTest {
     }
 
     @Test
-    public void closeIfNotAuthenticated() throws Exception {
+    void closeIfNotAuthenticated() throws Exception {
         doHandshakeComplete();
 
         Runnable scheduledTask = scheduledCaptor.getValue();
@@ -115,20 +112,20 @@ public class PushRegistrationHandlerTest {
     }
 
     @Test
-    public void authFailed() throws Exception {
+    void authFailed() throws Exception {
         doHandshakeComplete();
         handler.userEventTriggered(context, new TestAuth(false));
         validateConnectionClosed(1008, "Auth failed");
     }
 
     @Test
-    public void authSuccess() throws Exception {
+    void authSuccess() throws Exception {
         doHandshakeComplete();
         authenticateChannel();
     }
 
     @Test
-    public void requestClientToCloseInactiveConnection() throws Exception {
+    void requestClientToCloseInactiveConnection() throws Exception {
         doHandshakeComplete();
         Mockito.reset(eventLoopSpy);
         authenticateChannel();
@@ -140,7 +137,7 @@ public class PushRegistrationHandlerTest {
     }
 
     @Test
-    public void requestClientToClose() throws Exception {
+    void requestClientToClose() throws Exception {
         doHandshakeComplete();
         Mockito.reset(eventLoopSpy);
         authenticateChannel();
@@ -158,7 +155,7 @@ public class PushRegistrationHandlerTest {
     }
 
     @Test
-    public void channelInactiveCancelsTasks() throws Exception {
+    void channelInactiveCancelsTasks() throws Exception {
         doHandshakeComplete();
         TestAuth testAuth = new TestAuth(true);
         authenticateChannel();

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ssl/SslHandshakeInfoHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ssl/SslHandshakeInfoHandlerTest.java
@@ -16,8 +16,8 @@
 
 package com.netflix.zuul.netty.server.ssl;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -31,18 +31,15 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.ReferenceCountUtil;
 import java.nio.channels.ClosedChannelException;
 import javax.net.ssl.SSLEngine;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link SslHandshakeInfoHandler}.
  */
-@RunWith(JUnit4.class)
 public class SslHandshakeInfoHandlerTest {
 
     @Test
-    public void sslEarlyHandshakeFailure() throws Exception {
+    void sslEarlyHandshakeFailure() throws Exception {
         EmbeddedChannel clientChannel = new EmbeddedChannel();
         SSLEngine clientEngine = SslContextBuilder.forClient().build().newEngine(clientChannel.alloc());
         clientChannel.pipeline().addLast(new SslHandler(clientEngine));

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/ssl/BaseSslContextFactoryTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/ssl/BaseSslContextFactoryTest.java
@@ -16,21 +16,18 @@
 
 package com.netflix.zuul.netty.ssl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.netty.handler.ssl.SslProvider;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 
 /**
  * Tests for {@link BaseSslContextFactory}.
  */
-@RunWith(JUnit4.class)
 public class BaseSslContextFactoryTest {
     @Test
-    public void testDefaultSslProviderIsOpenSsl() {
+    void testDefaultSslProviderIsOpenSsl() {
         assertEquals(SslProvider.OPENSSL, BaseSslContextFactory.chooseSslProvider());
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/ssl/ClientSslContextFactoryTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/ssl/ClientSslContextFactoryTest.java
@@ -16,29 +16,26 @@
 
 package com.netflix.zuul.netty.ssl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 
 /**
  * Tests for {@link ClientSslContextFactory}.
  */
-@RunWith(JUnit4.class)
 public class ClientSslContextFactoryTest {
 
     @Test
-    public void enableTls13() {
+    void enableTls13() {
         String[] protos = ClientSslContextFactory.maybeAddTls13(true, "TLSv1.2");
 
         assertEquals(Arrays.asList("TLSv1.3", "TLSv1.2"), Arrays.asList(protos));
     }
 
     @Test
-    public void disableTls13() {
+    void disableTls13() {
         String[] protos = ClientSslContextFactory.maybeAddTls13(false, "TLSv1.2");
 
         assertEquals(Arrays.asList("TLSv1.2"), Arrays.asList(protos));

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
@@ -17,7 +17,7 @@
 package com.netflix.zuul.netty.timeouts;
 
 import static com.netflix.zuul.netty.timeouts.OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import com.netflix.client.config.CommonClientConfigKey;
@@ -28,11 +28,11 @@ import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.origins.NettyOrigin;
 import java.time.Duration;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Origin Timeout Manager Test
@@ -40,7 +40,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author Arthur Gonigberg
  * @since March 23, 2021
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class OriginTimeoutManagerTest {
 
     @Mock
@@ -54,7 +54,7 @@ public class OriginTimeoutManagerTest {
 
     private OriginTimeoutManager originTimeoutManager;
 
-    @Before
+    @BeforeEach
     public void before() {
         originTimeoutManager = new OriginTimeoutManager(origin);
 
@@ -69,14 +69,14 @@ public class OriginTimeoutManagerTest {
     }
 
     @Test
-    public void computeReadTimeout_default() {
+    void computeReadTimeout_default() {
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
 
         assertEquals(MAX_OUTBOUND_READ_TIMEOUT_MS.get(), timeout.toMillis());
     }
 
     @Test
-    public void computeReadTimeout_requestOnly() {
+    void computeReadTimeout_requestOnly() {
         requestConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
 
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
@@ -85,7 +85,7 @@ public class OriginTimeoutManagerTest {
     }
 
     @Test
-    public void computeReadTimeout_originOnly() {
+    void computeReadTimeout_originOnly() {
         originConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
 
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
@@ -94,7 +94,7 @@ public class OriginTimeoutManagerTest {
     }
 
     @Test
-    public void computeReadTimeout_bolth_equal() {
+    void computeReadTimeout_bolth_equal() {
         requestConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
         originConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
 
@@ -104,7 +104,7 @@ public class OriginTimeoutManagerTest {
     }
 
     @Test
-    public void computeReadTimeout_bolth_originLower() {
+    void computeReadTimeout_bolth_originLower() {
         requestConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
         originConfig.set(CommonClientConfigKey.ReadTimeout, 100);
 
@@ -114,7 +114,7 @@ public class OriginTimeoutManagerTest {
     }
 
     @Test
-    public void computeReadTimeout_bolth_requestLower() {
+    void computeReadTimeout_bolth_requestLower() {
         requestConfig.set(CommonClientConfigKey.ReadTimeout, 100);
         originConfig.set(CommonClientConfigKey.ReadTimeout, 1000);
 
@@ -124,7 +124,7 @@ public class OriginTimeoutManagerTest {
     }
 
     @Test
-    public void computeReadTimeout_bolth_enforceMax() {
+    void computeReadTimeout_bolth_enforceMax() {
         requestConfig.set(CommonClientConfigKey.ReadTimeout,
                 (int) MAX_OUTBOUND_READ_TIMEOUT_MS.get() + 1000);
         originConfig.set(CommonClientConfigKey.ReadTimeout,

--- a/zuul-core/src/test/java/com/netflix/zuul/origins/OriginNameTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/origins/OriginNameTest.java
@@ -17,24 +17,21 @@
 
 package com.netflix.zuul.origins;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class OriginNameTest {
     @Test
-    public void getAuthority() {
+    void getAuthority() {
         OriginName trusted = OriginName.fromVipAndApp("woodly-doodly", "westerndigital");
 
         assertEquals("westerndigital", trusted.getAuthority());
     }
 
     @Test
-    public void getMetrics() {
+    void getMetrics() {
         OriginName trusted = OriginName.fromVipAndApp("WOODLY-doodly", "westerndigital");
 
         assertEquals("woodly-doodly", trusted.getMetricId());
@@ -43,7 +40,7 @@ public class OriginNameTest {
 
 
     @Test
-    public void equals() {
+    void equals() {
         OriginName name1 = OriginName.fromVipAndApp("woodly-doodly", "westerndigital");
         OriginName name2 = OriginName.fromVipAndApp("woodly-doodly", "westerndigital", "woodly-doodly");
 
@@ -53,7 +50,7 @@ public class OriginNameTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    public void equals_legacy_niws() {
+    void equals_legacy_niws() {
         OriginName name1 = OriginName.fromVip("woodly-doodly", "westerndigital");
         OriginName name2 = OriginName.fromVipAndApp("woodly-doodly", "woodly", "westerndigital");
 
@@ -62,7 +59,7 @@ public class OriginNameTest {
     }
 
     @Test
-    public void equals_legacy() {
+    void equals_legacy() {
         OriginName name1 = OriginName.fromVip("woodly-doodly");
         OriginName name2 = OriginName.fromVipAndApp("woodly-doodly", "woodly", "woodly-doodly");
 
@@ -71,7 +68,7 @@ public class OriginNameTest {
     }
 
     @Test
-    public void noNull() {
+    void noNull() {
         assertThrows(NullPointerException.class, () -> OriginName.fromVipAndApp(null, "app"));
         assertThrows(NullPointerException.class, () -> OriginName.fromVipAndApp("vip", null));
         assertThrows(NullPointerException.class, () -> OriginName.fromVipAndApp(null, "app", "niws"));

--- a/zuul-core/src/test/java/com/netflix/zuul/passport/CurrentPassportTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/passport/CurrentPassportTest.java
@@ -16,18 +16,18 @@
 
 package com.netflix.zuul.passport;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static com.netflix.zuul.passport.PassportState.MISC_IO_START;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CurrentPassportTest
 {
     @Test
-    public void test_findEachPairOf_1pair()
+    void test_findEachPairOf_1pair()
     {
         CurrentPassport passport = CurrentPassport.parseFromToString(
                 "CurrentPassport {start_ms=0, [+0=IN_REQ_HEADERS_RECEIVED, +5=FILTERS_INBOUND_START, +50=IN_REQ_LAST_CONTENT_RECEIVED, +200=MISC_IO_START, +250=MISC_IO_STOP, +350=FILTERS_INBOUND_END, +1117794707=NOW]}");
@@ -39,7 +39,7 @@ public class CurrentPassportTest
     }
 
     @Test
-    public void test_findEachPairOf_2pairs()
+    void test_findEachPairOf_2pairs()
     {
         CurrentPassport passport = CurrentPassport.parseFromToString(
                 "CurrentPassport {start_ms=0, [+0=IN_REQ_HEADERS_RECEIVED, +5=FILTERS_INBOUND_START, +50=IN_REQ_LAST_CONTENT_RECEIVED, +200=MISC_IO_START, +250=MISC_IO_STOP, +300=MISC_IO_START, +350=FILTERS_INBOUND_END, +400=MISC_IO_STOP, +1117794707=NOW]}");
@@ -53,7 +53,7 @@ public class CurrentPassportTest
     }
 
     @Test
-    public void test_findEachPairOf_noneFound()
+    void test_findEachPairOf_noneFound()
     {
         CurrentPassport passport = CurrentPassport.parseFromToString(
                 "CurrentPassport {start_ms=0, [+0=FILTERS_INBOUND_START, +200=MISC_IO_START, +1117794707=NOW]}");
@@ -63,7 +63,7 @@ public class CurrentPassportTest
     }
 
     @Test
-    public void test_findEachPairOf_endButNoStart()
+    void test_findEachPairOf_endButNoStart()
     {
         CurrentPassport passport = CurrentPassport.parseFromToString(
                 "CurrentPassport {start_ms=0, [+0=FILTERS_INBOUND_START, +50=IN_REQ_LAST_CONTENT_RECEIVED, +200=MISC_IO_START, +1117794707=NOW]}");
@@ -73,7 +73,7 @@ public class CurrentPassportTest
     }
 
     @Test
-    public void test_findEachPairOf_wrongOrder()
+    void test_findEachPairOf_wrongOrder()
     {
         CurrentPassport passport = CurrentPassport.parseFromToString(
                 "CurrentPassport {start_ms=0, [+0=FILTERS_INBOUND_START, +50=IN_REQ_LAST_CONTENT_RECEIVED, +200=MISC_IO_START, +250=IN_REQ_HEADERS_RECEIVED, +1117794707=NOW]}");
@@ -83,7 +83,7 @@ public class CurrentPassportTest
     }
 
     @Test
-    public void testFindBackwards()
+    void testFindBackwards()
     {
         CurrentPassport passport = CurrentPassport.parseFromToString(
                 "CurrentPassport {start_ms=0, [+0=FILTERS_INBOUND_START, +50=IN_REQ_LAST_CONTENT_RECEIVED, +200=MISC_IO_START, +250=IN_REQ_HEADERS_RECEIVED, +1117794707=NOW]}");
@@ -92,7 +92,7 @@ public class CurrentPassportTest
     }
 
     @Test
-    public void testGetStateWithNoHistory() {
+    void testGetStateWithNoHistory() {
         assertNull(CurrentPassport.create().getState());
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/stats/ErrorStatsDataTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/stats/ErrorStatsDataTest.java
@@ -16,22 +16,21 @@
 
 package com.netflix.zuul.stats;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit tests for {@link ErrorStatsData}.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ErrorStatsDataTest {
 
     @Test
-    public void testUpdateStats() {
+    void testUpdateStats() {
         ErrorStatsData sd = new ErrorStatsData("route", "test");
         sd.update();
         assertEquals(sd.getCount(), 1);
@@ -41,16 +40,16 @@ public class ErrorStatsDataTest {
 
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         ErrorStatsData sd = new ErrorStatsData("route", "test");
         ErrorStatsData sd1 = new ErrorStatsData("route", "test");
         ErrorStatsData sd2 = new ErrorStatsData("route", "test1");
         ErrorStatsData sd3 = new ErrorStatsData("route", "test");
 
-        assertTrue(sd.equals(sd1));
-        assertTrue(sd1.equals(sd));
-        assertTrue(sd.equals(sd));
-        assertFalse(sd.equals(sd2));
-        assertFalse(sd2.equals(sd3));
+        assertEquals(sd, sd1);
+        assertEquals(sd1, sd);
+        assertEquals(sd, sd);
+        assertNotEquals(sd, sd2);
+        assertNotEquals(sd2, sd3);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/stats/ErrorStatsManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/stats/ErrorStatsManagerTest.java
@@ -16,22 +16,22 @@
 
 package com.netflix.zuul.stats;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.concurrent.ConcurrentHashMap;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit tests for {@link ErrorStatsManager}.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ErrorStatsManagerTest {
 
     @Test
-    public void testPutStats() {
+    void testPutStats() {
         ErrorStatsManager sm = new ErrorStatsManager();
         assertNotNull(sm);
         sm.putStats("test", "cause");
@@ -44,7 +44,7 @@ public class ErrorStatsManagerTest {
     }
 
     @Test
-    public void testGetStats() {
+    void testGetStats() {
         ErrorStatsManager sm = new ErrorStatsManager();
         assertNotNull(sm);
         sm.putStats("test", "cause");

--- a/zuul-core/src/test/java/com/netflix/zuul/stats/RouteStatusCodeMonitorTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/stats/RouteStatusCodeMonitorTest.java
@@ -16,21 +16,17 @@
 
 package com.netflix.zuul.stats;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link RouteStatusCodeMonitor}.
  */
-@RunWith(JUnit4.class)
 public class RouteStatusCodeMonitorTest {
     @Test
-    public void testUpdateStats() {
+    void testUpdateStats() {
         RouteStatusCodeMonitor sd = new RouteStatusCodeMonitor("test", 200);
         assertEquals(sd.route, "test");
         sd.update();
@@ -40,17 +36,17 @@ public class RouteStatusCodeMonitorTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         RouteStatusCodeMonitor sd = new RouteStatusCodeMonitor("test", 200);
         RouteStatusCodeMonitor sd1 = new RouteStatusCodeMonitor("test", 200);
         RouteStatusCodeMonitor sd2 = new RouteStatusCodeMonitor("test1", 200);
         RouteStatusCodeMonitor sd3 = new RouteStatusCodeMonitor("test", 201);
 
-        assertTrue(sd.equals(sd1));
-        assertTrue(sd1.equals(sd));
-        assertTrue(sd.equals(sd));
-        assertFalse(sd.equals(sd2));
-        assertFalse(sd.equals(sd3));
-        assertFalse(sd2.equals(sd3));
+        assertEquals(sd, sd1);
+        assertEquals(sd1, sd);
+        assertEquals(sd, sd);
+        assertNotEquals(sd, sd2);
+        assertNotEquals(sd, sd3);
+        assertNotEquals(sd2, sd3);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/stats/StatsManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/stats/StatsManagerTest.java
@@ -16,28 +16,25 @@
 
 package com.netflix.zuul.stats;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import com.netflix.zuul.message.Headers;
 import com.netflix.zuul.message.http.HttpRequestInfo;
 import java.util.concurrent.ConcurrentHashMap;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit tests for {@link StatsManager}.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class StatsManagerTest {
 
     @Test
-    public void testCollectRouteStats() {
+    void testCollectRouteStats() {
         String route = "test";
         int status = 500;
 
@@ -60,7 +57,7 @@ public class StatsManagerTest {
     }
 
     @Test
-    public void testGetRouteStatusCodeMonitor() {
+    void testGetRouteStatusCodeMonitor() {
         StatsManager sm = StatsManager.getManager();
         assertNotNull(sm);
         sm.collectRouteStats("test", 500);
@@ -68,7 +65,7 @@ public class StatsManagerTest {
     }
 
     @Test
-    public void testCollectRequestStats() {
+    void testCollectRequestStats() {
         final String host = "api.netflix.com";
         final String proto = "https";
 
@@ -83,17 +80,17 @@ public class StatsManagerTest {
         sm.collectRequestStats(req);
 
         final NamedCountingMonitor hostMonitor = sm.getHostMonitor(host);
-        assertNotNull("hostMonitor should not be null", hostMonitor);
+        assertNotNull(hostMonitor, "hostMonitor should not be null");
 
         final NamedCountingMonitor protoMonitor = sm.getProtocolMonitor(proto);
-        assertNotNull("protoMonitor should not be null", protoMonitor);
+        assertNotNull(protoMonitor, "protoMonitor should not be null");
 
         assertEquals(1, hostMonitor.getCount());
         assertEquals(1, protoMonitor.getCount());
     }
 
     @Test
-    public void createsNormalizedHostKey() {
+    void createsNormalizedHostKey() {
         assertEquals("host_EC2.amazonaws.com", StatsManager.hostKey("ec2-174-129-179-89.compute-1.amazonaws.com"));
         assertEquals("host_IP", StatsManager.hostKey("12.345.6.789"));
         assertEquals("host_IP", StatsManager.hostKey("ip-10-86-83-168"));
@@ -103,7 +100,7 @@ public class StatsManagerTest {
     }
 
     @Test
-    public void extractsClientIpFromXForwardedFor() {
+    void extractsClientIpFromXForwardedFor() {
         final String ip1 = "hi";
         final String ip2 = "hey";
         assertEquals(ip1, StatsManager.extractClientIpFromXForwardedFor(ip1));
@@ -112,7 +109,7 @@ public class StatsManagerTest {
     }
 
     @Test
-    public void isIPv6() {
+    void isIPv6() {
         assertTrue(StatsManager.isIPv6("0:0:0:0:0:0:0:1"));
         assertTrue(StatsManager.isIPv6("2607:fb10:2:232:72f3:95ff:fe03:a6e7"));
         assertFalse(StatsManager.isIPv6("127.0.0.1"));

--- a/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
@@ -17,10 +17,7 @@
 package com.netflix.zuul.util;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.Headers;
@@ -31,62 +28,59 @@ import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpRequestMessageImpl;
 import com.netflix.zuul.message.http.HttpResponseMessage;
 import com.netflix.zuul.message.http.HttpResponseMessageImpl;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link HttpUtils}.
  */
-@RunWith(JUnit4.class)
 public class HttpUtilsTest {
 
     @Test
-    public void detectsGzip() {
+    void detectsGzip() {
         assertTrue(HttpUtils.isCompressed("gzip"));
     }
 
     @Test
-    public void detectsDeflate() {
+    void detectsDeflate() {
         assertTrue(HttpUtils.isCompressed("deflate"));
     }
 
     @Test
-    public void detectsCompress() {
+    void detectsCompress() {
         assertTrue(HttpUtils.isCompressed("compress"));
     }
 
     @Test
-    public void detectsBR() {
+    void detectsBR() {
         assertTrue(HttpUtils.isCompressed("br"));
     }
 
     @Test
-    public void detectsNonGzip() {
+    void detectsNonGzip() {
         assertFalse(HttpUtils.isCompressed("identity"));
     }
 
     @Test
-    public void detectsGzipAmongOtherEncodings() {
+    void detectsGzipAmongOtherEncodings() {
         assertTrue(HttpUtils.isCompressed("gzip, deflate"));
     }
 
     @Test
-    public void acceptsGzip() {
+    void acceptsGzip() {
         Headers headers = new Headers();
         headers.add("Accept-Encoding", "gzip, deflate");
         assertTrue(HttpUtils.acceptsGzip(headers));
     }
 
     @Test
-    public void acceptsGzip_only() {
+    void acceptsGzip_only() {
         Headers headers = new Headers();
         headers.add("Accept-Encoding", "deflate");
         assertFalse(HttpUtils.acceptsGzip(headers));
     }
 
     @Test
-    public void stripMaliciousHeaderChars() {
+    void stripMaliciousHeaderChars() {
         assertEquals("something", HttpUtils.stripMaliciousHeaderChars("some\r\nthing"));
         assertEquals("some thing", HttpUtils.stripMaliciousHeaderChars("some thing"));
         assertEquals("something", HttpUtils.stripMaliciousHeaderChars("\nsome\r\nthing\r"));
@@ -96,7 +90,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void getBodySizeIfKnown_returnsContentLengthValue() {
+    void getBodySizeIfKnown_returnsContentLengthValue() {
         SessionContext context = new SessionContext();
         Headers headers = new Headers();
         headers.add(com.netflix.zuul.message.http.HttpHeaderNames.CONTENT_LENGTH, "23450");
@@ -105,7 +99,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void getBodySizeIfKnown_returnsResponseBodySize() {
+    void getBodySizeIfKnown_returnsResponseBodySize() {
         SessionContext context = new SessionContext();
         Headers headers = new Headers();
         HttpQueryParams queryParams = new HttpQueryParams();
@@ -117,7 +111,7 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void getBodySizeIfKnown_returnsNull() {
+    void getBodySizeIfKnown_returnsNull() {
         SessionContext context = new SessionContext();
         Headers headers = new Headers();
         ZuulMessage msg = new ZuulMessageImpl(context, headers);

--- a/zuul-core/src/test/java/com/netflix/zuul/util/JsonUtilityTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/util/JsonUtilityTest.java
@@ -16,25 +16,22 @@
 
 package com.netflix.zuul.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link JsonUtility}.
  */
-@RunWith(JUnit4.class)
 public class JsonUtilityTest {
 
     // I'm using LinkedHashMap in the testing so I get consistent ordering for the expected results
 
     @Test
-    public void testSimpleOne() {
+    void testSimpleOne() {
         Map<String, Object> jsonData = new LinkedHashMap<String, Object>();
         jsonData.put("myKey", "myValue");
 
@@ -45,7 +42,7 @@ public class JsonUtilityTest {
     }
 
     @Test
-    public void testSimpleTwo() {
+    void testSimpleTwo() {
         Map<String, Object> jsonData = new LinkedHashMap<String, Object>();
         jsonData.put("myKey", "myValue");
         jsonData.put("myKey2", "myValue2");
@@ -57,7 +54,7 @@ public class JsonUtilityTest {
     }
 
     @Test
-    public void testNestedMapOne() {
+    void testNestedMapOne() {
         Map<String, Object> jsonData = new LinkedHashMap<String, Object>();
         jsonData.put("myKey", "myValue");
 
@@ -73,7 +70,7 @@ public class JsonUtilityTest {
     }
 
     @Test
-    public void testNestedMapTwo() {
+    void testNestedMapTwo() {
         Map<String, Object> jsonData = new LinkedHashMap<String, Object>();
         jsonData.put("myKey", "myValue");
 
@@ -90,7 +87,7 @@ public class JsonUtilityTest {
     }
 
     @Test
-    public void testArrayOne() {
+    void testArrayOne() {
         Map<String, Object> jsonData = new LinkedHashMap<String, Object>();
         int[] numbers = {1, 2, 3, 4};
         jsonData.put("myKey", numbers);
@@ -102,7 +99,7 @@ public class JsonUtilityTest {
     }
 
     @Test
-    public void testArrayTwo() {
+    void testArrayTwo() {
         Map<String, Object> jsonData = new LinkedHashMap<String, Object>();
         String[] values = {"one", "two", "three", "four"};
         jsonData.put("myKey", values);
@@ -114,7 +111,7 @@ public class JsonUtilityTest {
     }
 
     @Test
-    public void testCollectionOne() {
+    void testCollectionOne() {
         Map<String, Object> jsonData = new LinkedHashMap<String, Object>();
         ArrayList<String> values = new ArrayList<String>();
         values.add("one");
@@ -130,7 +127,7 @@ public class JsonUtilityTest {
     }
 
     @Test
-    public void testMapAndList() {
+    void testMapAndList() {
         Map<String, Object> jsonData = new LinkedHashMap<String, Object>();
         jsonData.put("myKey", "myValue");
         int[] numbers = {1, 2, 3, 4};
@@ -151,7 +148,7 @@ public class JsonUtilityTest {
     }
 
     @Test
-    public void testArrayOfMaps() {
+    void testArrayOfMaps() {
         Map<String, Object> jsonData = new LinkedHashMap<String, Object>();
         ArrayList<Map<String, Object>> messages = new ArrayList<Map<String, Object>>();
 

--- a/zuul-core/src/test/java/com/netflix/zuul/util/VipUtilsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/util/VipUtilsTest.java
@@ -16,33 +16,36 @@
 
 package com.netflix.zuul.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link VipUtils}.
  */
-@RunWith(JUnit4.class)
 public class VipUtilsTest {
-    @Test(expected = NullPointerException.class)
-    public void testGetVIPPrefix() {
-        assertEquals("api-test", VipUtils.getVIPPrefix("api-test.netflix.net:7001"));
-        assertEquals("api-test", VipUtils.getVIPPrefix("api-test.netflix.net"));
-        assertEquals("api-test", VipUtils.getVIPPrefix("api-test:7001"));
-        assertEquals("api-test", VipUtils.getVIPPrefix("api-test"));
-        assertEquals("", VipUtils.getVIPPrefix(""));
-        VipUtils.getVIPPrefix(null);
+    @Test
+    void testGetVIPPrefix() {
+        assertThrows(NullPointerException.class, () -> {
+            assertEquals("api-test", VipUtils.getVIPPrefix("api-test.netflix.net:7001"));
+            assertEquals("api-test", VipUtils.getVIPPrefix("api-test.netflix.net"));
+            assertEquals("api-test", VipUtils.getVIPPrefix("api-test:7001"));
+            assertEquals("api-test", VipUtils.getVIPPrefix("api-test"));
+            assertEquals("", VipUtils.getVIPPrefix(""));
+            VipUtils.getVIPPrefix(null);
+        });
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testExtractAppNameFromVIP() {
-        assertEquals("api", VipUtils.extractUntrustedAppNameFromVIP("api-test.netflix.net:7001"));
-        assertEquals("api", VipUtils.extractUntrustedAppNameFromVIP("api-test-blah.netflix.net:7001"));
-        assertEquals("api", VipUtils.extractUntrustedAppNameFromVIP("api"));
-        assertEquals("", VipUtils.extractUntrustedAppNameFromVIP(""));
-        VipUtils.extractUntrustedAppNameFromVIP(null);
+    @Test
+    void testExtractAppNameFromVIP() {
+        assertThrows(NullPointerException.class, () -> {
+            assertEquals("api", VipUtils.extractUntrustedAppNameFromVIP("api-test.netflix.net:7001"));
+            assertEquals("api", VipUtils.extractUntrustedAppNameFromVIP("api-test-blah.netflix.net:7001"));
+            assertEquals("api", VipUtils.extractUntrustedAppNameFromVIP("api"));
+            assertEquals("", VipUtils.extractUntrustedAppNameFromVIP(""));
+            VipUtils.extractUntrustedAppNameFromVIP(null);
+        });
     }
 }

--- a/zuul-discovery/build.gradle
+++ b/zuul-discovery/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation "com.netflix.eureka:eureka-client:1.10.17"
 
 
-    testImplementation libraries.junit,
+    testImplementation libraries.jupiterApi, libraries.jupiterEngine,
             libraries.mockito,
             libraries.truth
 }

--- a/zuul-discovery/dependencies.lock
+++ b/zuul-discovery/dependencies.lock
@@ -81,8 +81,11 @@
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "locked": "2.4.4"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
         },
         "org.mockito:mockito-core": {
             "locked": "4.8.0"
@@ -142,8 +145,11 @@
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "locked": "2.4.4"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
         },
         "org.mockito:mockito-core": {
             "locked": "4.8.0"
@@ -174,8 +180,11 @@
         "com.netflix.ribbon:ribbon-loadbalancer": {
             "locked": "2.4.4"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
         },
         "org.mockito:mockito-core": {
             "locked": "4.8.0"

--- a/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DiscoveryResultTest.java
+++ b/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DiscoveryResultTest.java
@@ -16,8 +16,9 @@
 
 package com.netflix.zuul.discovery;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.google.common.truth.Truth;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.InstanceInfo.Builder;
@@ -27,19 +28,19 @@ import com.netflix.loadbalancer.DynamicServerListLoadBalancer;
 import com.netflix.loadbalancer.Server;
 import com.netflix.niws.loadbalancer.DiscoveryEnabledServer;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DiscoveryResultTest {
 
     @Test
-    public void hashCodeForNull() {
+    void hashCodeForNull() {
         final DiscoveryResult discoveryResult = new DiscoveryResult(null);
         assertNotNull(discoveryResult.hashCode());
         assertEquals(0, discoveryResult.hashCode());
     }
 
     @Test
-    public void hostAndPortForNullServer() {
+    void hostAndPortForNullServer() {
         final DiscoveryResult discoveryResult = new DiscoveryResult(null);
 
         assertEquals("undefined", discoveryResult.getHost());
@@ -47,7 +48,7 @@ public class DiscoveryResultTest {
     }
 
     @Test
-    public void serverStatsCacheForSameServer() {
+    void serverStatsCacheForSameServer() {
         final InstanceInfo instanceInfo = Builder.newBuilder()
                 .setAppName("serverstats-cache")
                 .setHostName("serverstats-cache")
@@ -64,7 +65,7 @@ public class DiscoveryResultTest {
     }
 
     @Test
-    public void serverStatsDifferForDifferentServer() {
+    void serverStatsDifferForDifferentServer() {
         final InstanceInfo instanceInfo = Builder.newBuilder()
                 .setAppName("serverstats-cache")
                 .setHostName("serverstats-cache")
@@ -85,7 +86,7 @@ public class DiscoveryResultTest {
     }
 
     @Test
-    public void ipAddrV4FromInstanceInfo() {
+    void ipAddrV4FromInstanceInfo() {
         final String ipAddr = "100.1.0.1";
         final InstanceInfo instanceInfo = Builder.newBuilder()
                 .setAppName("ipAddrv4")
@@ -101,7 +102,7 @@ public class DiscoveryResultTest {
     }
 
     @Test
-    public void ipAddrEmptyForIncompleteInstanceInfo() {
+    void ipAddrEmptyForIncompleteInstanceInfo() {
         final InstanceInfo instanceInfo = Builder.newBuilder()
                 .setAppName("ipAddrMissing")
                 .setHostName("ipAddrMissing")
@@ -115,7 +116,7 @@ public class DiscoveryResultTest {
     }
 
     @Test
-    public void sameUnderlyingInstanceInfoEqualsSameResult() {
+    void sameUnderlyingInstanceInfoEqualsSameResult() {
         final InstanceInfo instanceInfo = Builder.newBuilder()
                 .setAppName("server-equality")
                 .setHostName("server-equality")
@@ -133,7 +134,7 @@ public class DiscoveryResultTest {
     }
 
     @Test
-    public void serverInstancesExposingDiffPortsAreNotEqual() {
+    void serverInstancesExposingDiffPortsAreNotEqual() {
         final InstanceInfo instanceInfo = Builder.newBuilder()
                 .setAppName("server-equality")
                 .setHostName("server-equality")
@@ -155,7 +156,7 @@ public class DiscoveryResultTest {
     }
 
     @Test
-    public void securePortMustCheckInstanceInfo() {
+    void securePortMustCheckInstanceInfo() {
         final InstanceInfo instanceInfo = Builder.newBuilder()
                 .setAppName("secure-port")
                 .setHostName("secure-port")

--- a/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DynamicServerResolverTest.java
+++ b/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DynamicServerResolverTest.java
@@ -26,17 +26,13 @@ import com.netflix.niws.loadbalancer.DiscoveryEnabledServer;
 import com.netflix.zuul.resolver.ResolverListener;
 import java.security.cert.TrustAnchor;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class DynamicServerResolverTest {
 
 
     @Test
-    public void verifyListenerUpdates() {
+    void verifyListenerUpdates() {
 
         class CustomListener implements ResolverListener<DiscoveryResult> {
 
@@ -76,7 +72,7 @@ public class DynamicServerResolverTest {
     }
 
     @Test
-    public void properSentinelValueWhenServersUnavailable() {
+    void properSentinelValueWhenServersUnavailable() {
         final DynamicServerResolver resolver = new DynamicServerResolver(new DefaultClientConfigImpl(), new ResolverListener<DiscoveryResult>() {
             @Override
             public void onChange(List<DiscoveryResult> removedSet) {

--- a/zuul-groovy/build.gradle
+++ b/zuul-groovy/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation project(":zuul-core")
     api "org.codehaus.groovy:groovy-all:${versions_groovy}"
 
-    testImplementation libraries.junit,
+    testImplementation libraries.jupiterApi, libraries.jupiterEngine, libraries.jupiterMockito,
             libraries.mockito,
             libraries.truth
 }

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -412,9 +412,6 @@
             ],
             "locked": "1"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
-        },
         "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -430,7 +427,16 @@
         "org.codehaus.groovy:groovy-all": {
             "locked": "3.0.9"
         },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
+        },
         "org.mockito:mockito-core": {
+            "locked": "4.8.0"
+        },
+        "org.mockito:mockito-junit-jupiter": {
             "locked": "4.8.0"
         },
         "org.openjdk.jmh:jmh-core": {
@@ -746,13 +752,19 @@
             ],
             "locked": "1.3.8"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
-        },
         "org.codehaus.groovy:groovy-all": {
             "locked": "3.0.9"
         },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
+        },
         "org.mockito:mockito-core": {
+            "locked": "4.8.0"
+        },
+        "org.mockito:mockito-junit-jupiter": {
             "locked": "4.8.0"
         },
         "org.slf4j:slf4j-api": {
@@ -935,9 +947,6 @@
             ],
             "locked": "1"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
-        },
         "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -953,7 +962,16 @@
         "org.codehaus.groovy:groovy-all": {
             "locked": "3.0.9"
         },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
+        },
         "org.mockito:mockito-core": {
+            "locked": "4.8.0"
+        },
+        "org.mockito:mockito-junit-jupiter": {
             "locked": "4.8.0"
         },
         "org.slf4j:slf4j-api": {

--- a/zuul-groovy/src/test/java/com/netflix/zuul/groovy/GroovyCompilerTest.java
+++ b/zuul-groovy/src/test/java/com/netflix/zuul/groovy/GroovyCompilerTest.java
@@ -16,38 +16,38 @@
 
 package com.netflix.zuul.groovy;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.spy;
 
 import groovy.lang.GroovyObject;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * Unit tests for {@link GroovyCompiler}.
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class GroovyCompilerTest {
 
     @Test
-    public void testLoadGroovyFromString() {
+    void testLoadGroovyFromString() {
 
         GroovyCompiler compiler = Mockito.spy(new GroovyCompiler());
 
         try {
 
             String code = "class test { public String hello(){return \"hello\" } } ";
-            Class clazz = compiler.compile(code, "test");
+            Class clazz = compiler.compile(code,"test");
             assertNotNull(clazz);
-            assertEquals(clazz.getName(), "test");
+            assertEquals(clazz.getName(),"test");
             GroovyObject groovyObject = (GroovyObject) clazz.newInstance();
             Object[] args = {};
-            String s = (String) groovyObject.invokeMethod("hello", args);
-            assertEquals(s, "hello");
+            String s = (String) groovyObject.invokeMethod("hello",args);
+            assertEquals(s,"hello");
         } catch (Exception e) {
             assertFalse(true);
         }

--- a/zuul-groovy/src/test/java/com/netflix/zuul/groovy/GroovyFileFilterTest.java
+++ b/zuul-groovy/src/test/java/com/netflix/zuul/groovy/GroovyFileFilterTest.java
@@ -16,26 +16,23 @@
 
 package com.netflix.zuul.groovy;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link GroovyFileFilter}.
  */
-@RunWith(JUnit4.class)
 public class GroovyFileFilterTest {
 
     @Test
-    public void testGroovyFileFilter() {
+    void testGroovyFileFilter() {
 
         GroovyFileFilter filter = new GroovyFileFilter();
 
-        assertFalse(filter.accept(new File("/"), "file.mikey"));
-        assertTrue(filter.accept(new File("/"), "file.groovy"));
+        assertFalse(filter.accept(new File("/"),"file.mikey"));
+        assertTrue(filter.accept(new File("/"),"file.groovy"));
     }
 }

--- a/zuul-groovy/src/test/java/com/netflix/zuul/scriptManager/FilterVerifierTest.java
+++ b/zuul-groovy/src/test/java/com/netflix/zuul/scriptManager/FilterVerifierTest.java
@@ -144,8 +144,8 @@ public class FilterVerifierTest {
         assertFalse(filterInfo1.isActive());
         assertFalse(filterInfo1.isCanary());
 
-        assertThrows(InstantiationException.class,() -> FilterVerifier.INSTANCE.verifyFilter(sNotZuulFilterGroovy));
+        assertThrows(InstantiationException.class, () -> FilterVerifier.INSTANCE.verifyFilter(sNotZuulFilterGroovy));
 
-        assertThrows(CompilationFailedException.class,() -> FilterVerifier.INSTANCE.verifyFilter(sCompileFailCode));
+        assertThrows(CompilationFailedException.class, () -> FilterVerifier.INSTANCE.verifyFilter(sCompileFailCode));
     }
 }

--- a/zuul-groovy/src/test/java/com/netflix/zuul/scriptManager/FilterVerifierTest.java
+++ b/zuul-groovy/src/test/java/com/netflix/zuul/scriptManager/FilterVerifierTest.java
@@ -116,7 +116,7 @@ public class FilterVerifierTest {
         filterClass = FilterVerifier.INSTANCE.compileGroovy(sNotZuulFilterGroovy);
         assertNotNull(filterClass);
 
-        assertThrows(CompilationFailedException.class,() -> FilterVerifier.INSTANCE.compileGroovy(sCompileFailCode));
+        assertThrows(CompilationFailedException.class, () -> FilterVerifier.INSTANCE.compileGroovy(sCompileFailCode));
     }
 
     @Test
@@ -131,7 +131,7 @@ public class FilterVerifierTest {
         assertNotNull(filterClass);
 
         Object filter2 = FilterVerifier.INSTANCE.instantiateClass(filterClass);
-        assertThrows(InstantiationException.class,() -> FilterVerifier.INSTANCE.checkZuulFilterInstance(filter2));
+        assertThrows(InstantiationException.class, () -> FilterVerifier.INSTANCE.checkZuulFilterInstance(filter2));
     }
 
     @Test

--- a/zuul-groovy/src/test/java/com/netflix/zuul/scriptManager/FilterVerifierTest.java
+++ b/zuul-groovy/src/test/java/com/netflix/zuul/scriptManager/FilterVerifierTest.java
@@ -138,9 +138,9 @@ public class FilterVerifierTest {
     void testVerify() throws Exception {
         FilterInfo filterInfo1 = FilterVerifier.INSTANCE.verifyFilter(sGoodGroovyScriptFilter);
         assertNotNull(filterInfo1);
-        assertEquals(filterInfo1.getFilterID(),"null:filter:in");
-        assertEquals(filterInfo1.getFilterType(),FilterType.INBOUND);
-        assertEquals(filterInfo1.getFilterName(),"filter");
+        assertEquals(filterInfo1.getFilterID(), "null:filter:in");
+        assertEquals(filterInfo1.getFilterType(), FilterType.INBOUND);
+        assertEquals(filterInfo1.getFilterName(), "filter");
         assertFalse(filterInfo1.isActive());
         assertFalse(filterInfo1.isCanary());
 

--- a/zuul-groovy/src/test/java/com/netflix/zuul/scriptManager/FilterVerifierTest.java
+++ b/zuul-groovy/src/test/java/com/netflix/zuul/scriptManager/FilterVerifierTest.java
@@ -16,22 +16,19 @@
 
 package com.netflix.zuul.scriptManager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.netflix.zuul.filters.FilterType;
 import org.codehaus.groovy.control.CompilationFailedException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 
 /**
  * Unit tests for {@link FilterVerifier}.
  */
-@RunWith(JUnit4.class)
 public class FilterVerifierTest {
 
     private final String sGoodGroovyScriptFilter = "import com.netflix.zuul.filters.*\n" +
@@ -113,17 +110,17 @@ public class FilterVerifierTest {
         "}";
 
     @Test
-    public void testCompile() {
+    void testCompile() {
         Class<?> filterClass = FilterVerifier.INSTANCE.compileGroovy(sGoodGroovyScriptFilter);
         assertNotNull(filterClass);
         filterClass = FilterVerifier.INSTANCE.compileGroovy(sNotZuulFilterGroovy);
         assertNotNull(filterClass);
 
-        assertThrows(CompilationFailedException.class, () -> FilterVerifier.INSTANCE.compileGroovy(sCompileFailCode));
+        assertThrows(CompilationFailedException.class,() -> FilterVerifier.INSTANCE.compileGroovy(sCompileFailCode));
     }
 
     @Test
-    public void testZuulFilterInstance() throws Exception {
+    void testZuulFilterInstance() throws Exception {
         Class<?> filterClass = FilterVerifier.INSTANCE.compileGroovy(sGoodGroovyScriptFilter);
         assertNotNull(filterClass);
 
@@ -134,21 +131,21 @@ public class FilterVerifierTest {
         assertNotNull(filterClass);
 
         Object filter2 = FilterVerifier.INSTANCE.instantiateClass(filterClass);
-        assertThrows(InstantiationException.class, () -> FilterVerifier.INSTANCE.checkZuulFilterInstance(filter2));
+        assertThrows(InstantiationException.class,() -> FilterVerifier.INSTANCE.checkZuulFilterInstance(filter2));
     }
 
     @Test
-    public void testVerify() throws Exception {
+    void testVerify() throws Exception {
         FilterInfo filterInfo1 = FilterVerifier.INSTANCE.verifyFilter(sGoodGroovyScriptFilter);
         assertNotNull(filterInfo1);
-        assertEquals(filterInfo1.getFilterID(), "null:filter:in");
-        assertEquals(filterInfo1.getFilterType(), FilterType.INBOUND);
-        assertEquals(filterInfo1.getFilterName(), "filter");
+        assertEquals(filterInfo1.getFilterID(),"null:filter:in");
+        assertEquals(filterInfo1.getFilterType(),FilterType.INBOUND);
+        assertEquals(filterInfo1.getFilterName(),"filter");
         assertFalse(filterInfo1.isActive());
         assertFalse(filterInfo1.isCanary());
 
-        assertThrows(InstantiationException.class, () -> FilterVerifier.INSTANCE.verifyFilter(sNotZuulFilterGroovy));
+        assertThrows(InstantiationException.class,() -> FilterVerifier.INSTANCE.verifyFilter(sNotZuulFilterGroovy));
 
-        assertThrows(CompilationFailedException.class, () -> FilterVerifier.INSTANCE.verifyFilter(sCompileFailCode));
+        assertThrows(CompilationFailedException.class,() -> FilterVerifier.INSTANCE.verifyFilter(sCompileFailCode));
     }
 }

--- a/zuul-guice/build.gradle
+++ b/zuul-guice/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api(group: 'com.google.inject', name: 'guice', version: "5.1.0")
     implementation 'commons-configuration:commons-configuration:1.10'
 
-    testImplementation libraries.junit,
+    testImplementation libraries.jupiterApi, libraries.jupiterEngine, libraries.jupiterMockito,
             libraries.mockito,
             libraries.truth
 }

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -418,9 +418,6 @@
             ],
             "locked": "1"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
-        },
         "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -433,7 +430,16 @@
             ],
             "locked": "1.70"
         },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
+        },
         "org.mockito:mockito-core": {
+            "locked": "4.8.0"
+        },
+        "org.mockito:mockito-junit-jupiter": {
             "locked": "4.8.0"
         },
         "org.openjdk.jmh:jmh-core": {
@@ -755,10 +761,16 @@
             ],
             "locked": "1.3.8"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
         },
         "org.mockito:mockito-core": {
+            "locked": "4.8.0"
+        },
+        "org.mockito:mockito-junit-jupiter": {
             "locked": "4.8.0"
         },
         "org.slf4j:slf4j-api": {
@@ -947,9 +959,6 @@
             ],
             "locked": "1"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
-        },
         "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -962,7 +971,16 @@
             ],
             "locked": "1.70"
         },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
+        },
         "org.mockito:mockito-core": {
+            "locked": "4.8.0"
+        },
+        "org.mockito:mockito-junit-jupiter": {
             "locked": "4.8.0"
         },
         "org.slf4j:slf4j-api": {

--- a/zuul-guice/src/test/java/com/netflix/zuul/BaseInjectionIntegTest.java
+++ b/zuul-guice/src/test/java/com/netflix/zuul/BaseInjectionIntegTest.java
@@ -19,7 +19,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.netflix.zuul.init.InitTestModule;
 import com.netflix.zuul.init.ZuulFiltersModule;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Base Injection Integration Test
@@ -32,7 +32,7 @@ import org.junit.Before;
 public abstract class BaseInjectionIntegTest {
     protected Injector injector = Guice.createInjector(new InitTestModule(), new ZuulFiltersModule());
 
-    @Before
+    @BeforeEach
     public void setup () {
         injector.injectMembers(this);
     }

--- a/zuul-guice/src/test/java/com/netflix/zuul/guice/GuiceFilterFactoryIntegTest.java
+++ b/zuul-guice/src/test/java/com/netflix/zuul/guice/GuiceFilterFactoryIntegTest.java
@@ -16,29 +16,26 @@
 
 package com.netflix.zuul.guice;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.inject.Inject;
 import com.netflix.zuul.BaseInjectionIntegTest;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.jupiter.api.Test;
 
-@RunWith(BlockJUnit4ClassRunner.class)
 public class GuiceFilterFactoryIntegTest extends BaseInjectionIntegTest {
 
     @Inject
     private GuiceFilterFactory filterFactory;
 
     @Test
-    public void ctorInjection() throws Exception {
+    void ctorInjection() throws Exception {
         TestGuiceConstructorFilter filter = (TestGuiceConstructorFilter) filterFactory.newInstance(TestGuiceConstructorFilter.class);
 
         assertNotNull(filter.injector);
     }
 
     @Test
-    public void fieldInjection() throws Exception {
+    void fieldInjection() throws Exception {
         TestGuiceFieldFilter filter = (TestGuiceFieldFilter) filterFactory.newInstance(TestGuiceFieldFilter.class);
 
         assertNotNull(filter.injector);

--- a/zuul-guice/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleIntegTest.java
+++ b/zuul-guice/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleIntegTest.java
@@ -16,25 +16,22 @@
 
 package com.netflix.zuul.init;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.netflix.config.ConfigurationManager;
 import com.netflix.zuul.BaseInjectionIntegTest;
 import com.netflix.zuul.FilterFileManager.FilterFileManagerConfig;
 import javax.inject.Inject;
 import org.apache.commons.configuration.AbstractConfiguration;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-@RunWith(BlockJUnit4ClassRunner.class)
 public class ZuulFiltersModuleIntegTest extends BaseInjectionIntegTest {
 
     @Inject
     private FilterFileManagerConfig filterFileManagerConfig;
 
-    @BeforeClass
+    @BeforeAll
     public static void before() {
         AbstractConfiguration configuration = ConfigurationManager.getConfigInstance();
         configuration.setProperty("zuul.filters.locations", "inbound,outbound,endpoint");
@@ -42,16 +39,16 @@ public class ZuulFiltersModuleIntegTest extends BaseInjectionIntegTest {
     }
 
     @Test
-    public void scanningWorks() {
+    void scanningWorks() {
         String[] filterLocations = filterFileManagerConfig.getDirectories();
         String[] classNames = filterFileManagerConfig.getClassNames();
 
-        assertEquals(3, filterLocations.length);
-        assertEquals("outbound", filterLocations[1]);
+        assertEquals(3,filterLocations.length);
+        assertEquals("outbound",filterLocations[1]);
 
-        assertEquals(2, classNames.length);
-        assertEquals("com.netflix.zuul.init.TestZuulFilter", classNames[0]);
-        assertEquals("com.netflix.zuul.init2.TestZuulFilter2", classNames[1]);
+        assertEquals(2,classNames.length);
+        assertEquals("com.netflix.zuul.init.TestZuulFilter",classNames[0]);
+        assertEquals("com.netflix.zuul.init2.TestZuulFilter2",classNames[1]);
     }
 
 }

--- a/zuul-guice/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleIntegTest.java
+++ b/zuul-guice/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleIntegTest.java
@@ -43,12 +43,12 @@ public class ZuulFiltersModuleIntegTest extends BaseInjectionIntegTest {
         String[] filterLocations = filterFileManagerConfig.getDirectories();
         String[] classNames = filterFileManagerConfig.getClassNames();
 
-        assertEquals(3,filterLocations.length);
-        assertEquals("outbound",filterLocations[1]);
+        assertEquals(3, filterLocations.length);
+        assertEquals("outbound", filterLocations[1]);
 
-        assertEquals(2,classNames.length);
-        assertEquals("com.netflix.zuul.init.TestZuulFilter",classNames[0]);
-        assertEquals("com.netflix.zuul.init2.TestZuulFilter2",classNames[1]);
+        assertEquals(2, classNames.length);
+        assertEquals("com.netflix.zuul.init.TestZuulFilter", classNames[0]);
+        assertEquals("com.netflix.zuul.init2.TestZuulFilter2", classNames[1]);
     }
 
 }

--- a/zuul-guice/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleTest.java
+++ b/zuul-guice/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleTest.java
@@ -21,13 +21,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.netflix.zuul.init2.TestZuulFilter2;
 import org.apache.commons.configuration.AbstractConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ZuulFiltersModuleTest {
 
     @Mock
@@ -36,37 +36,37 @@ public class ZuulFiltersModuleTest {
     private final ZuulFiltersModule module = new ZuulFiltersModule();
 
     @Test
-    public void testDefaultFilterLocations() {
+    void testDefaultFilterLocations() {
         Mockito.when(configuration.getStringArray("zuul.filters.locations"))
                 .thenReturn("inbound,outbound,endpoint".split(","));
 
         String[] filterLocations = module.findFilterLocations(configuration);
 
-        assertThat(filterLocations.length, equalTo(3));
-        assertThat(filterLocations[1], equalTo("outbound"));
+        assertThat(filterLocations.length,equalTo(3));
+        assertThat(filterLocations[1],equalTo("outbound"));
     }
 
     @Test
-    public void testEmptyFilterLocations() {
+    void testEmptyFilterLocations() {
         Mockito.when(configuration.getStringArray("zuul.filters.locations")).thenReturn(new String[0]);
 
         String[] filterLocations = module.findFilterLocations(configuration);
 
-        assertThat(filterLocations.length, equalTo(0));
+        assertThat(filterLocations.length,equalTo(0));
     }
 
     @Test
-    public void testEmptyClassNames() {
+    void testEmptyClassNames() {
         Mockito.when(configuration.getStringArray("zuul.filters.classes")).thenReturn(new String[]{});
         Mockito.when(configuration.getStringArray("zuul.filters.packages")).thenReturn(new String[]{});
 
         String[] classNames = module.findClassNames(configuration);
 
-        assertThat(classNames.length, equalTo(0));
+        assertThat(classNames.length,equalTo(0));
     }
 
     @Test
-    public void testClassNamesOnly() {
+    void testClassNamesOnly() {
 
         Class<?> expectedClass = TestZuulFilter.class;
 
@@ -76,13 +76,13 @@ public class ZuulFiltersModuleTest {
 
         String[] classNames = module.findClassNames(configuration);
 
-        assertThat(classNames.length, equalTo(1));
-        assertThat(classNames[0], equalTo(expectedClass.getCanonicalName()));
+        assertThat(classNames.length,equalTo(1));
+        assertThat(classNames[0],equalTo(expectedClass.getCanonicalName()));
 
     }
 
     @Test
-    public void testClassNamesPackagesOnly() {
+    void testClassNamesPackagesOnly() {
 
         Class<?> expectedClass = TestZuulFilter.class;
 
@@ -92,41 +92,41 @@ public class ZuulFiltersModuleTest {
 
         String[] classNames = module.findClassNames(configuration);
 
-        assertThat(classNames.length, equalTo(1));
-        assertThat(classNames[0], equalTo(expectedClass.getCanonicalName()));
+        assertThat(classNames.length,equalTo(1));
+        assertThat(classNames[0],equalTo(expectedClass.getCanonicalName()));
 
     }
 
     @Test
-    public void testMultiClasses() {
+    void testMultiClasses() {
         Class<?> expectedClass1 = TestZuulFilter.class;
         Class<?> expectedClass2 = TestZuulFilter2.class;
 
         Mockito.when(configuration.getStringArray("zuul.filters.classes"))
-                .thenReturn(new String[] {
-                        "com.netflix.zuul.init.TestZuulFilter", "com.netflix.zuul.init2.TestZuulFilter2"});
+                .thenReturn(new String[]{
+                        "com.netflix.zuul.init.TestZuulFilter","com.netflix.zuul.init2.TestZuulFilter2"});
         Mockito.when(configuration.getStringArray("zuul.filters.packages")).thenReturn(new String[0]);
 
         String[] classNames = module.findClassNames(configuration);
 
-        assertThat(classNames.length, equalTo(2));
-        assertThat(classNames[0], equalTo(expectedClass1.getCanonicalName()));
-        assertThat(classNames[1], equalTo(expectedClass2.getCanonicalName()));
+        assertThat(classNames.length,equalTo(2));
+        assertThat(classNames[0],equalTo(expectedClass1.getCanonicalName()));
+        assertThat(classNames[1],equalTo(expectedClass2.getCanonicalName()));
     }
 
     @Test
-    public void testMultiPackages() {
+    void testMultiPackages() {
         Class<?> expectedClass1 = TestZuulFilter.class;
         Class<?> expectedClass2 = TestZuulFilter2.class;
 
         Mockito.when(configuration.getStringArray("zuul.filters.classes")).thenReturn(new String[0]);
         Mockito.when(configuration.getStringArray("zuul.filters.packages"))
-                .thenReturn(new String[]{"com.netflix.zuul.init", "com.netflix.zuul.init2"});
+                .thenReturn(new String[]{"com.netflix.zuul.init","com.netflix.zuul.init2"});
 
         String[] classNames = module.findClassNames(configuration);
 
-        assertThat(classNames.length, equalTo(2));
-        assertThat(classNames[0], equalTo(expectedClass1.getCanonicalName()));
-        assertThat(classNames[1], equalTo(expectedClass2.getCanonicalName()));
+        assertThat(classNames.length,equalTo(2));
+        assertThat(classNames[0],equalTo(expectedClass1.getCanonicalName()));
+        assertThat(classNames[1],equalTo(expectedClass2.getCanonicalName()));
     }
 }

--- a/zuul-guice/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleTest.java
+++ b/zuul-guice/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleTest.java
@@ -104,7 +104,7 @@ public class ZuulFiltersModuleTest {
 
         Mockito.when(configuration.getStringArray("zuul.filters.classes"))
                 .thenReturn(new String[]{
-                        "com.netflix.zuul.init.TestZuulFilter","com.netflix.zuul.init2.TestZuulFilter2"});
+                        "com.netflix.zuul.init.TestZuulFilter", "com.netflix.zuul.init2.TestZuulFilter2"});
         Mockito.when(configuration.getStringArray("zuul.filters.packages")).thenReturn(new String[0]);
 
         String[] classNames = module.findClassNames(configuration);
@@ -121,7 +121,7 @@ public class ZuulFiltersModuleTest {
 
         Mockito.when(configuration.getStringArray("zuul.filters.classes")).thenReturn(new String[0]);
         Mockito.when(configuration.getStringArray("zuul.filters.packages"))
-                .thenReturn(new String[]{"com.netflix.zuul.init","com.netflix.zuul.init2"});
+                .thenReturn(new String[]{"com.netflix.zuul.init", "com.netflix.zuul.init2"});
 
         String[] classNames = module.findClassNames(configuration);
 

--- a/zuul-guice/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleTest.java
+++ b/zuul-guice/src/test/java/com/netflix/zuul/init/ZuulFiltersModuleTest.java
@@ -42,8 +42,8 @@ public class ZuulFiltersModuleTest {
 
         String[] filterLocations = module.findFilterLocations(configuration);
 
-        assertThat(filterLocations.length,equalTo(3));
-        assertThat(filterLocations[1],equalTo("outbound"));
+        assertThat(filterLocations.length, equalTo(3));
+        assertThat(filterLocations[1], equalTo("outbound"));
     }
 
     @Test
@@ -52,7 +52,7 @@ public class ZuulFiltersModuleTest {
 
         String[] filterLocations = module.findFilterLocations(configuration);
 
-        assertThat(filterLocations.length,equalTo(0));
+        assertThat(filterLocations.length, equalTo(0));
     }
 
     @Test
@@ -62,7 +62,7 @@ public class ZuulFiltersModuleTest {
 
         String[] classNames = module.findClassNames(configuration);
 
-        assertThat(classNames.length,equalTo(0));
+        assertThat(classNames.length, equalTo(0));
     }
 
     @Test
@@ -76,8 +76,8 @@ public class ZuulFiltersModuleTest {
 
         String[] classNames = module.findClassNames(configuration);
 
-        assertThat(classNames.length,equalTo(1));
-        assertThat(classNames[0],equalTo(expectedClass.getCanonicalName()));
+        assertThat(classNames.length, equalTo(1));
+        assertThat(classNames[0], equalTo(expectedClass.getCanonicalName()));
 
     }
 
@@ -92,8 +92,8 @@ public class ZuulFiltersModuleTest {
 
         String[] classNames = module.findClassNames(configuration);
 
-        assertThat(classNames.length,equalTo(1));
-        assertThat(classNames[0],equalTo(expectedClass.getCanonicalName()));
+        assertThat(classNames.length, equalTo(1));
+        assertThat(classNames[0], equalTo(expectedClass.getCanonicalName()));
 
     }
 
@@ -109,9 +109,9 @@ public class ZuulFiltersModuleTest {
 
         String[] classNames = module.findClassNames(configuration);
 
-        assertThat(classNames.length,equalTo(2));
-        assertThat(classNames[0],equalTo(expectedClass1.getCanonicalName()));
-        assertThat(classNames[1],equalTo(expectedClass2.getCanonicalName()));
+        assertThat(classNames.length, equalTo(2));
+        assertThat(classNames[0], equalTo(expectedClass1.getCanonicalName()));
+        assertThat(classNames[1], equalTo(expectedClass2.getCanonicalName()));
     }
 
     @Test
@@ -125,8 +125,8 @@ public class ZuulFiltersModuleTest {
 
         String[] classNames = module.findClassNames(configuration);
 
-        assertThat(classNames.length,equalTo(2));
-        assertThat(classNames[0],equalTo(expectedClass1.getCanonicalName()));
-        assertThat(classNames[1],equalTo(expectedClass2.getCanonicalName()));
+        assertThat(classNames.length, equalTo(2));
+        assertThat(classNames[0], equalTo(expectedClass1.getCanonicalName()));
+        assertThat(classNames[1], equalTo(expectedClass2.getCanonicalName()));
     }
 }

--- a/zuul-processor/build.gradle
+++ b/zuul-processor/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     implementation libraries.guava
     implementation project(":zuul-core")
 
-    testImplementation libraries.junit,
+    testImplementation libraries.jupiterApi, libraries.jupiterEngine,
             libraries.truth
     testAnnotationProcessor project(":zuul-processor")
 }

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -406,9 +406,6 @@
             ],
             "locked": "1"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
-        },
         "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -420,6 +417,12 @@
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.35"
@@ -928,8 +931,11 @@
             ],
             "locked": "1.3.8"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1111,9 +1117,6 @@
             ],
             "locked": "1"
         },
-        "junit:junit": {
-            "locked": "4.13.2"
-        },
         "org.bouncycastle:bcpkix-jdk15on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -1125,6 +1128,12 @@
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "1.70"
+        },
+        "org.junit.jupiter:junit-jupiter-api": {
+            "locked": "5.9.1"
+        },
+        "org.junit.jupiter:junit-jupiter-engine": {
+            "locked": "5.9.1"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [

--- a/zuul-processor/src/test/java/com/netflix/zuul/filters/processor/FilterProcessorTest.java
+++ b/zuul-processor/src/test/java/com/netflix/zuul/filters/processor/FilterProcessorTest.java
@@ -22,18 +22,15 @@ import com.netflix.zuul.filters.ZuulFilter;
 import com.netflix.zuul.filters.processor.override.SubpackageFilter;
 import com.netflix.zuul.filters.processor.subpackage.OverrideFilter;
 import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link FilterProcessor}.
  */
-@RunWith(JUnit4.class)
 public class FilterProcessorTest {
 
     @Test
-    public void allFilterClassedRecorded() throws Exception {
+    void allFilterClassedRecorded() throws Exception {
         Collection<Class<ZuulFilter<?, ?>>> filters =
                 StaticFilterLoader.loadFilterTypesFromResources(getClass().getClassLoader());
 


### PR DESCRIPTION
This migration was accomplished using the OpenRewrite JUnit 5 recipe.

```
activeRecipe("org.openrewrite.java.testing.junit5.JUnit5BestPractices")
```

The recipe was applied by running this Gradle command:

```
./gradlew clean rewriteRun
```

Reference:
https://docs.openrewrite.org
