### PR TITLE
Lower log severity and print exception on cookie parsing failure

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
@@ -30,9 +30,6 @@ import com.netflix.zuul.util.HttpUtils;
 import io.netty.handler.codec.http.Cookie;
 import io.netty.handler.codec.http.CookieDecoder;
 import io.netty.handler.codec.http.HttpContent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
@@ -44,6 +41,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * User: michaels
@@ -394,10 +393,11 @@ public class HttpRequestMessageImpl implements HttpRequestMessage {
                     cookies.add(cookie);
                 }
             } catch (Exception e) {
-                LOG.error(
+                LOG.warn(
                         "Error parsing request Cookie header. cookie={}, request-info={}",
                         aCookieHeader,
-                        getInfoForLogging());
+                        getInfoForLogging(),
+                        e);
             }
         }
         parsedCookies = cookies;


### PR DESCRIPTION
The log line happens when invalid cookies are received and is not actionable. 
Lowering the severity level and adding exception to identify reasons for the failures. Based on the ressons, in future can be lower to info level.