### PR TITLE
Remove reflection from direct memory monitor

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/DirectMemoryMonitor.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/DirectMemoryMonitor.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.netflix.config.DynamicIntProperty;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.patterns.PolledMeter;
+import io.netty.util.internal.PlatformDependent;
 import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.concurrent.Executors;
@@ -42,50 +43,6 @@ public final class DirectMemoryMonitor {
     private static final String PROP_PREFIX = "zuul.directmemory";
     private static final DynamicIntProperty TASK_DELAY_PROP = new DynamicIntProperty(PROP_PREFIX + ".task.delay", 10);
 
-    private static final Supplier<Long> directMemoryLimitGetter;
-    private static final Supplier<Long> reservedMemoryGetter;
-
-    static {
-        Supplier<Long> directMemoryLimit;
-        Supplier<Long> reservedMemory;
-        try {
-            Class<?> c = Class.forName("io.netty.util.internal.PlatformDependent");
-            Field directMemoryLimitField = c.getDeclaredField("DIRECT_MEMORY_LIMIT");
-            directMemoryLimitField.setAccessible(true);
-            directMemoryLimit = () -> {
-                try {
-                    return (long) directMemoryLimitField.get(null);
-                } catch (IllegalAccessException e) {
-                    throw new RuntimeException(e);
-                }
-            };
-            // Check that the call works
-            directMemoryLimit.get();
-            Field reservedMemoryField = c.getDeclaredField("DIRECT_MEMORY_COUNTER");
-            reservedMemoryField.setAccessible(true);
-            reservedMemory = () -> {
-                try {
-                    AtomicLong value = (AtomicLong) reservedMemoryField.get(null);
-                    // Matches behavior in PlatformDependent.usedDirectMemory.
-                    return value == null ? -1 : value.get();
-                } catch (IllegalAccessException e) {
-                    throw new RuntimeException(e);
-                }
-            };
-            if (reservedMemory.get() == -1) {
-                // This can occur when using JDK 11, which can prevent some of the reflective operations
-                // PlatformDependent depends on.
-                LOG.debug("Unable to get direct memory");
-            }
-        } catch (Throwable t) {
-            LOG.warn("Unable to query direct memory, disabling monitor", t);
-            directMemoryLimit = null;
-            reservedMemory = null;
-        }
-        directMemoryLimitGetter = directMemoryLimit;
-        reservedMemoryGetter = reservedMemory;
-    }
-
     // TODO(carl-mastrangelo): this should be passed in as a dependency, so it can be shutdown and waited on for
     //    termination.
     private final ScheduledExecutorService service =
@@ -94,26 +51,24 @@ public final class DirectMemoryMonitor {
 
     @Inject
     public DirectMemoryMonitor(Registry registry) {
-        if (reservedMemoryGetter != null) {
-            PolledMeter.using(registry)
-                    .withName(PROP_PREFIX + ".reserved")
-                    .withDelay(Duration.ofSeconds(TASK_DELAY_PROP.get()))
-                    .scheduleOn(service)
-                    .monitorValue(DirectMemoryMonitor.class, DirectMemoryMonitor::getReservedMemory);
-        }
-        if (directMemoryLimitGetter != null) {
-            PolledMeter.using(registry)
-                    .withName(PROP_PREFIX + ".max")
-                    .withDelay(Duration.ofSeconds(TASK_DELAY_PROP.get()))
-                    .scheduleOn(service)
-                    .monitorValue(DirectMemoryMonitor.class, DirectMemoryMonitor::getMaxMemory);
-        }
+        PolledMeter.using(registry)
+                   .withName(PROP_PREFIX + ".reserved")
+                   .withDelay(Duration.ofSeconds(TASK_DELAY_PROP.get()))
+                   .scheduleOn(service)
+                   .monitorValue(DirectMemoryMonitor.class, DirectMemoryMonitor::getReservedMemory);
+
+        PolledMeter.using(registry)
+                   .withName(PROP_PREFIX + ".max")
+                   .withDelay(Duration.ofSeconds(TASK_DELAY_PROP.get()))
+                   .scheduleOn(service)
+                   .monitorValue(DirectMemoryMonitor.class, DirectMemoryMonitor::getMaxMemory);
+
     }
 
     private static double getReservedMemory(Object discard) {
         try {
-            return reservedMemoryGetter.get();
-        } catch (RuntimeException | Error e) {
+            return PlatformDependent.maxDirectMemory();
+        } catch (Throwable e) {
             LOG.warn("Error in DirectMemoryMonitor task.", e);
         }
         return -1;
@@ -121,8 +76,8 @@ public final class DirectMemoryMonitor {
 
     private static double getMaxMemory(Object discard) {
         try {
-            return directMemoryLimitGetter.get();
-        } catch (RuntimeException | Error e) {
+            return PlatformDependent.usedDirectMemory();
+        } catch (Throwable e) {
             LOG.warn("Error in DirectMemoryMonitor task.", e);
         }
         return -1;

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/DirectMemoryMonitor.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/DirectMemoryMonitor.java
@@ -67,7 +67,7 @@ public final class DirectMemoryMonitor {
 
     private static double getReservedMemory(Object discard) {
         try {
-            return PlatformDependent.maxDirectMemory();
+            return PlatformDependent.usedDirectMemory();
         } catch (Throwable e) {
             LOG.warn("Error in DirectMemoryMonitor task.", e);
         }
@@ -76,7 +76,7 @@ public final class DirectMemoryMonitor {
 
     private static double getMaxMemory(Object discard) {
         try {
-            return PlatformDependent.usedDirectMemory();
+            return PlatformDependent.maxDirectMemory();
         } catch (Throwable e) {
             LOG.warn("Error in DirectMemoryMonitor task.", e);
         }


### PR DESCRIPTION
Looks like PlatformDependent added some getters after this class was written