### PR TITLE
use BouncyCastle jdk18on

### DIFF
--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -6,8 +6,8 @@ dependencies {
     implementation libraries.guava
     // TODO(carl-mastrangelo): this can be implementation; remove Logger from public api points.
     api libraries.slf4j
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
-    implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.76'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.76'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.14.2'
     api 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
 

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -78,11 +78,11 @@
         "javax.inject:javax.inject": {
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcpkix-jdk18on": {
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcprov-jdk18on": {
+            "locked": "1.76"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.36"
@@ -178,11 +178,11 @@
         "javax.inject:javax.inject": {
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcpkix-jdk18on": {
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcprov-jdk18on": {
+            "locked": "1.76"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.37"
@@ -306,11 +306,11 @@
         "org.awaitility:awaitility": {
             "locked": "4.2.0"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcpkix-jdk18on": {
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcprov-jdk18on": {
+            "locked": "1.76"
         },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.10.0"
@@ -446,11 +446,11 @@
         "javax.inject:javax.inject": {
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcpkix-jdk18on": {
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcprov-jdk18on": {
+            "locked": "1.76"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -547,11 +547,11 @@
         "org.awaitility:awaitility": {
             "locked": "4.2.0"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcpkix-jdk18on": {
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcprov-jdk18on": {
+            "locked": "1.76"
         },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.10.0"
@@ -681,11 +681,11 @@
         "org.awaitility:awaitility": {
             "locked": "4.2.0"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcpkix-jdk18on": {
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
-            "locked": "1.70"
+        "org.bouncycastle:bcprov-jdk18on": {
+            "locked": "1.76"
         },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.10.0"

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -424,17 +424,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "3.0.19"
@@ -638,17 +638,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "3.0.19"
@@ -971,17 +971,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.codehaus.groovy:groovy-all": {
             "locked": "3.0.19"

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -430,17 +430,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.10.0"
@@ -647,17 +647,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -983,17 +983,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.10.0"

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -176,17 +176,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -696,17 +696,17 @@
         "org.apache.logging.log4j:log4j-slf4j2-impl": {
             "locked": "2.21.1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.10.0"
@@ -928,17 +928,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1336,17 +1336,17 @@
         "org.apache.logging.log4j:log4j-slf4j2-impl": {
             "locked": "2.21.1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.10.0"

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -418,17 +418,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.10.0"
@@ -623,17 +623,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -820,17 +820,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -1141,17 +1141,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.10.0"

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -176,17 +176,17 @@
             ],
             "locked": "1"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -677,17 +677,17 @@
         "org.apache.logging.log4j:log4j-slf4j-impl": {
             "locked": "2.19.0"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [
@@ -908,17 +908,17 @@
         "org.apache.logging.log4j:log4j-slf4j-impl": {
             "locked": "2.19.0"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [
@@ -1267,17 +1267,17 @@
         "org.apache.logging.log4j:log4j-slf4j-impl": {
             "locked": "2.19.0"
         },
-        "org.bouncycastle:bcpkix-jdk15on": {
+        "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
-        "org.bouncycastle:bcprov-jdk15on": {
+        "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.70"
+            "locked": "1.76"
         },
         "org.codehaus.groovy:groovy-all": {
             "firstLevelTransitive": [


### PR DESCRIPTION
# Modifications

- BouncyCastle:  replace 'jdk15on' with 'jdk18on'
- BouncyCastle:  bump to latest release


# Motivation

https://www.bouncycastle.org/latest_releases.html

Note:
```
Packaging Change (users of 1.70 or earlier): 
BC 1.71 changed the jdk15on jars to jdk18on so the base has now 
moved to Java 8. 

For earlier JVMs, or containers/applications that cannot cope with 
multi-release jars, you should now use the jdk15to18 jars.
```

