### PR TITLE
Remove @Singleton from PushMessageSender

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushMessageSender.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushMessageSender.java
@@ -55,7 +55,6 @@ import org.slf4j.LoggerFactory;
  * Author: Susheel Aroskar
  * Date: 5/14/18
  */
-@Singleton
 @ChannelHandler.Sharable
 public abstract class PushMessageSender  extends SimpleChannelInboundHandler<FullHttpRequest> {
 


### PR DESCRIPTION
Spring doesn't allow this annotation on abstract classes, and it also doesn't make any sense