### PR TITLE
fail build on OpenRewrite Dry Run result

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'gradle'
       - name: Build
         run: |
-          sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon build"
+          sudo env "PATH=$PATH" bash -c "ulimit -l 65536 && ulimit -a && ./gradlew --no-daemon rewriteDryRun build"
           echo "Status of build: $?"
   validation:
     name: "Gradle Validation"

--- a/build.gradle
+++ b/build.gradle
@@ -91,5 +91,6 @@ dependencies {
 }
 
 rewrite {
+    failOnDryRunResults = true
     activeRecipe("org.openrewrite.java.testing.junit5.JUnit5BestPractices")
 }


### PR DESCRIPTION
https://docs.openrewrite.org/reference/gradle-plugin-configuration

```
rewriteDryRun can be used as a "gate" in a continuous integration 
environment by failing the build if rewriteDryRun detects changes 
to be made and failOnDryRunResults is set to true
```
