### PR TITLE
Add graceful shutdown method to ClientChannelManager

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ClientChannelManager.java
@@ -40,6 +40,10 @@ public interface ClientChannelManager
 
     void shutdown();
 
+    default void gracefulShutdown() {
+        shutdown();
+    }
+
     boolean release(PooledConnection conn);
 
     Promise<PooledConnection> acquire(EventLoop eventLoop);
@@ -60,4 +64,5 @@ public interface ClientChannelManager
     int getConnsInUse();
 
     ConnectionPoolConfig getConfig();
+
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
@@ -237,12 +237,6 @@ public class DefaultClientChannelManager implements ClientChannelManager {
         discoveryResult.decrementActiveRequestsCount();
         discoveryResult.incrementNumRequests();
 
-        if (shuttingDown) {
-            LOG.debug("[{}] closing connection released during shutdown", conn.getChannel().id());
-            conn.close();
-            return false;
-        }
-
         boolean released = false;
 
         // if the connection has been around too long (i.e. too many requests), then close it

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/IConnectionPool.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/IConnectionPool.java
@@ -35,8 +35,13 @@ public interface IConnectionPool
     boolean release(PooledConnection conn);
     boolean remove(PooledConnection conn);
     void shutdown();
+
+    default void drain() {
+        shutdown();
+    }
     boolean isAvailable();
     int getConnsInUse();
     int getConnsInPool();
     ConnectionPoolConfig getConfig();
+
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPool.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPool.java
@@ -29,6 +29,7 @@ import io.netty.util.concurrent.Promise;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.Objects;
@@ -431,7 +432,12 @@ public class PerServerConnectionPool implements IConnectionPool
      */
     void drainIdleConnectionsOnEventLoop(EventLoop eventLoop) {
         eventLoop.execute(() -> {
-            for(PooledConnection connection : connectionsPerEventLoop.get(eventLoop)) {
+            Deque<PooledConnection> connections = connectionsPerEventLoop.get(eventLoop);
+            if(connections == null) {
+                return;
+            }
+
+            for(PooledConnection connection : connections) {
                 //any connections in the Deque are idle since they are removed in tryGettingFromConnectionPool()
                 connection.setInPool(false);
                 LOG.debug("Closing connection {}", connection);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPool.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPool.java
@@ -431,12 +431,9 @@ public class PerServerConnectionPool implements IConnectionPool
      */
     void drainIdleConnectionsOnEventLoop(EventLoop eventLoop) {
         eventLoop.execute(() -> {
-            Deque<PooledConnection> connections = connectionsPerEventLoop.get(eventLoop);
-            for(Iterator<PooledConnection> it = connections.iterator(); it.hasNext(); ) {
+            for(PooledConnection connection : connectionsPerEventLoop.get(eventLoop)) {
                 //any connections in the Deque are idle since they are removed in tryGettingFromConnectionPool()
-                PooledConnection connection = it.next();
                 connection.setInPool(false);
-                it.remove();
                 LOG.debug("Closing connection {}", connection);
                 connection.close();
                 connsInPool.decrementAndGet();

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPool.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPool.java
@@ -323,6 +323,12 @@ public class PerServerConnectionPool implements IConnectionPool
             return false;
         }
 
+        if(draining) {
+            LOG.debug("[{}] closing released connection during drain", conn.getChannel().id());
+            conn.getChannel().close();
+            return false;
+        }
+
         // Get the eventloop for this channel.
         EventLoop eventLoop = conn.getChannel().eventLoop();
         Deque<PooledConnection> connections = getPoolForEventLoop(eventLoop);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PooledConnection.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PooledConnection.java
@@ -230,6 +230,13 @@ public class PooledConnection {
                 new ReadTimeoutHandler(readTimeout.toMillis(), TimeUnit.MILLISECONDS));
     }
 
+    ConnectionState getConnectionState() {
+        return connectionState;
+    }
+
+    boolean isReleased() {
+        return released;
+    }
 
     @Override
     public String toString()

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManagerTest.java
@@ -16,7 +16,9 @@
 
 package com.netflix.zuul.netty.connectionpool;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -26,6 +28,7 @@ import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.InstanceInfo.Builder;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.spectator.api.Registry;
 import com.netflix.zuul.discovery.DiscoveryResult;
 import com.netflix.zuul.discovery.DynamicServerResolver;
@@ -35,6 +38,7 @@ import com.netflix.zuul.origins.OriginName;
 import com.netflix.zuul.passport.CurrentPassport;
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.EventLoop;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.Promise;
@@ -206,4 +210,30 @@ class DefaultClientChannelManagerTest {
         clientChannelManager.shutdown();
         serverSocket.close();
     }
+
+    @Test
+    public void connClosedIfReleasedDuringShutdown() {
+        OriginName originName = OriginName.fromVip("vip", "test");
+        DynamicServerResolver resolver = mock(DynamicServerResolver.class);
+
+        NoopRegistry registry = new NoopRegistry();
+        DefaultClientChannelManager clientChannelManager = new DefaultClientChannelManager(originName,
+                null, resolver, registry);
+
+        clientChannelManager.shutdown();
+
+        InstanceInfo instanceInfo = Builder.newBuilder()
+                                                 .setAppName("server-equality")
+                                                 .setHostName("server-equality")
+                                                 .setPort(7777).build();
+        DiscoveryResult discoveryResult = DiscoveryResult.from(instanceInfo, false);
+
+        EmbeddedChannel channel = new EmbeddedChannel();
+        PooledConnection pooledConnection = new PooledConnection(channel, discoveryResult, clientChannelManager,
+                registry.counter("counter1"), registry.counter("counter2"));
+
+        Truth.assertThat(clientChannelManager.release(pooledConnection)).isFalse();
+        Truth.assertThat(pooledConnection.getChannel().closeFuture().isSuccess()).isTrue();
+    }
+
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManagerTest.java
@@ -210,30 +210,4 @@ class DefaultClientChannelManagerTest {
         clientChannelManager.shutdown();
         serverSocket.close();
     }
-
-    @Test
-    public void connClosedIfReleasedDuringShutdown() {
-        OriginName originName = OriginName.fromVip("vip", "test");
-        DynamicServerResolver resolver = mock(DynamicServerResolver.class);
-
-        NoopRegistry registry = new NoopRegistry();
-        DefaultClientChannelManager clientChannelManager = new DefaultClientChannelManager(originName,
-                null, resolver, registry);
-
-        clientChannelManager.shutdown();
-
-        InstanceInfo instanceInfo = Builder.newBuilder()
-                                                 .setAppName("server-equality")
-                                                 .setHostName("server-equality")
-                                                 .setPort(7777).build();
-        DiscoveryResult discoveryResult = DiscoveryResult.from(instanceInfo, false);
-
-        EmbeddedChannel channel = new EmbeddedChannel();
-        PooledConnection pooledConnection = new PooledConnection(channel, discoveryResult, clientChannelManager,
-                registry.counter("counter1"), registry.counter("counter2"));
-
-        Truth.assertThat(clientChannelManager.release(pooledConnection)).isFalse();
-        Truth.assertThat(pooledConnection.getChannel().closeFuture().isSuccess()).isTrue();
-    }
-
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPoolTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPoolTest.java
@@ -323,12 +323,10 @@ class PerServerConnectionPoolTest {
         connections.add(connection2);
         connsInPool.set(2);
 
-        assertEquals(2, connections.size());
         assertEquals(2, connsInPool.get());
         pool.drainIdleConnectionsOnEventLoop(channel1.eventLoop());
         channel1.runPendingTasks();
 
-        assertEquals(0, connections.size());
         assertEquals(0, connsInPool.get());
         assertTrue(connection1.getChannel().closeFuture().isSuccess());
         assertTrue(connection2.getChannel().closeFuture().isSuccess());

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPoolTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPoolTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
 package com.netflix.zuul.netty.connectionpool;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPoolTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPoolTest.java
@@ -1,0 +1,321 @@
+package com.netflix.zuul.netty.connectionpool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Ticker;
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.appinfo.InstanceInfo.Builder;
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfigKey.Keys;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
+import com.netflix.zuul.discovery.DiscoveryResult;
+import com.netflix.zuul.netty.connectionpool.PooledConnection.ConnectionState;
+import com.netflix.zuul.netty.server.Server;
+import com.netflix.zuul.origins.OriginName;
+import com.netflix.zuul.passport.CurrentPassport;
+import com.netflix.zuul.passport.PassportState;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoop;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalServerChannel;
+import io.netty.util.concurrent.Promise;
+import java.util.Deque;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+
+/**
+ * @author Justin Guerra
+ * @since 2/24/23
+ */
+public class PerServerConnectionPoolTest {
+
+    private static LocalAddress LOCAL_ADDRESS;
+    private static DefaultEventLoopGroup ORIGIN_EVENT_LOOP_GROUP;
+    private static DefaultEventLoopGroup CLIENT_EVENT_LOOP_GROUP;
+    private static EventLoop CLIENT_EVENT_LOOP;
+    private static Class<? extends Channel> PREVIOUS_CHANNEL_TYPE;
+
+    @Mock
+    private ClientChannelManager channelManager;
+
+    private Registry registry;
+    private DiscoveryResult discoveryResult;
+    private DefaultClientConfigImpl clientConfig;
+    private ConnectionPoolConfig connectionPoolConfig;
+    private PerServerConnectionPool pool;
+
+    private Counter createNewConnCounter;
+    private Counter createConnSucceededCounter;
+    private Counter createConnFailedCounter;
+    private Counter requestConnCounter;
+    private Counter reuseConnCounter;
+    private Counter connTakenFromPoolIsNotOpen;
+    private Counter closeAboveHighWaterMarkCounter;
+    private Counter maxConnsPerHostExceededCounter;
+    private Timer connEstablishTimer;
+    private AtomicInteger connsInPool;
+    private AtomicInteger connsInUse;
+
+    @BeforeAll
+    @SuppressWarnings("deprecation")
+    public static void staticSetup() throws InterruptedException {
+        LOCAL_ADDRESS = new LocalAddress(UUID.randomUUID().toString());
+
+        CLIENT_EVENT_LOOP_GROUP = new DefaultEventLoopGroup(1);
+        CLIENT_EVENT_LOOP = CLIENT_EVENT_LOOP_GROUP.next();
+
+        ORIGIN_EVENT_LOOP_GROUP = new DefaultEventLoopGroup(1);
+        ServerBootstrap bootstrap = new ServerBootstrap().group(ORIGIN_EVENT_LOOP_GROUP)
+                                                         .localAddress(LOCAL_ADDRESS)
+                                                         .channel(LocalServerChannel.class)
+                                                         .childHandler(new ChannelInitializer<LocalChannel>() {
+                                                             @Override
+                                                             protected void initChannel(LocalChannel ch) {
+                                                             }
+                                                         });
+
+        bootstrap.bind().sync();
+        PREVIOUS_CHANNEL_TYPE = Server.defaultOutboundChannelType.getAndSet(LocalChannel.class);
+    }
+
+    @AfterAll
+    @SuppressWarnings("deprecation")
+    public static void staticCleanup() {
+        ORIGIN_EVENT_LOOP_GROUP.shutdownGracefully();
+        CLIENT_EVENT_LOOP_GROUP.shutdownGracefully();
+
+        if(PREVIOUS_CHANNEL_TYPE != null) {
+            Server.defaultOutboundChannelType.set(PREVIOUS_CHANNEL_TYPE);
+        }
+    }
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        registry = new DefaultRegistry();
+
+
+        int index = 0;
+        createNewConnCounter = registry.counter("fake_counter" + index++);
+        createConnSucceededCounter = registry.counter("fake_counter" + index++);
+        createConnFailedCounter = registry.counter("fake_counter" + index++);
+        requestConnCounter = registry.counter("fake_counter" + index++);
+        reuseConnCounter = registry.counter("fake_counter" + index++);
+        connTakenFromPoolIsNotOpen = registry.counter("fake_counter" + index++);
+        closeAboveHighWaterMarkCounter = registry.counter("fake_counter" + index++);
+        maxConnsPerHostExceededCounter = registry.counter("fake_counter" + index++);
+        connEstablishTimer = registry.timer("fake_timer");
+        connsInPool = new AtomicInteger();
+        connsInUse = new AtomicInteger();
+
+        OriginName originName = OriginName.fromVipAndApp("whatever", "whatever-secure");
+
+        InstanceInfo instanceInfo = Builder.newBuilder()
+                                           .setIPAddr("175.45.176.0")
+                                           .setPort(7001)
+                                           .setAppName("whatever")
+                                           .build();
+        discoveryResult = DiscoveryResult.from(instanceInfo, true);
+
+        clientConfig = new DefaultClientConfigImpl();
+        connectionPoolConfig = spy(new ConnectionPoolConfigImpl(originName, clientConfig));
+
+        NettyClientConnectionFactory nettyConnectionFactory = new NettyClientConnectionFactory(connectionPoolConfig,
+                new ChannelInitializer<Channel>() {
+                    @Override
+                    protected void initChannel(Channel ch) {
+                    }
+                });
+
+        PooledConnectionFactory pooledConnectionFactory = this::newPooledConnection;
+
+        pool = new PerServerConnectionPool(discoveryResult, LOCAL_ADDRESS, nettyConnectionFactory,
+                pooledConnectionFactory,
+                connectionPoolConfig, clientConfig,
+                createNewConnCounter, createConnSucceededCounter, createConnFailedCounter, requestConnCounter,
+                reuseConnCounter, connTakenFromPoolIsNotOpen, closeAboveHighWaterMarkCounter,
+                maxConnsPerHostExceededCounter, connEstablishTimer, connsInPool, connsInUse);
+    }
+
+    @Test
+    public void acquireNewConnectionHitsMaxConnections() {
+        CurrentPassport currentPassport = CurrentPassport.create();
+
+        clientConfig.set(Keys.MaxConnectionsPerHost, 1);
+        discoveryResult.incrementOpenConnectionsCount();
+
+        Promise<PooledConnection> promise = pool.acquire(CLIENT_EVENT_LOOP, currentPassport, new AtomicReference<>());
+
+        assertFalse(promise.isSuccess());
+        assertTrue(promise.cause() instanceof OriginConnectException);
+        assertEquals(1, maxConnsPerHostExceededCounter.count());
+    }
+
+    @Test
+    public void acquireNewConnection() throws InterruptedException, ExecutionException {
+        CurrentPassport currentPassport = CurrentPassport.create();
+        Promise<PooledConnection> promise = pool.acquire(CLIENT_EVENT_LOOP, currentPassport, new AtomicReference<>());
+
+        PooledConnection connection = promise.sync().get();
+        assertEquals(1, requestConnCounter.count());
+        assertEquals(1, createNewConnCounter.count());
+        assertNotNull(currentPassport.findState(PassportState.ORIGIN_CH_CONNECTING));
+                assertNotNull(currentPassport.findState(PassportState.ORIGIN_CH_CONNECTED));
+        assertEquals(1, createConnSucceededCounter.count());
+        assertEquals(1, connsInUse.get());
+
+        //check state on PooledConnection - not all thread safe
+        CLIENT_EVENT_LOOP.submit(() -> {
+                checkChannelState(connection, currentPassport, 1);
+        }).sync();
+    }
+
+    @Test
+    public void acquireConnectionFromPool() throws InterruptedException, ExecutionException {
+        CurrentPassport currentPassport = CurrentPassport.create();
+        Promise<PooledConnection> promise = pool.acquire(CLIENT_EVENT_LOOP, currentPassport, new AtomicReference<>());
+
+        PooledConnection connection = promise.sync().get();
+
+        CLIENT_EVENT_LOOP.submit(() -> {
+            pool.release(connection);
+        }).sync();
+
+        assertEquals(1, connsInPool.get());
+
+        CurrentPassport newPassport = CurrentPassport.create();
+        Promise<PooledConnection> secondPromise = pool.acquire(CLIENT_EVENT_LOOP, newPassport, new AtomicReference<>());
+
+        PooledConnection connection2 = secondPromise.sync().get();
+        assertEquals(connection, connection2);
+        assertEquals(2, requestConnCounter.count());
+        assertEquals(0, connsInPool.get());
+
+
+        CLIENT_EVENT_LOOP.submit(() -> {
+           checkChannelState(connection, newPassport, 2);
+        }).sync();
+    }
+
+    @Test
+    public void acquireConnectionFromPoolButAlreadyClosed() throws InterruptedException, ExecutionException {
+        CurrentPassport currentPassport = CurrentPassport.create();
+        Promise<PooledConnection> promise = pool.acquire(CLIENT_EVENT_LOOP, currentPassport, new AtomicReference<>());
+
+        PooledConnection connection = promise.sync().get();
+
+        CLIENT_EVENT_LOOP.submit(() -> {
+            pool.release(connection);
+        }).sync();
+
+        //make the connection invalid
+        connection.getChannel().deregister().sync();
+
+        CurrentPassport newPassport = CurrentPassport.create();
+        Promise<PooledConnection> secondPromise = pool.acquire(CLIENT_EVENT_LOOP, newPassport, new AtomicReference<>());
+        PooledConnection connection2 = secondPromise.sync().get();
+
+        assertNotEquals(connection, connection2);
+        assertEquals(1, connTakenFromPoolIsNotOpen.count());
+        assertEquals(0, connsInPool.get());
+        assertTrue(connection.getChannel().closeFuture().await(5, TimeUnit.SECONDS), "Channel should have been closed by pool");
+    }
+
+    @Test
+    public void poolAboveHighWaterMark() throws InterruptedException, ExecutionException {
+        CurrentPassport currentPassport = CurrentPassport.create();
+
+        AbstractConfiguration configuration = ConfigurationManager.getConfigInstance();
+        String propertyName = "whatever.netty.client.perServerWaterline";
+
+        Promise<PooledConnection> promise = pool.acquire(CLIENT_EVENT_LOOP, currentPassport, new AtomicReference<>());
+
+        PooledConnection connection = promise.sync().get();
+        try {
+            configuration.setProperty(propertyName, 0);
+            CLIENT_EVENT_LOOP.submit(() -> {
+                assertFalse(pool.release(connection));
+                assertEquals(1, closeAboveHighWaterMarkCounter.count());
+                assertFalse(connection.isInPool());
+            }).sync();
+            assertTrue(connection.getChannel().closeFuture().await(5, TimeUnit.SECONDS), "connection should have been closed");
+        } finally {
+            configuration.setProperty(propertyName, 4);
+        }
+    }
+
+    @Test
+    public void acquireWhileDraining() {
+        pool.drain();
+        assertFalse(pool.isAvailable());
+        assertThrows(IllegalStateException.class, () -> pool.acquire(CLIENT_EVENT_LOOP, CurrentPassport.create(), new AtomicReference<>()));
+    }
+
+    @Test
+    public void gracefulDrain() {
+        EmbeddedChannel channel1 = new EmbeddedChannel();
+        EmbeddedChannel channel2 = new EmbeddedChannel();
+
+        PooledConnection connection1 = newPooledConnection(channel1);
+        PooledConnection connection2 = newPooledConnection(channel2);
+
+
+        Deque<PooledConnection> connections = pool.getPoolForEventLoop(channel1.eventLoop());
+        connections.add(connection1);
+        connections.add(connection2);
+        connsInPool.set(2);
+
+        assertEquals(2, connections.size());
+        assertEquals(2, connsInPool.get());
+        pool.drainIdleConnectionsOnEventLoop(channel1.eventLoop());
+        channel1.runPendingTasks();
+
+        assertEquals(0, connections.size());
+        assertEquals(0, connsInPool.get());
+        assertTrue(connection1.getChannel().closeFuture().isSuccess());
+        assertTrue(connection2.getChannel().closeFuture().isSuccess());
+    }
+
+    private void checkChannelState(PooledConnection connection, CurrentPassport passport, int expectedUsage) {
+        Channel channel = connection.getChannel();
+        assertEquals(expectedUsage, connection.getUsageCount());
+        assertEquals(passport, CurrentPassport.fromChannelOrNull(channel));
+        assertFalse(connection.isReleased());
+        assertEquals(ConnectionState.WRITE_BUSY, connection.getConnectionState());
+        assertNull(channel.pipeline().get(DefaultClientChannelManager.IDLE_STATE_HANDLER_NAME));
+    }
+
+    private PooledConnection newPooledConnection(Channel ch) {
+        return new PooledConnection(ch, discoveryResult,
+                channelManager, registry.counter("fake_close_counter"), registry.counter("fake_close_wrt_counter"));
+    }
+
+}


### PR DESCRIPTION
Adds a method to gracefully shutdown ClientChannelManager. A graceful shutdown will close any idle connections, and allow any in-flight requests to finish. 