### PR TITLE
Separate adding push handlers in initializer

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushMessageSenderInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushMessageSenderInitializer.java
@@ -26,20 +26,13 @@ import io.netty.handler.codec.http.HttpServerCodec;
  * Date: 5/16/18
  */
 public abstract class PushMessageSenderInitializer extends ChannelInitializer<Channel> {
-
-    private final PushConnectionRegistry pushConnectionRegistry;
-
-    public PushMessageSenderInitializer(PushConnectionRegistry pushConnectionRegistry) {
-        this.pushConnectionRegistry = pushConnectionRegistry;
-    }
-
     @Override
     protected void initChannel(Channel ch) throws Exception {
         final ChannelPipeline pipeline = ch.pipeline();
         pipeline.addLast(new HttpServerCodec());
         pipeline.addLast(new HttpObjectAggregator(65536));
-        pipeline.addLast(getPushMessageSender(pushConnectionRegistry));
+        addPushMessageHandlers(pipeline);
     }
 
-    protected abstract PushMessageSender getPushMessageSender(PushConnectionRegistry pushConnectionRegistry);
+    protected abstract void addPushMessageHandlers(final ChannelPipeline pipeline);
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushMessageSenderInitializerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushMessageSenderInitializerTest.java
@@ -1,0 +1,44 @@
+package com.netflix.zuul.netty.server.push;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PushMessageSenderInitializer}.
+ */
+class PushMessageSenderInitializerTest {
+    private PushMessageSenderInitializer initializer;
+    private Channel channel;
+    private ChannelHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = mock(ChannelHandler.class); // Initialize mock handler
+
+        initializer = new PushMessageSenderInitializer() {
+            @Override
+            protected void addPushMessageHandlers(ChannelPipeline pipeline) {
+                pipeline.addLast("mockHandler", handler);
+            }
+        };
+
+        channel = new EmbeddedChannel();
+    }
+
+    @Test
+    void testInitChannel() throws Exception {
+        initializer.initChannel(channel);
+
+        assertNotNull(channel.pipeline().context(HttpServerCodec.class));
+        assertNotNull(channel.pipeline().context(HttpObjectAggregator.class));
+        assertNotNull(channel.pipeline().get("mockHandler"));
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushMessageSenderInitializerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushMessageSenderInitializerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
 package com.netflix.zuul.netty.server.push;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SamplePushMessageSenderInitializer.java
+++ b/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SamplePushMessageSenderInitializer.java
@@ -18,7 +18,7 @@ package com.netflix.zuul.sample.push;
 import com.netflix.zuul.netty.server.push.PushConnectionRegistry;
 import com.netflix.zuul.netty.server.push.PushMessageSender;
 import com.netflix.zuul.netty.server.push.PushMessageSenderInitializer;
-
+import io.netty.channel.ChannelPipeline;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -33,12 +33,12 @@ public class SamplePushMessageSenderInitializer extends PushMessageSenderInitial
 
     @Inject
     public SamplePushMessageSenderInitializer(PushConnectionRegistry pushConnectionRegistry) {
-        super(pushConnectionRegistry);
+        super();
         pushMessageSender = new SamplePushMessageSender(pushConnectionRegistry);
     }
 
     @Override
-    protected PushMessageSender getPushMessageSender(PushConnectionRegistry pushConnectionRegistry) {
-        return pushMessageSender;
+    protected void addPushMessageHandlers(ChannelPipeline pipeline) {
+        pipeline.addLast(pushMessageSender);
     }
 }


### PR DESCRIPTION
Add new method to handle adding of push handlers. This allows extending the method to add any additional handlers. 