### PR TITLE
Only capture the first failure state in passport future listener

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/insights/PassportStateListener.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/insights/PassportStateListener.java
@@ -48,8 +48,12 @@ public class PassportStateListener implements GenericFutureListener
             passport.add(successState);
         }
         else {
-            if (failState != null)
-                passport.add(failState);
+            if (failState != null) {
+                // only capture a single failure state event,
+                // as sending content errors will fire for all content chunks,
+                // and we only need the first one
+                passport.addIfNotAlready(failState);
+            }
         }
     }
 }


### PR DESCRIPTION
During large content streams, if a client cancels a request mid-stream, the `ChannelPromise` will fire failed events for each chunk queued to be written to the `ChannelOutboundHandlerAdapter`. This can cause a huge amount of `PassportState.OUT_REQ_CONTENT_ERROR_SENDING` to be added to the passport.

This PR will only add the first failure state for passport state listeners, which will ensure that only the first `OUT_REQ_CONTENT_ERROR_SENDING` is logged against the passport, with others being dropped.