### PR TITLE
Properly apply socket options

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
@@ -269,20 +269,14 @@ public class Server
         ServerBootstrap serverBootstrap =
                 new ServerBootstrap().group(serverGroup.clientToProxyBossPool, serverGroup.clientToProxyWorkerPool);
 
-        // Choose socket options.
-        Map<ChannelOption<?>, Object> channelOptions = new HashMap<>();
-        channelOptions.put(ChannelOption.SO_BACKLOG, 128);
-        channelOptions.put(ChannelOption.SO_LINGER, -1);
-        channelOptions.put(ChannelOption.TCP_NODELAY, true);
-        channelOptions.put(ChannelOption.SO_KEEPALIVE, true);
-
         LOG.info("Proxy listening with {}", serverGroup.channelType);
         serverBootstrap.channel(serverGroup.channelType);
 
-        // Apply socket options.
-        for (Map.Entry<ChannelOption<?>, ?> optionEntry : channelOptions.entrySet()) {
-            serverBootstrap = serverBootstrap.option((ChannelOption) optionEntry.getKey(), optionEntry.getValue());
-        }
+        serverBootstrap.option(ChannelOption.SO_BACKLOG, 128);
+        serverBootstrap.childOption(ChannelOption.SO_LINGER, -1);
+        serverBootstrap.childOption(ChannelOption.TCP_NODELAY, true);
+        serverBootstrap.childOption(ChannelOption.SO_KEEPALIVE, true);
+
         // Apply transport specific socket options.
         for (Map.Entry<ChannelOption<?>, ?> optionEntry : serverGroup.transportChannelOptions.entrySet()) {
             serverBootstrap = serverBootstrap.option((ChannelOption) optionEntry.getKey(), optionEntry.getValue());


### PR DESCRIPTION
These errors have always annoyed me:

```
2023-09-08T15:30:58.748 WARN  [main] io.netty.bootstrap.ServerBootstrap: Unknown channel option 'SO_LINGER' for channel '[id: 0x08c9bd45]'
2023-09-08T15:30:58.748 WARN  [main] io.netty.bootstrap.ServerBootstrap: Unknown channel option 'SO_KEEPALIVE' for channel '[id: 0x08c9bd45]'
2023-09-08T15:30:58.748 WARN  [main] io.netty.bootstrap.ServerBootstrap: Unknown channel option 'TCP_NODELAY' for channel '[id: 0x08c9bd45]'
```

turns out we were attempting to apply the options incorrectly 
