### PR TITLE
fix JUnit 5 import

### DIFF
--- a/zuul-integration-test/src/test/java/com/netflix/zuul/integration/IntegrationTest.java
+++ b/zuul-integration-test/src/test/java/com/netflix/zuul/integration/IntegrationTest.java
@@ -64,7 +64,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.google.common.truth.Truth.assertThat;
 import static com.netflix.netty.common.metrics.CustomLeakDetector.assertZeroLeaks;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 


### PR DESCRIPTION
This fix was generated by OpenRewrite

```
./gradlew clean rewriteRun
```
