### PR TITLE
Prevent stray chunks from reaching filter chain

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
@@ -98,6 +98,7 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
         }
         else if (evt instanceof RequestCancelledEvent) {
             if (zuulRequest != null) {
+                zuulRequest.getContext().cancel();
                 StatusCategoryUtils.storeStatusCategoryIfNotAlreadyFailure(zuulRequest.getContext(), FAILURE_CLIENT_CANCELLED);
             }
             fireEndpointFinish(true);
@@ -112,6 +113,7 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
         }
         else {
             final SessionContext zuulCtx = zuulRequest.getContext();
+            zuulRequest.getContext().cancel();
             StatusCategoryUtils.storeStatusCategoryIfNotAlreadyFailure(zuulCtx, statusCategory);
             final HttpResponseMessage zuulResponse = new HttpResponseMessageImpl(zuulCtx, zuulRequest, status);
             final Headers headers = zuulResponse.getHeaders();

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -71,6 +71,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.net.ssl.SSLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -458,11 +459,14 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
         final String errMesg = String.format("Error writing %s to client", requestPart);
 
         if (cause instanceof java.nio.channels.ClosedChannelException ||
-                cause instanceof Errors.NativeIoException) {
+                cause instanceof Errors.NativeIoException ||
+                cause instanceof SSLException ||
+                (cause.getCause() != null && cause.getCause() instanceof SSLException)) {
             LOG.debug(errMesg + " - client connection is closed.");
             if (zuulRequest != null) {
                 zuulRequest.getContext().cancel();
-                StatusCategoryUtils.storeStatusCategoryIfNotAlreadyFailure(zuulRequest.getContext(), ZuulStatusCategory.FAILURE_CLIENT_CANCELLED);
+                StatusCategoryUtils.storeStatusCategoryIfNotAlreadyFailure(zuulRequest.getContext(),
+                        ZuulStatusCategory.FAILURE_CLIENT_CANCELLED);
             }
         }
         else {


### PR DESCRIPTION
If a client has gone away, but the origin is still sending us content chunks, we should release them as soon as possible.