### PR TITLE
integration test blockRequestWithMultipleHostHeaders

### DIFF
--- a/zuul-integration-test/src/test/java/com/netflix/zuul/integration/IntegrationTest.java
+++ b/zuul-integration-test/src/test/java/com/netflix/zuul/integration/IntegrationTest.java
@@ -331,6 +331,25 @@ class IntegrationTest {
         response.close();
     }
 
+    @ParameterizedTest
+    @MethodSource("arguments")
+    void blockRequestWithMultipleHostHeaders(final String description, final OkHttpClient okHttp, final boolean requestBodyBuffering, final boolean responseBodyBuffering) throws Exception {
+        final WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(
+                get(anyUrl())
+                        .willReturn(aResponse().withStatus(200)));
+
+        Request request = setupRequestBuilder(requestBodyBuffering, responseBodyBuffering).get()
+                .addHeader("Host", "aaa.example.com")
+                .addHeader("Host", "aaa.foobar.com")
+                .build();
+        Response response = okHttp.newCall(request).execute();
+        assertThat(response.code()).isEqualTo(500);
+        verify(0, anyRequestedFor(anyUrl()));
+        response.close();
+    }
+
+
     @Test
     void deflateOnly() throws Exception {
         final String expectedResponseBody = TestUtil.COMPRESSIBLE_CONTENT;


### PR DESCRIPTION
This test verifies the behavior from an earlier PR (May 2021) 
https://github.com/Netflix/zuul/pull/1060
