### PR TITLE
Ensure response filters are not left waiting for buffered body

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
@@ -115,8 +115,8 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
         return (AtomicInteger) Preconditions.checkNotNull(ctx.get(RUNNING_FILTER_IDX_SESSION_CTX_KEY), "runningFilterIndex");
     }
 
-    protected final boolean isFilterAwaitingBody(I zuulMesg) {
-        return zuulMesg.getContext().containsKey(AWAITING_BODY_FLAG_SESSION_CTX_KEY);
+    protected final boolean isFilterAwaitingBody(SessionContext context) {
+        return context.containsKey(AWAITING_BODY_FLAG_SESSION_CTX_KEY);
     }
 
     protected final void setFilterAwaitingBody(I zuulMesg, boolean flag) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
@@ -34,6 +34,7 @@ import com.netflix.zuul.message.ZuulMessage;
 import com.netflix.zuul.message.http.HttpRequestInfo;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpResponseMessage;
+import com.netflix.zuul.netty.SpectatorUtils;
 import com.netflix.zuul.netty.server.MethodBinding;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpContent;
@@ -140,7 +141,15 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
             try (TaskCloseable ignored =
                     traceTask(this, s -> s.getClass().getSimpleName() + ".fireChannelReadChunk")) {
                 addPerfMarkTags(zuulMesg);
-                getChannelHandlerContext(zuulMesg).fireChannelRead(chunk);
+                ChannelHandlerContext channelHandlerContext = getChannelHandlerContext(zuulMesg);
+                if (!channelHandlerContext.channel().isActive()) {
+                    zuulMesg.getContext().cancel();
+                    zuulMesg.disposeBufferedBody();
+                    SpectatorUtils.newCounter("zuul.filterChain.chunk.hanging",
+                            zuulMesg.getClass().getSimpleName()).increment();
+                } else {
+                    channelHandlerContext.fireChannelRead(chunk);
+                }
             }
         }
     }
@@ -157,7 +166,16 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
             try (TaskCloseable ignored =
                     traceTask(this, s -> s.getClass().getSimpleName() + ".fireChannelRead")) {
                 addPerfMarkTags(zuulMesg);
-                getChannelHandlerContext(zuulMesg).fireChannelRead(zuulMesg);
+                ChannelHandlerContext channelHandlerContext = getChannelHandlerContext(zuulMesg);
+                if (!channelHandlerContext.channel().isActive()) {
+                    zuulMesg.getContext().cancel();
+                    zuulMesg.disposeBufferedBody();
+                    SpectatorUtils.newCounter("zuul.filterChain.message.hanging",
+                            zuulMesg.getClass().getSimpleName()).increment();
+                }
+                else {
+                    channelHandlerContext.fireChannelRead(zuulMesg);
+                }
             }
         }
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulEndPointRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulEndPointRunner.java
@@ -146,7 +146,7 @@ public class ZuulEndPointRunner extends BaseZuulFilterRunner<HttpRequestMessage,
                     chunk.release();
                 }
 
