### PR TITLE
Release chunks on filter exceptions

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulEndPointRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulEndPointRunner.java
@@ -35,6 +35,7 @@ import com.netflix.zuul.filters.endpoint.MissingEndpointHandlingFilter;
 import com.netflix.zuul.filters.SyncZuulFilterAdapter;
 import com.netflix.zuul.netty.server.MethodBinding;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.util.ReferenceCountUtil;
 import io.perfmark.PerfMark;
 import io.perfmark.TaskCloseable;
 import javax.annotation.Nullable;
@@ -150,6 +151,7 @@ public class ZuulEndPointRunner extends BaseZuulFilterRunner<HttpRequestMessage,
             }
         }
         catch (Exception ex) {
+            ReferenceCountUtil.safeRelease(chunk);
             handleException(zuulReq, endpointName, ex);
         }
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunner.java
@@ -27,6 +27,7 @@ import com.netflix.zuul.passport.CurrentPassport;
 import com.netflix.zuul.passport.PassportState;
 import io.netty.handler.codec.http.HttpContent;
 
+import io.netty.util.ReferenceCountUtil;
 import io.perfmark.PerfMark;
 import io.perfmark.TaskCloseable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -154,6 +155,7 @@ public class ZuulFilterChainRunner<T extends ZuulMessage> extends BaseZuulFilter
             }
         }
         catch (Exception ex) {
+            ReferenceCountUtil.safeRelease(chunk);
             handleException(inMesg, filterName, ex);
         }
     }


### PR DESCRIPTION
If we're processing a chunk and a filter exception happens, we bail out of the request and return a 500. Since we're in the middle of handling the chunk and may not have added it to the body contents, we need to make sure to release it. 