### PR TITLE
Add metrics for h2 frames passed through userEventTriggered

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/metrics/Http2MetricsChannelHandlers.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/metrics/Http2MetricsChannelHandlers.java
@@ -94,6 +94,17 @@ public class Http2MetricsChannelHandlers {
         }
 
         @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            try {
+                if (evt instanceof Http2Frame) {
+                    incrementCounter(registry, frameCounterName, metricId, (Http2Frame) evt);
+                }
+            } finally {
+                super.userEventTriggered(ctx, evt);
+            }
+        }
+
+        @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             try {
                 if (cause instanceof Http2Exception) {


### PR DESCRIPTION
Currently we have metrics for all frames that are passed through the channelRead method in Http2MetricsChannelHandlers. However, it turns out that Netty's [Http2MultiplexHandler class ](https://github.com/netty/netty/blob/33931652a82b16bb2f758bce86ee20eb0ffa566f/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexHandler.java#L179-L181)handles Http2GoAwayFrames and Http2ResetFrames differently and sends them via the userEventTriggered method instead. This PR ensures that all frames are counted, whether they are passed through channelRead or userEventTriggered. 