### PR TITLE
ci: use Temurin distributions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
           cache: 'gradle'
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
       - name: Build candidate

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
       - name: Build snapshot


### PR DESCRIPTION
Host runners include Temurin by default as part of the [hosted tool cache ](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#hosted-tool-cache)

Using Temurin speeds up builds as there is no need to download and configure the Java SDK with every build.