### PR TITLE
Remove explicit unboxing

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/ConnectionCloseChannelAttributes.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/ConnectionCloseChannelAttributes.java
@@ -32,13 +32,13 @@ public class ConnectionCloseChannelAttributes
     {
         ChannelConfig channelConfig = channel.attr(BaseZuulChannelInitializer.ATTR_CHANNEL_CONFIG).get();
         Integer gracefulCloseDelay = channelConfig.get(CommonChannelConfigKeys.connCloseDelay);
-        return gracefulCloseDelay == null ? 0 : gracefulCloseDelay.intValue();
+        return gracefulCloseDelay == null ? 0 : gracefulCloseDelay;
     }
 
     public static boolean allowGracefulDelayed(Channel channel)
     {
         ChannelConfig channelConfig = channel.attr(BaseZuulChannelInitializer.ATTR_CHANNEL_CONFIG).get();
         Boolean value = channelConfig.get(CommonChannelConfigKeys.http2AllowGracefulDelayed);
-        return value == null ? false : value.booleanValue();
+        return value == null ? false : value;
     }
 }

--- a/zuul-core/src/main/java/com/netflix/netty/common/HttpChannelFlags.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/HttpChannelFlags.java
@@ -60,7 +60,7 @@ public class HttpChannelFlags
         {
             Attribute<Boolean> attr = ch.attr(attributeKey);
             Boolean value = attr.get();
-            return (value == null) ? false : value.booleanValue();
+            return (value == null) ? false : value;
         }
 
         public boolean get(ChannelHandlerContext ctx)

--- a/zuul-core/src/main/java/com/netflix/netty/common/accesslog/AccessLogPublisher.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/accesslog/AccessLogPublisher.java
@@ -77,10 +77,10 @@ public class AccessLogPublisher
         requestId = requestId != null ? requestId : "-";
 
         // Convert duration to microseconds.
-        String durationStr = (durationNs != null && durationNs.longValue() > 0) ? String.valueOf(durationNs / 1000) : "-";
+        String durationStr = (durationNs != null && durationNs > 0) ? String.valueOf(durationNs / 1000) : "-";
 
-        String requestBodySizeStr = (requestBodySize != null && requestBodySize.intValue() > 0) ? requestBodySize.toString() : "-";
-        String responseBodySizeStr = (responseBodySize != null && responseBodySize.intValue() > 0) ? responseBodySize.toString() : "-";
+        String requestBodySizeStr = (requestBodySize != null && requestBodySize > 0) ? requestBodySize.toString() : "-";
+        String responseBodySizeStr = (responseBodySize != null && responseBodySize > 0) ? responseBodySize.toString() : "-";
 
 
         // Build the line.

--- a/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
@@ -249,7 +249,7 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
     public boolean getBoolean(String key, boolean defaultResponse) {
         Boolean b = (Boolean) get(key);
         if (b != null) {
-            return b.booleanValue();
+            return b;
         }
         return defaultResponse;
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/common/GZipResponseFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/common/GZipResponseFilter.java
@@ -75,7 +75,7 @@ public class GZipResponseFilter extends HttpOutboundSyncFilter
         final HttpRequestInfo request = response.getInboundRequest();
         final Boolean overrideIsGzipRequested = (Boolean) response.getContext().get(CommonContextKeys.OVERRIDE_GZIP_REQUESTED);
         final boolean isGzipRequested = (overrideIsGzipRequested == null) ?
-                HttpUtils.acceptsGzip(request.getHeaders()) :  overrideIsGzipRequested.booleanValue();
+                HttpUtils.acceptsGzip(request.getHeaders()) : overrideIsGzipRequested;
 
         // Check the headers to see if response is already gzipped.
         final Headers respHeaders = response.getHeaders();
@@ -97,7 +97,7 @@ public class GZipResponseFilter extends HttpOutboundSyncFilter
     boolean isRightSizeForGzip(HttpResponseMessage response) {
         final Integer bodySize = HttpUtils.getBodySizeIfKnown(response);
         //bodySize == null is chunked encoding which is eligible for gzip compression
-        return (bodySize == null) || (bodySize.intValue() >= MIN_BODY_SIZE_FOR_GZIP.get());
+        return (bodySize == null) || (bodySize >= MIN_BODY_SIZE_FOR_GZIP.get());
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -115,7 +115,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
 
     public static boolean isLastContentReceivedForChannel(Channel ch) {
         Boolean value = ch.attr(ATTR_LAST_CONTENT_RECEIVED).get();
-        return value == null ? false : value.booleanValue();
+        return value == null ? false : value;
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/passport/CurrentPassport.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/passport/CurrentPassport.java
@@ -431,11 +431,11 @@ public class CurrentPassport
                         String stateName = stateMatch.group(2);
                         if (stateName.equals("NOW")) {
                             long startTime = passport.history.size() > 0 ? passport.firstTime() : 0;
-                            long now = Long.valueOf(stateMatch.group(1)) + startTime;
+                            long now = Long.parseLong(stateMatch.group(1)) + startTime;
                             ticker.setNow(now);
                         } else {
                             PassportState state = PassportState.valueOf(stateName);
-                            PassportItem item = new PassportItem(state, Long.valueOf(stateMatch.group(1)));
+                            PassportItem item = new PassportItem(state, Long.parseLong(stateMatch.group(1)));
                             passport.history.add(item);
                         }
                     }

--- a/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
@@ -120,7 +120,7 @@ public class HttpUtils
     public static boolean hasNonZeroContentLengthHeader(ZuulMessage msg)
     {
         final Integer contentLengthVal = getContentLengthIfPresent(msg);
-        return (contentLengthVal != null) && (contentLengthVal.intValue() > 0);
+        return (contentLengthVal != null) && (contentLengthVal > 0);
     }
 
     public static Integer getContentLengthIfPresent(ZuulMessage msg)


### PR DESCRIPTION
Motivation:
Explicit unboxing is not required to use primitive types in Java 1.8 or newer. So we should transition from it.

Modification:
Removed explicit unboxing of wrapper classes

Result:
Less overhead