### PR TITLE
Replace PromiseCombiner usage on ClientConnectionsShutdown

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientConnectionsShutdown.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientConnectionsShutdown.java
@@ -110,7 +110,6 @@ public class ClientConnectionsShutdown {
         closeFuture.addListener(future -> {
             if (!timeoutTask.isDone()) {
                 //close happened before the timeout
-                LOG.info("All connections closed within timeout");
                 timeoutTask.cancel(false);
             }
             promise.setSuccess(null);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientConnectionsShutdown.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientConnectionsShutdown.java
@@ -23,35 +23,28 @@ import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.StatusChangeEvent;
 import com.netflix.netty.common.ConnectionCloseChannelAttributes;
 import com.netflix.netty.common.ConnectionCloseType;
-import com.netflix.netty.common.HttpChannelFlags;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.ChannelGroupFuture;
 import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.ImmediateEventExecutor;
-import io.netty.util.concurrent.Promise;
-import io.netty.util.concurrent.PromiseCombiner;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * TODO: Change this class to be an instance per-port.
  * So that then the configuration can be different per-port, which is need for the combined FTL/Cloud clusters.
- *
+ * <p>
  * User: michaels@netflix.com
  * Date: 3/6/17
  * Time: 12:36 PM
  */
-public class ClientConnectionsShutdown
-{
+public class ClientConnectionsShutdown {
+
     private static final Logger LOG = LoggerFactory.getLogger(ClientConnectionsShutdown.class);
-    private static final DynamicBooleanProperty ENABLED = new DynamicBooleanProperty("server.outofservice.connections.shutdown", false);
+    private static final DynamicBooleanProperty ENABLED = new DynamicBooleanProperty(
+            "server.outofservice.connections.shutdown", false);
     private static final DynamicIntProperty DELAY_AFTER_OUT_OF_SERVICE_MS =
             new DynamicIntProperty("server.outofservice.connections.delay", 2000);
 
@@ -59,8 +52,7 @@ public class ClientConnectionsShutdown
     private final EventExecutor executor;
     private final EurekaClient discoveryClient;
 
-    public ClientConnectionsShutdown(ChannelGroup channels, EventExecutor executor, EurekaClient discoveryClient)
-    {
+    public ClientConnectionsShutdown(ChannelGroup channels, EventExecutor executor, EurekaClient discoveryClient) {
         this.channels = channels;
         this.executor = executor;
         this.discoveryClient = discoveryClient;
@@ -68,35 +60,24 @@ public class ClientConnectionsShutdown
         if (discoveryClient != null) {
             initDiscoveryListener();
         }
-
-        // Only uncomment this for local testing!
-        // Allow a fast property to invoke connection shutdown for testing purposes.
-//        DynamicBooleanProperty DEBUG_SHUTDOWN = new DynamicBooleanProperty("server.outofservice.connections.shutdown.debug", false);
-//        DEBUG_SHUTDOWN.addCallback(() -> {
-//            if (DEBUG_SHUTDOWN.get()) {
-//                gracefullyShutdownClientChannels();
-//            }
-//        });
     }
 
-    private void initDiscoveryListener()
-    {
+    private void initDiscoveryListener() {
         this.discoveryClient.registerEventListener(event -> {
             if (event instanceof StatusChangeEvent) {
                 StatusChangeEvent sce = (StatusChangeEvent) event;
 
-                LOG.info("Received {}", sce.toString());
+                LOG.info("Received {}", sce);
 
                 if (sce.getPreviousStatus() == InstanceInfo.InstanceStatus.UP
-                    && (sce.getStatus() == InstanceInfo.InstanceStatus.OUT_OF_SERVICE || sce.getStatus() == InstanceInfo.InstanceStatus.DOWN))
-                {
+                        && (sce.getStatus() == InstanceInfo.InstanceStatus.OUT_OF_SERVICE
+                        || sce.getStatus() == InstanceInfo.InstanceStatus.DOWN)) {
                     // TODO - Also should stop accepting any new client connections now too?
 
                     // Schedule to gracefully close all the client connections.
                     if (ENABLED.get()) {
-                        executor.schedule(() -> {
-                            gracefullyShutdownClientChannels();
-                        }, DELAY_AFTER_OUT_OF_SERVICE_MS.get(), TimeUnit.MILLISECONDS);
+                        executor.schedule(this::gracefullyShutdownClientChannels, DELAY_AFTER_OUT_OF_SERVICE_MS.get(),
+                                TimeUnit.MILLISECONDS);
                     }
                 }
             }
@@ -106,51 +87,36 @@ public class ClientConnectionsShutdown
     /**
      * Note this blocks until all the channels have finished closing.
      */
-    public void gracefullyShutdownClientChannels()
-    {
+    public void gracefullyShutdownClientChannels() {
         LOG.warn("Gracefully shutting down all client channels");
         try {
-
-
             // Mark all active connections to be closed after next response sent.
             LOG.warn("Flagging CLOSE_AFTER_RESPONSE on {} client channels.", channels.size());
-            // Pick some arbitrary executor.
-            PromiseCombiner closeAfterPromises = new PromiseCombiner(ImmediateEventExecutor.INSTANCE);
-            for (Channel channel : channels)
-            {
-                ConnectionCloseType.setForChannel(channel, ConnectionCloseType.DELAYED_GRACEFUL);
 
+            //racy situation if new connections are still coming in, but any channels created after newCloseFuture will
+            //be closed during the force close stage
+            ChannelGroupFuture closeFuture = channels.newCloseFuture();
+            for (Channel channel : channels) {
+                ConnectionCloseType.setForChannel(channel, ConnectionCloseType.DELAYED_GRACEFUL);
                 ChannelPromise closePromise = channel.pipeline().newPromise();
                 channel.attr(ConnectionCloseChannelAttributes.CLOSE_AFTER_RESPONSE).set(closePromise);
-                // TODO(carl-mastrangelo): remove closePromise, since I don't think it's needed.  Need to verify.
-                closeAfterPromises.add(channel.closeFuture());
             }
 
-            // Wait for all of the attempts to close connections gracefully, or max of 30 secs each.
-            Promise<Void> combinedCloseAfterPromise = executor.newPromise();
-            closeAfterPromises.finish(combinedCloseAfterPromise);
-            combinedCloseAfterPromise.await(30, TimeUnit.SECONDS);
+            // Wait for all the attempts to close connections gracefully, or max of 30 secs
+            if(closeFuture.await(30, TimeUnit.SECONDS)) {
+                LOG.info("All connections closed within timeout");
+                return;
+            }
 
-            // Close all of the remaining active connections.
-            LOG.warn("Closing remaining active client channels.");
-            List<ChannelFuture> forceCloseFutures = new ArrayList<>();
-            channels.forEach(channel -> {
-                if (channel.isActive()) {
-                    ChannelFuture f = channel.pipeline().close();
-                    forceCloseFutures.add(f);
-                }
-            });
-
-            LOG.warn("Waiting for {} client channels to be closed.", forceCloseFutures.size());
-            PromiseCombiner closePromisesCombiner = new PromiseCombiner(ImmediateEventExecutor.INSTANCE);
-            closePromisesCombiner.addAll(forceCloseFutures.toArray(new ChannelFuture[0]));
-            Promise<Void> combinedClosePromise = executor.newPromise();
-            closePromisesCombiner.finish(combinedClosePromise);
-            combinedClosePromise.await(5, TimeUnit.SECONDS);
-            LOG.warn("{} client channels closed.", forceCloseFutures.size());
-        }
-        catch (InterruptedException ie) {
+            LOG.warn("Closing remaining {} active client channels.", channels.size());
+            // Close all the remaining active connections.
+            if(!channels.close().await(5, TimeUnit.SECONDS)) {
+                LOG.warn("Timeout waiting for remaining connections to close");
+            }
+        } catch (InterruptedException ie) {
             LOG.warn("Interrupted while shutting down client channels");
+        } catch (Exception e) {
+            LOG.error("Unexpected exception during graceful shutdown", e);
         }
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
@@ -435,7 +435,7 @@ public class Server
             // NOTE: ClientConnectionsShutdown can also be configured to gracefully close connections when the
             // discovery status changes to DOWN. So if it has been configured that way, then this will be an additional
             // call to gracefullyShutdownClientChannels(), which will be a noop.
-            clientConnectionsShutdown.gracefullyShutdownClientChannels();
+            clientConnectionsShutdown.gracefullyShutdownClientChannels().syncUninterruptibly();
 
             LOG.info("Shutting down event loops");
             List<EventLoopGroup> allEventLoopGroups = new ArrayList<>();

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientConnectionsShutdownTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientConnectionsShutdownTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.netty.server;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import com.google.common.reflect.Reflection;
+import com.netflix.appinfo.InstanceInfo.InstanceStatus;
+import com.netflix.config.ConfigurationManager;
+import com.netflix.discovery.EurekaClient;
+import com.netflix.discovery.EurekaEventListener;
+import com.netflix.discovery.StatusChangeEvent;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.ChannelGroupFuture;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalServerChannel;
+import io.netty.util.concurrent.EventExecutor;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+
+/**
+ * @author Justin Guerra
+ * @since 2/28/23
+ */
+class ClientConnectionsShutdownTest {
+
+    //using LocalChannels instead of EmbeddedChannels to re-create threading behavior in an actual deployment
+    private static LocalAddress LOCAL_ADDRESS;
+    private static DefaultEventLoopGroup SERVER_EVENT_LOOP;
+    private static DefaultEventLoopGroup CLIENT_EVENT_LOOP;
+    private static ExecutorService EXECUTOR;
+
+    @BeforeAll
+    static void staticSetup() throws InterruptedException {
+        LOCAL_ADDRESS = new LocalAddress(UUID.randomUUID().toString());
+
+        CLIENT_EVENT_LOOP = new DefaultEventLoopGroup(4);
+        SERVER_EVENT_LOOP = new DefaultEventLoopGroup(4);
+        ServerBootstrap serverBootstrap = new ServerBootstrap().group(SERVER_EVENT_LOOP)
+                                                               .localAddress(LOCAL_ADDRESS)
+                                                               .channel(LocalServerChannel.class)
+                                                               .childHandler(new ChannelInitializer<LocalChannel>() {
+                                                                   @Override
+                                                                   protected void initChannel(LocalChannel ch) {
+
+                                                                   }
+                                                               });
+
+        serverBootstrap.bind().sync();
+        EXECUTOR = Executors.newSingleThreadExecutor();
+    }
+
+    @AfterAll
+    static void staticCleanup() {
+        CLIENT_EVENT_LOOP.shutdownGracefully();
+        SERVER_EVENT_LOOP.shutdownGracefully();
+    }
+
+    private ChannelGroup channels;
+    private ClientConnectionsShutdown shutdown;
+    private CountDownLatch latch;
+    private AtomicReference<Boolean> awaitEscapeHatch;
+
+    @BeforeEach
+    void setup() {
+        latch = new CountDownLatch(1);
+        awaitEscapeHatch = new AtomicReference<>();
+
+        channels = spy(new DefaultChannelGroup(SERVER_EVENT_LOOP.next()));
+        doAnswer(invocation -> {
+            ChannelGroupFuture future = (ChannelGroupFuture) invocation.callRealMethod();
+            return testGroupFuture(future);
+        }).when(channels).newCloseFuture();
+
+        shutdown = new ClientConnectionsShutdown(channels, null, null);
+    }
+
+    @Test
+    void discoveryShutdown() {
+        String configName = "server.outofservice.connections.shutdown";
+        AbstractConfiguration configuration = ConfigurationManager.getConfigInstance();
+
+        try {
+            configuration.setProperty(configName, "true");
+            EurekaClient eureka = Mockito.mock(EurekaClient.class);
+            EventExecutor executor = Mockito.mock(EventExecutor.class);
+
+            ArgumentCaptor<EurekaEventListener> captor = ArgumentCaptor.forClass(
+                    EurekaEventListener.class);
+            shutdown = spy(new ClientConnectionsShutdown(channels, executor, eureka));
+            verify(eureka).registerEventListener(captor.capture());
+            doNothing().when(shutdown).gracefullyShutdownClientChannels();
+
+            EurekaEventListener listener = captor.getValue();
+
+            listener.onEvent(new StatusChangeEvent(InstanceStatus.UP, InstanceStatus.DOWN));
+            verify(executor).schedule(ArgumentMatchers.isA(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS));
+
+            Mockito.reset(executor);
+            listener.onEvent(new StatusChangeEvent(InstanceStatus.UP, InstanceStatus.OUT_OF_SERVICE));
+            verify(executor).schedule(ArgumentMatchers.isA(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS));
+
+            Mockito.reset(executor);
+            listener.onEvent(new StatusChangeEvent(InstanceStatus.STARTING, InstanceStatus.OUT_OF_SERVICE));
+            verify(executor, never()).schedule(ArgumentMatchers.isA(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS));
+        } finally {
+            configuration.setProperty(configName, "false");
+        }
+    }
+
+    @Test
+    void allConnectionsGracefullyClosed() throws Exception {
+        createChannels(100);
+        Future<?> gracefulShutdown = EXECUTOR.submit(() -> shutdown.gracefullyShutdownClientChannels());
+        awaitNewCloseAwait();
+        channels.forEach(Channel::close);
+        gracefulShutdown.get(5, TimeUnit.SECONDS);
+        assertTrue(channels.isEmpty());
+    }
+
+    @Test
+    void connectionNeedsToBeForceClosed() throws Exception {
+        createChannels(10);
+
+        awaitEscapeHatch.set(false);
+        Future<?> gracefulShutdown = EXECUTOR.submit(() -> shutdown.gracefullyShutdownClientChannels());
+        awaitNewCloseAwait();
+
+        gracefulShutdown.get(10, TimeUnit.SECONDS);
+        assertTrue(channels.isEmpty(), "All channels in group should have been force closed");
+    }
+
+    private void createChannels(int numChannels) throws InterruptedException {
+        ChannelInitializer<LocalChannel> initializer = new ChannelInitializer<LocalChannel>() {
+            @Override
+            protected void initChannel(LocalChannel ch) {
+
+            }
+        };
+
+        for (int i = 0; i < numChannels; ++i) {
+            ChannelFuture connect = new Bootstrap()
+                    .group(CLIENT_EVENT_LOOP)
+                    .channel(LocalChannel.class)
+                    .handler(initializer)
+                    .remoteAddress(LOCAL_ADDRESS)
+                    .connect()
+                    .sync();
+
+            channels.add(connect.channel());
+        }
+    }
+
+    private void awaitNewCloseAwait() throws InterruptedException {
+        if(!latch.await(5, TimeUnit.SECONDS)) {
+            fail();
+        }
+    }
+
+    /**
+     * Creates a proxy that delegates calls to a proper {@link ChannelGroupFuture}. The method {@link ChannelGroupFuture#await(long, TimeUnit)}
+     * has a synchronization aid and can have its behavior modified
+     */
+    private ChannelGroupFuture testGroupFuture(ChannelGroupFuture delegate) {
+        return Reflection.newProxy(ChannelGroupFuture.class, (proxy, method, args) -> {
+            if(method.getName().equals("await") && args.length == 2) {
+                latch.countDown();
+                if(awaitEscapeHatch.get() != null) {
+                    return awaitEscapeHatch.get();
+                }
+            }
+            return method.invoke(delegate, args);
+        });
+    }
+
+}


### PR DESCRIPTION
ClientConnectionsShutdown is broken in two different ways

1) When `gracefullyShutdownClientChannels()` is called as part of a discovery callback, the use of `ImmediateEventExecutor.INSTANCE` triggers a deadlock check in netty:

```
Caused by: io.netty.util.concurrent.BlockingOperationException: DefaultPromise@7ff6ea19(incomplete)
	at app//io.netty.util.concurrent.DefaultPromise.checkDeadLock(DefaultPromise.java:463)
	at app//io.netty.util.concurrent.DefaultPromise.await0(DefaultPromise.java:687)
	at app//io.netty.util.concurrent.DefaultPromise.await(DefaultPromise.java:295)
```

2) The use of PromiseCombiner isn't  thread safe and the future isn't always finished correctly


I replaced the use of PromiseCombiner with bulk operations on the ChannelGroup, and also added unit tests