-                if (isFilterAwaitingBody(zuulReq) && zuulReq.hasCompleteBody() && !(endpoint instanceof ProxyEndpoint)) {
+                if (isFilterAwaitingBody(zuulReq.getContext()) && zuulReq.hasCompleteBody() && !(endpoint instanceof ProxyEndpoint)) {
                     //whole body has arrived, resume filter chain
                     newChunk.touch("Endpoint body complete, resume chain, ZuulMessage: " + zuulReq);
                     invokeNextStage(filter(endpoint, zuulReq));

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
@@ -34,6 +34,7 @@ import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpResponseMessage;
 import com.netflix.zuul.message.http.HttpResponseMessageImpl;
 import com.netflix.zuul.netty.RequestCancelledEvent;
+import com.netflix.zuul.netty.SpectatorUtils;
 import com.netflix.zuul.stats.status.StatusCategory;
 import com.netflix.zuul.stats.status.StatusCategoryUtils;
 import io.netty.channel.ChannelHandlerContext;
@@ -149,6 +150,8 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
             if (zuulResponse != null) {
                 // fire a last content into the filter chain to unblock any filters awaiting a buffered body
                 responseFilterChain.filter(zuulResponse, new DefaultLastHttpContent());
+                SpectatorUtils.newCounter("zuul.filterChain.bodyBuffer.hanging",
+                                zuulRequest.getContext().getRouteVIP()).increment();
             }
         }
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
@@ -18,11 +18,11 @@ package com.netflix.zuul.netty.filter;
 
 import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason.SESSION_COMPLETE;
 import static com.netflix.zuul.context.CommonContextKeys.NETTY_SERVER_CHANNEL_HANDLER_CONTEXT;
+import static com.netflix.zuul.netty.server.ClientRequestReceiver.ATTR_ZUUL_RESP;
 import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_CLIENT_CANCELLED;
 import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_CLIENT_TIMEOUT;
 import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_LOCAL;
 import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_LOCAL_IDLE_TIMEOUT;
-
 import com.google.common.base.Preconditions;
 import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
 import com.netflix.netty.common.HttpRequestReadTimeoutEvent;
@@ -39,6 +39,7 @@ import com.netflix.zuul.stats.status.StatusCategoryUtils;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.unix.Errors;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.ReferenceCountUtil;
@@ -88,7 +89,7 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
     public final void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof CompleteEvent) {
             final CompleteEvent completeEvent = (CompleteEvent)evt;
-            fireEndpointFinish(completeEvent.getReason() != SESSION_COMPLETE);
+            fireEndpointFinish(completeEvent.getReason() != SESSION_COMPLETE, ctx);
         }
         else if (evt instanceof HttpRequestReadTimeoutEvent) {
             sendResponse(FAILURE_CLIENT_TIMEOUT, 408, ctx);
@@ -101,7 +102,7 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
                 zuulRequest.getContext().cancel();
                 StatusCategoryUtils.storeStatusCategoryIfNotAlreadyFailure(zuulRequest.getContext(), FAILURE_CLIENT_CANCELLED);
             }
-            fireEndpointFinish(true);
+            fireEndpointFinish(true, ctx);
             ctx.close();
         }
         super.userEventTriggered(ctx, evt);
@@ -121,7 +122,7 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
             headers.add("Content-Length", "0");
             zuulResponse.finishBufferedBodyIfIncomplete();
             responseFilterChain.filter(zuulResponse);
-            fireEndpointFinish(true);
+            fireEndpointFinish(true, ctx);
         }
     }
 
@@ -129,13 +130,27 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
         return zuulRequest;
     }
 
-    protected void fireEndpointFinish(final boolean error) {
+    protected void fireEndpointFinish(final boolean error, final ChannelHandlerContext ctx) {
+        // make sure filter chain is not left hanging
+        finishResponseFilters(ctx);
+
         final ZuulFilter endpoint = ZuulEndPointRunner.getEndpoint(zuulRequest);
         if (endpoint instanceof ProxyEndpoint) {
             final ProxyEndpoint edgeProxyEndpoint = (ProxyEndpoint) endpoint;
             edgeProxyEndpoint.finish(error);
         }
         zuulRequest = null;
+    }
+
+    private void finishResponseFilters(ChannelHandlerContext ctx) {
+        // check if there are any response filters awaiting a buffered body
+        if (zuulRequest != null && responseFilterChain.isFilterAwaitingBody(zuulRequest.getContext())) {
+            HttpResponseMessage zuulResponse = ctx.channel().attr(ATTR_ZUUL_RESP).get();
+            if (zuulResponse != null) {
+                // fire a last content into the filter chain to unblock any filters awaiting a buffered body
+                responseFilterChain.filter(zuulResponse, new DefaultLastHttpContent());
+            }
+        }
     }
 
     @Override
@@ -147,7 +162,7 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
             zuulCtx.setShouldSendErrorResponse(true);
             sendResponse(FAILURE_LOCAL, 500, ctx);
         } else {
-            fireEndpointFinish(true);
+            fireEndpointFinish(true, ctx);
             ctx.close();
         }
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunner.java
@@ -131,7 +131,7 @@ public class ZuulFilterChainRunner<T extends ZuulMessage> extends BaseZuulFilter
                 chunk.touch("Filter runner buffering chunk, message: " + inMesg);
                 inMesg.bufferBodyContents(chunk);
 
-                boolean isAwaitingBody = isFilterAwaitingBody(inMesg);
+                boolean isAwaitingBody = isFilterAwaitingBody(inMesg.getContext());
 
                 // Record passport states for start and end of buffering bodies.
                 if (isAwaitingBody) {


### PR DESCRIPTION
In case of client cancellations or connectivity errors, we may have a response filter chain hanging, waiting for a complete buffered body. The goal for this PR is to close out that filter chain and clean up any body chunks being processed.