### PR TITLE
jmh 1.37

### DIFF
--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -84,13 +84,13 @@
     },
     "jmh": {
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.36"
+            "locked": "1.37"
         },
         "org.openjdk.jmh:jmh-generator-annprocess": {
-            "locked": "1.36"
+            "locked": "1.37"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.36"
+            "locked": "1.37"
         }
     },
     "jmhCompileClasspath": {
@@ -173,13 +173,13 @@
             "locked": "1.70"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.36"
+            "locked": "1.37"
         },
         "org.openjdk.jmh:jmh-generator-annprocess": {
-            "locked": "1.36"
+            "locked": "1.37"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.36"
+            "locked": "1.37"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.36"
@@ -316,13 +316,13 @@
             "locked": "4.11.0"
         },
         "org.openjdk.jmh:jmh-core": {
-            "locked": "1.36"
+            "locked": "1.37"
         },
         "org.openjdk.jmh:jmh-generator-annprocess": {
-            "locked": "1.36"
+            "locked": "1.37"
         },
         "org.openjdk.jmh:jmh-generator-bytecode": {
-            "locked": "1.36"
+            "locked": "1.37"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
https://mail.openjdk.org/pipermail/jmh-dev/2023-August/003762.html

As part of Virtual Threads support, -Djmh.executor accepts new set of executor options, while 
rejecting now unsupported ones. We studied the commonly used executor types in the wild, and these 
types are now available: PLATFORM, VIRTUAL, FJP, CUSTOM. If you use any other executor type, the run 
would fail.
