### PR TITLE
Add getIgnore method to HttpQueryParams getting UpperCase queryParams

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpQueryParams.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpQueryParams.java
@@ -116,6 +116,10 @@ public class HttpQueryParams implements Cloneable {
     }
 
     public List<String> get(String name) {
+        return delegate.get(name);
+    }
+
+    public List<String> getIgnoreCase(String name) {
         return delegate.get(name.toLowerCase());
     }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpQueryParamsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpQueryParamsTest.java
@@ -22,8 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Locale;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 class HttpQueryParamsTest {
@@ -145,5 +144,67 @@ class HttpQueryParamsTest {
         queryParams.add(camelCaseKey.toLowerCase(Locale.ROOT), "value");
 
         assertTrue(queryParams.containsIgnoreCase(camelCaseKey));
+    }
+
+    @Test
+    public void getReturnsValuesForExactKeyMatch() {
+        HttpQueryParams queryParams = new HttpQueryParams();
+        queryParams.add("key", "value");
+        assertEquals("value", queryParams.get("key").get(0));
+    }
+
+    @Test
+    public void getReturnsEmptyListForNonExistentKey() {
+        HttpQueryParams queryParams = new HttpQueryParams();
+        assertTrue(queryParams.get("none").isEmpty());
+    }
+
+    @Test
+    public void getReturnsMultipleValuesForSameKey() {
+        HttpQueryParams queryParams = new HttpQueryParams();
+        queryParams.add("key", "value1");
+        queryParams.add("key", "value2");
+        assertEquals(2, queryParams.get("key").size());
+    }
+
+    @Test
+    public void getReturnsCaseSensitive() {
+        HttpQueryParams queryParams = new HttpQueryParams();
+        queryParams.add("KEY", "value");
+        assertTrue(queryParams.get("key").isEmpty());
+    }
+
+    @Test
+    public void getReturnsEmptyListForNullKey() {
+        HttpQueryParams queryParams = new HttpQueryParams();
+        assertTrue(queryParams.get(null).isEmpty());
+    }
+
+    @Test
+    public void getIgnoreCaseReturnsValuesForExactKeyMatch() {
+        HttpQueryParams queryParams = new HttpQueryParams();
+        queryParams.add("key", "value");
+        assertEquals("value", queryParams.getIgnoreCase("key").get(0));
+    }
+
+    @Test
+    public void getIgnoreCaseReturnsEmptyListForNonExistentKey() {
+        HttpQueryParams queryParams = new HttpQueryParams();
+        assertTrue(queryParams.getIgnoreCase("nonExistentKey").isEmpty());
+    }
+
+    @Test
+    public void getIgnoreCaseReturnsMultipleValuesForSameKey() {
+        HttpQueryParams queryParams = new HttpQueryParams();
+        queryParams.add("key", "value1");
+        queryParams.add("key", "value2");
+        assertEquals(2, queryParams.getIgnoreCase("KEY").size());
+    }
+
+    @Test
+    public void getIgnoreCaseReturnsCaseInsensitive() {
+        HttpQueryParams queryParams = new HttpQueryParams();
+        queryParams.add("key", "value");
+        assertTrue(queryParams.getIgnoreCase("KEY").get(0).equals("value"));
     }
 }


### PR DESCRIPTION
Related issue: https://github.com/Netflix/zuul/issues/527

### Motivation
- In the HttpQueryParams class, when invoking `get("cityId")`, the key is converted to lowercase, causing the value associated with the key cityId returns as null. 
  - To address this issue, I've added a function that recognizes uppercase characters within the key.

### Modification
- Add getIgnoreCase(String name) on HttpQueryParams 

### Result
- Close https://github.com/Netflix/zuul/issues/527
- Now user can use getIgnoreCase(String name) on HttpQueryParams