### PR TITLE
downgrade logging for request expiry on connect

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/exception/RequestExpiredException.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/exception/RequestExpiredException.java
@@ -1,0 +1,13 @@
+package com.netflix.zuul.exception;
+
+/**
+ * @author Argha C
+ * @since 4/26/23
+ */
+public class RequestExpiredException extends ZuulException {
+
+    public RequestExpiredException(String message) {
+        super(message, true);
+        setStatusCode(504);
+    }
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/exception/RequestExpiredException.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/exception/RequestExpiredException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
 package com.netflix.zuul.exception;
 
 /**


### PR DESCRIPTION
We map these to a proper status internally, so the logging isn't really useful at ERROR level.