### PR TITLE
Refactor server stats updating on connection lifecycle hooks

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
@@ -214,8 +214,7 @@ public class DefaultClientChannelManager implements ClientChannelManager {
         connsInUse.decrementAndGet();
 
         final DiscoveryResult discoveryResult = conn.getServer();
-        discoveryResult.decrementActiveRequestsCount();
-        discoveryResult.incrementNumRequests();
+        updateServerStatsOnRelease(conn);
 
         boolean released = false;
 
@@ -272,6 +271,12 @@ public class DefaultClientChannelManager implements ClientChannelManager {
         }
 
         return released;
+    }
+
+    protected void updateServerStatsOnRelease(final PooledConnection conn) {
+        final DiscoveryResult discoveryResult = conn.getServer();
+        discoveryResult.decrementActiveRequestsCount();
+        discoveryResult.incrementNumRequests();
     }
 
     protected void releaseHandlers(PooledConnection conn) {


### PR DESCRIPTION
Refactor stats updates on DiscoveryResults to allow overriding behavior for different connection pooling types