### PR TITLE
Revert "Netty 4.1.86"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 versions_groovy=3.0.13
 versions_ribbon=2.4.4
-versions_netty=4.1.86.Final
+versions_netty=4.1.85.Final
 versions_netty_io_uring=0.0.16.Final
 release.scope=patch
 release.version=2.3.1-SNAPSHOT

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -34,34 +34,34 @@
             "locked": "0.0.16.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -128,34 +128,34 @@
             "locked": "0.0.16.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -250,37 +250,37 @@
             "locked": "0.0.16.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -393,37 +393,37 @@
             "locked": "0.0.16.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -488,34 +488,34 @@
             "locked": "0.0.16.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"
@@ -619,37 +619,37 @@
             "locked": "0.0.16.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.54.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.25.0"

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -58,43 +58,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -179,43 +179,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -332,43 +332,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -380,19 +380,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -546,43 +546,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -594,19 +594,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -711,43 +711,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -873,43 +873,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -921,19 +921,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -61,43 +61,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -182,43 +182,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -338,43 +338,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -386,19 +386,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -555,43 +555,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -603,19 +603,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -720,43 +720,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -885,43 +885,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -933,19 +933,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -96,43 +96,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -144,19 +144,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -270,43 +270,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -403,43 +403,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -577,43 +577,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -625,19 +625,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -812,43 +812,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -860,19 +860,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -995,43 +995,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1178,43 +1178,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1226,19 +1226,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -58,43 +58,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -176,43 +176,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -326,43 +326,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -374,19 +374,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -531,43 +531,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -579,19 +579,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -728,43 +728,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -776,19 +776,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -890,43 +890,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1043,43 +1043,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1091,19 +1091,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -96,43 +96,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -144,19 +144,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -267,43 +267,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -403,43 +403,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -579,43 +579,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -627,19 +627,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -810,43 +810,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -858,19 +858,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -993,43 +993,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1163,43 +1163,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1211,19 +1211,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.86.Final"
+            "locked": "4.1.85.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
Reverts Netflix/zuul#1410

Reverting to previous version of Netty.  I am investigating Brotli test suite failures w/ 4.1.86
