### PR TITLE
cleanup alloc. for StringBuilder w/ bytebuf touch

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/ByteBufUtil.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/ByteBufUtil.java
@@ -16,8 +16,6 @@
 
 package com.netflix.netty.common;
 
-import static io.netty.util.ResourceLeakDetector.Level.ADVANCED;
-import static io.netty.util.ResourceLeakDetector.Level.PARANOID;
 import com.netflix.zuul.message.ZuulMessage;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.ResourceLeakDetector;
@@ -45,4 +43,9 @@ public class ByteBufUtil {
         }
     }
 
+    public static void touch(ReferenceCounted byteBuf, String hint, String filterName) {
+        if (isAdvancedLeakDetection) {
+            byteBuf.touch(hint + filterName);
+        }
+    }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
@@ -212,11 +212,12 @@ public class ZuulMessageImpl implements ZuulMessage
     public void runBufferedBodyContentThroughFilter(ZuulFilter<?, ?> filter) {
         //Loop optimized for the common case: Most filters' processContentChunk() return
         // original chunk passed in as is without any processing
+        final String filterName = filter.filterName();
         for (int i=0; i < bodyChunks.size(); i++) {
             final HttpContent origChunk = bodyChunks.get(i);
-            ByteBufUtil.touch(origChunk, "ZuulMessage processing chunk, filter: " + filter.filterName());
+            ByteBufUtil.touch(origChunk, "ZuulMessage processing chunk, filter: ", filterName);
             final HttpContent filteredChunk = filter.processContentChunk(this, origChunk);
-            ByteBufUtil.touch(filteredChunk, "ZuulMessage processing filteredChunk, filter: " + filter.filterName());
+            ByteBufUtil.touch(filteredChunk, "ZuulMessage processing filteredChunk, filter: ", filterName);
             if ((filteredChunk != null) && (filteredChunk != origChunk)) {
                 //filter actually did some processing, set the new chunk in and release the old chunk.
                 bodyChunks.set(i, filteredChunk);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunner.java
@@ -109,7 +109,7 @@ public class ZuulFilterChainRunner<T extends ZuulMessage> extends BaseZuulFilter
                 final ZuulFilter<T, T> filter = filters[i];
                 filterName = filter.filterName();
                 if ((! filter.isDisabled()) && (! shouldSkipFilter(inMesg, filter))) {
-                    ByteBufUtil.touch(chunk, "Filter runner processing chunk, filter: " + filter.filterName());
+                    ByteBufUtil.touch(chunk, "Filter runner processing chunk, filter: " , filterName);
                     final HttpContent newChunk = filter.processContentChunk(inMesg, chunk);
                     if (newChunk == null)  {
                         //Filter wants to break the chain and stop propagating this chunk any further
@@ -117,7 +117,7 @@ public class ZuulFilterChainRunner<T extends ZuulMessage> extends BaseZuulFilter
                     }
                     //deallocate original chunk if necessary
                     if ((newChunk != chunk) && (chunk.refCnt() > 0)) {
-                        ByteBufUtil.touch(chunk, "Filter runner processing newChunk, filter: " + filter.filterName());
+                        ByteBufUtil.touch(chunk, "Filter runner processing newChunk, filter: ", filterName);
                         chunk.release(chunk.refCnt());
                     }
                     chunk = newChunk;


### PR DESCRIPTION
This was a weird one. It kept littering my allocation profiling, and I want a cleaner slate. It seemed innocuous, but given how often this path gets called, the cleanup seemed simple enough and valuable.

For verification, I ran benchmarks for `1000000` ops w/ the 2 implementations, one forcing append with `getClass().getName()` and the other being the change. Results below:

To keep it clean, I bypassed calling `touch` on the ByteBuf completely. This is purely call site optimizations.

```
JMHHarness.touchNoConcat                        avgt    5        209.626 ±      14.086   ns/op
JMHHarness.touchNoConcat:·gc.alloc.rate         avgt    5        938.010 ±      64.005  MB/sec
JMHHarness.touchNoConcat:·gc.alloc.rate.norm    avgt    5        206.489 ±       0.151    B/op
JMHHarness.touchNoConcat:·gc.count              avgt    5         24.000                counts
JMHHarness.touchNoConcat:·gc.time               avgt    5         86.000                    ms
JMHHarness.touchWithConcat                      avgt    5   26716690.417 ± 2030317.313   ns/op
JMHHarness.touchWithConcat:·gc.alloc.rate       avgt    5       6844.642 ±     522.839  MB/sec
JMHHarness.touchWithConcat:·gc.alloc.rate.norm  avgt    5  192000239.684 ±      36.494    B/op
JMHHarness.touchWithConcat:·gc.count            avgt    5        172.000                counts
JMHHarness.touchWithConcat:·gc.time             avgt    5        334.000                    ms
```