### PR TITLE
netty 4.1.99

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 versions_groovy=3.0.19
 versions_ribbon=2.4.4
-versions_netty=4.1.98.Final
+versions_netty=4.1.99.Final
 versions_netty_io_uring=0.0.22.Final
 versions_brotli4j=1.12.0
 release.scope=patch

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -40,34 +40,34 @@
             "locked": "0.0.22.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.26.0"
@@ -140,34 +140,34 @@
             "locked": "0.0.22.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.26.0"
@@ -262,37 +262,37 @@
             "locked": "0.0.22.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.61.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.26.0"
@@ -405,37 +405,37 @@
             "locked": "0.0.22.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.61.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.26.0"
@@ -506,34 +506,34 @@
             "locked": "0.0.22.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.26.0"
@@ -637,37 +637,37 @@
             "locked": "0.0.22.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.61.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.26.0"

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -64,43 +64,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -191,43 +191,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -344,43 +344,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -392,19 +392,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -558,43 +558,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -606,19 +606,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -729,43 +729,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -891,43 +891,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -939,19 +939,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -67,43 +67,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -194,43 +194,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -350,43 +350,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -398,19 +398,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -567,43 +567,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -615,19 +615,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -738,43 +738,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -903,43 +903,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -951,19 +951,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -96,43 +96,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -144,19 +144,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -273,43 +273,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -409,43 +409,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -598,43 +598,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -646,19 +646,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -833,43 +833,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -881,19 +881,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1022,43 +1022,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1220,43 +1220,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1268,19 +1268,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -64,43 +64,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -188,43 +188,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -338,43 +338,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -386,19 +386,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -543,43 +543,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -591,19 +591,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -740,43 +740,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -788,19 +788,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -908,43 +908,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1061,43 +1061,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1109,19 +1109,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -96,43 +96,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -144,19 +144,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -273,43 +273,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -415,43 +415,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -591,43 +591,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -639,19 +639,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -822,43 +822,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -870,19 +870,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1011,43 +1011,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1181,43 +1181,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1229,19 +1229,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.1.98.Final"
+            "locked": "4.1.99.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
https://netty.io/news/2023/09/21/4-1-99-Final.html

Netty release notes:

```
We are happy to announce the release of netty 4.1.99.Final. 
This release fixes a bug which could lead to SIGSERV while running on 
JDK21+. As JDK21 was recently released and is considered an LTS 
release we did decided to do this emergency release. Because of 
the nature of this bug (crashing the JVM) you should upgrade ASAP.
```
