### PR TITLE
Revert "enable IP_TRANSPARENT on epoll channel bind"

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
@@ -16,7 +16,6 @@
 
 package com.netflix.zuul.netty.server;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.config.DynamicBooleanProperty;
@@ -64,6 +63,9 @@ import io.netty.util.concurrent.DefaultEventExecutorChooserFactory;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorChooserFactory;
 import io.netty.util.concurrent.ThreadPerTaskExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.InetSocketAddress;
 import java.nio.channels.spi.SelectorProvider;
 import java.util.ArrayList;
@@ -78,19 +80,21 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
+ *
  * NOTE: Shout-out to <a href="https://github.com/adamfisk/LittleProxy">LittleProxy</a> which was great as a reference.
- * <p>
- * User: michaels Date: 11/8/14 Time: 8:39 PM
+ *
+ * User: michaels
+ * Date: 11/8/14
+ * Time: 8:39 PM
  */
 public class Server {
-
     /**
-     * This field is effectively a noop, as Epoll is enabled automatically if available.   This can be disabled by using
-     * the {@link #FORCE_NIO} property.
+     * This field is effectively a noop, as Epoll is enabled automatically if available.   This can be disabled by
+     * using the {@link #FORCE_NIO} property.
      */
     @Deprecated
     public static final DynamicBooleanProperty USE_EPOLL =
@@ -137,9 +141,9 @@ public class Server {
     public static final AtomicReference<Class<? extends Channel>> defaultOutboundChannelType = new AtomicReference<>();
 
     /**
-     * Use
-     * {@link #Server(Registry, ServerStatusManager, Map, ClientConnectionsShutdown, EventLoopGroupMetrics,
-     * EventLoopConfig)} instead.
+     * Use {@link #Server(Registry, ServerStatusManager, Map, ClientConnectionsShutdown, EventLoopGroupMetrics,
+     * EventLoopConfig)}
+     * instead.
      */
     @SuppressWarnings("rawtypes")
     @Deprecated
@@ -157,9 +161,9 @@ public class Server {
     }
 
     /**
-     * Use
-     * {@link #Server(Registry, ServerStatusManager, Map, ClientConnectionsShutdown, EventLoopGroupMetrics,
-     * EventLoopConfig)} instead.
+     * Use {@link #Server(Registry, ServerStatusManager, Map, ClientConnectionsShutdown, EventLoopGroupMetrics,
+     * EventLoopConfig)}
+     * instead.
      */
     @SuppressWarnings({"unchecked", "rawtypes"
     }) // Channel init map has the wrong generics and we can't fix without api breakage.
@@ -294,11 +298,6 @@ public class Server {
         serverBootstrap.childOption(ChannelOption.TCP_NODELAY, true);
         serverBootstrap.childOption(ChannelOption.SO_KEEPALIVE, true);
 
-        if (epollIsAvailable()) {
-            LOG.info("******* Enabling IP_TRANSPARENT for epoll channel bound to {}", listenAddress);
-            serverBootstrap.childOption(EpollChannelOption.IP_TRANSPARENT, true);
-        }
-
         // Apply transport specific socket options.
         for (Map.Entry<ChannelOption<?>, ?> optionEntry : serverGroup.transportChannelOptions.entrySet()) {
             serverBootstrap = serverBootstrap.option((ChannelOption) optionEntry.getKey(), optionEntry.getValue());
@@ -330,18 +329,14 @@ public class Server {
     /**
      * Override for metrics or informational purposes
      *
-     * @param clientToProxyBossPool   - acceptor pool
+     * @param clientToProxyBossPool - acceptor pool
      * @param clientToProxyWorkerPool - worker pool
      */
     public void postEventLoopCreationHook(
-            EventLoopGroup clientToProxyBossPool, EventLoopGroup clientToProxyWorkerPool) {
-    }
+            EventLoopGroup clientToProxyBossPool, EventLoopGroup clientToProxyWorkerPool) {}
 
     private final class ServerGroup {
-
-        /**
-         * A name for this ServerGroup to use in naming threads.
-         */
+        /** A name for this ServerGroup to use in naming threads. */
         private final String name;
 
         private final int acceptorThreads;


### PR DESCRIPTION
This is designed to be a privileged op for epoll channels.
Reverting since we can't assume Zuul apps would start as superuser. 