### PR TITLE
synchronize on pooled conn. when releasing back or removing the pool

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PooledConnection.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PooledConnection.java
@@ -181,7 +181,9 @@ public class PooledConnection {
 
     public ChannelFuture closeAndRemoveFromPool()
     {
-        channelManager.remove(this);
+        synchronized (channelManager) {
+            channelManager.remove(this);
+        }
         return this.close();
     }
 
@@ -203,10 +205,12 @@ public class PooledConnection {
             this.shouldClose = true;
         }
 
-        // reset the connectionState
-        connectionState = ConnectionState.WRITE_READY;
-        released = true;
-        return channelManager.release(this);
+        // reset the connectionState and release
+        synchronized (channelManager) {
+            connectionState = ConnectionState.WRITE_READY;
+            released = true;
+            return channelManager.release(this);
+        }
     }
 
     public void removeReadTimeoutHandler()


### PR DESCRIPTION
The `ClientChannelManager` is designed to be shared across multiple conns. for a single `NettyOrigin`. 
Trouble is that makes access to the client channel manager multi-threaded, by definition.

This hasn't been a noticeable problem, probably since once this problem gets resolved by acquiring a new conn. from the pool, or other mechanisms. Regardless, I don't think there's a good reason to not enforce this safety.

While locking isn't ideal, the other solution is a proper refactor of the pool managers.