### PR TITLE
Ensure we release FullHttpResponse messages

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/OriginResponseReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/OriginResponseReceiver.java
@@ -84,7 +84,7 @@ public class OriginResponseReceiver extends ChannelDuplexHandler {
             if (edgeProxy != null) {
                 edgeProxy.responseFromOrigin((HttpResponse) msg);
             } else if (ReferenceCountUtil.refCnt(msg) > 0){
-                // this handles the case of a DefaultHttpResponse that could have content that needs to be released
+                // this handles the case of a DefaultFullHttpResponse that could have content that needs to be released
                 ReferenceCountUtil.safeRelease(msg);
             }
             ctx.channel().read();


### PR DESCRIPTION
In some cases, the response we get from the origin is a `DefaultFullHttpResponse`. We need to release it in case the client has gone away (i.e. request is decoupled from response). 