### PR TITLE
Properly serialize availabilityZone and remove maxRetries from RequestAttempt

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempt.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempt.java
@@ -57,10 +57,9 @@ public class RequestAttempt
     private String availabilityZone;
     private long readTimeout;
     private int connectTimeout;
-    private int maxRetries;
 
     public RequestAttempt(int attemptNumber, InstanceInfo server, String targetVip, String chosenWarmupLB, int status, String error, String exceptionType,
-                          int readTimeout, int connectTimeout, int maxRetries)
+                          int readTimeout, int connectTimeout)
     {
         if (attemptNumber < 1) {
             throw new IllegalArgumentException("Attempt number must be greater than 0! - " + attemptNumber);
@@ -96,7 +95,6 @@ public class RequestAttempt
         this.exceptionType = exceptionType;
         this.readTimeout = readTimeout;
         this.connectTimeout = connectTimeout;
-        this.maxRetries = maxRetries;
     }
 
     public RequestAttempt(final DiscoveryResult server, final IClientConfig clientConfig, int attemptNumber, int readTimeout) {
@@ -219,11 +217,6 @@ public class RequestAttempt
         return connectTimeout;
     }
 
-    public int getMaxRetries()
-    {
-        return maxRetries;
-    }
-
     public void setStatus(int status)
     {
         this.status = status;
@@ -330,11 +323,6 @@ public class RequestAttempt
         }
     }
 
-    public void setMaxRetries(int maxRetries)
-    {
-        this.maxRetries = maxRetries;
-    }
-
     @Override
     public String toString()
     {
@@ -357,6 +345,7 @@ public class RequestAttempt
         putNullableAttribute(root, "cause", cause);
         putNullableAttribute(root, "exceptionType", exceptionType);
         putNullableAttribute(root, "region", region);
+        putNullableAttribute(root, "availabilityZone", availabilityZone);
         putNullableAttribute(root, "asg", asg);
         putNullableAttribute(root, "instanceId", instanceId);
         putNullableAttribute(root, "vip", vip);


### PR DESCRIPTION
`RequestAttempt` includes `availabilityZone` but is never serialized into the `RequestAttempt` json. Fixed json mapper to include it and remove `maxRetries` as field is not used (replaced many moons ago by retry policies).