### PR TITLE
fix toString for empty sentinel stats

### DIFF
--- a/zuul-discovery/src/main/java/com/netflix/zuul/discovery/DiscoveryResult.java
+++ b/zuul-discovery/src/main/java/com/netflix/zuul/discovery/DiscoveryResult.java
@@ -61,7 +61,12 @@ public final class DiscoveryResult implements ResolverResult {
      */
     public DiscoveryResult(DiscoveryEnabledServer server) {
         this.server = server;
-        this.serverStats = new ServerStats();
+        this.serverStats = new ServerStats() {
+            @Override
+            public String toString() {
+                return "no stats configured for server";
+            }
+        };
     }
 
     /**

--- a/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DiscoveryResultTest.java
+++ b/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DiscoveryResultTest.java
@@ -40,6 +40,11 @@ class DiscoveryResultTest {
     }
 
     @Test
+    void serverStatsForEmptySentinel() {
+        Truth.assertThat(DiscoveryResult.EMPTY.getServerStats().toString()).isEqualTo("no stats configured for server");
+    }
+
+    @Test
     void hostAndPortForNullServer() {
         final DiscoveryResult discoveryResult = new DiscoveryResult(null);
 


### PR DESCRIPTION
only relevant for tests but annoying to see this in the debugger.