### PR TITLE
Refactor static import members to use qualified references

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/http2/DynamicHttp2FrameLogger.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/http2/DynamicHttp2FrameLogger.java
@@ -26,11 +26,10 @@ import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.logging.LogLevel;
 import io.netty.util.AttributeKey;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.logging.InternalLogLevel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 public class DynamicHttp2FrameLogger extends Http2FrameLogger {
     public static final AttributeKey<Object> ATTR_ENABLE = AttributeKey.valueOf("http2.frame.logger.enabled");
@@ -44,8 +43,8 @@ public class DynamicHttp2FrameLogger extends Http2FrameLogger {
 
     public DynamicHttp2FrameLogger(LogLevel level, Class<?> clazz) {
         super(level, clazz);
-        this.level = checkNotNull(level.toInternalLevel(), "level");
-        this.logger = checkNotNull(InternalLoggerFactory.getInstance(clazz), "logger");
+        this.level = ObjectUtil.checkNotNull(level.toInternalLevel(), "level");
+        this.logger = ObjectUtil.checkNotNull(InternalLoggerFactory.getInstance(clazz), "logger");
     }
 
     protected boolean enabled(ChannelHandlerContext ctx) {

--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java
@@ -16,6 +16,7 @@
 
 package com.netflix.netty.common.proxyprotocol;
 
+import com.google.common.base.Preconditions;
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.spectator.api.Registry;
 import io.netty.buffer.ByteBuf;
@@ -24,8 +25,6 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.ProtocolDetectionState;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Decides if we need to decode a HAProxyMessage. If so, adds the decoder followed by the handler.
@@ -39,7 +38,7 @@ public final class ElbProxyProtocolChannelHandler extends ChannelInboundHandlerA
 
     public ElbProxyProtocolChannelHandler(Registry registry, boolean withProxyProtocol) {
         this.withProxyProtocol = withProxyProtocol;
-        this.registry = checkNotNull(registry);
+        this.registry = Preconditions.checkNotNull(registry);
     }
 
     public void addProxyProtocol(ChannelPipeline pipeline) {

--- a/zuul-core/src/main/java/com/netflix/netty/common/throttle/RejectionUtils.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/throttle/RejectionUtils.java
@@ -17,6 +17,7 @@
 package com.netflix.netty.common.throttle;
 
 import com.netflix.netty.common.ConnectionCloseChannelAttributes;
+import com.netflix.netty.common.proxyprotocol.HAProxyMessageChannelHandler;
 import com.netflix.zuul.passport.CurrentPassport;
 import com.netflix.zuul.passport.PassportState;
 import com.netflix.zuul.stats.status.StatusCategory;
@@ -41,8 +42,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import static com.netflix.netty.common.proxyprotocol.HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION;
 
 /**
  * A collection of rejection related utilities useful for failing requests. These are tightly coupled with the channel
@@ -304,9 +303,10 @@ public final class RejectionUtils {
     }
 
     private static boolean closeConnectionAfterReject(Channel channel) {
-        if (channel.hasAttr(ATTR_HAPROXY_VERSION)) {
+        if (channel.hasAttr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION)) {
             return HAProxyProtocolVersion.V2
-                    == channel.attr(ATTR_HAPROXY_VERSION).get();
+                    == channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION)
+                            .get();
         } else {
             return false;
         }

--- a/zuul-core/src/main/java/com/netflix/zuul/Filter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/Filter.java
@@ -21,19 +21,16 @@ import com.netflix.zuul.filters.FilterType;
 import com.netflix.zuul.filters.ZuulFilter;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.PACKAGE;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.CLASS;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Identifies a {@link ZuulFilter}.
  */
-@Target({TYPE})
-@Retention(RUNTIME)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Filter {
 
@@ -57,8 +54,8 @@ public @interface Filter {
      */
     FilterSyncType sync() default FilterSyncType.SYNC;
 
-    @Target({PACKAGE})
-    @Retention(CLASS)
+    @Target({ElementType.PACKAGE})
+    @Retention(RetentionPolicy.CLASS)
     @Documented
     @interface FilterPackageName {
         String value();
@@ -71,8 +68,8 @@ public @interface Filter {
      * this annotation should be used on homogeneous filter types.  Additionally, this should not be applied to endpoint
      * filters.
      */
-    @Target({TYPE})
-    @Retention(RUNTIME)
+    @Target({ElementType.TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
     @Documented
     @interface ApplyAfter {
         Class<? extends ZuulFilter<?, ?>>[] value();
@@ -90,8 +87,8 @@ public @interface Filter {
      *
      * @see ApplyAfter
      */
-    @Target({TYPE})
-    @Retention(RUNTIME)
+    @Target({ElementType.TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
     @Documented
     @interface ApplyBefore {
         Class<? extends ZuulFilter<?, ?>>[] value();

--- a/zuul-core/src/main/java/com/netflix/zuul/FilterLoader.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/FilterLoader.java
@@ -21,9 +21,8 @@ import com.netflix.zuul.filters.ZuulFilter;
 import java.io.File;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.SortedSet;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * This class is one of the core classes in Zuul. It compiles, loads from a File, and checks if source code changed.
@@ -63,7 +62,7 @@ public interface FilterLoader {
 
     Comparator<Class<? extends ZuulFilter<?, ?>>> FILTER_CLASS_COMPARATOR =
             Comparator.<Class<? extends ZuulFilter<?, ?>>>comparingInt(
-                            c -> requireNonNull(c.getAnnotation(Filter.class), () -> "missing annotation: " + c)
+                            c -> Objects.requireNonNull(c.getAnnotation(Filter.class), () -> "missing annotation: " + c)
                                     .order())
                     .thenComparing(Class::getName);
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/exception/OutboundErrorType.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/exception/OutboundErrorType.java
@@ -18,23 +18,7 @@ package com.netflix.zuul.exception;
 
 import com.netflix.client.ClientException;
 import com.netflix.zuul.stats.status.StatusCategory;
-
-import static com.netflix.client.ClientException.ErrorType.CLIENT_THROTTLED;
-import static com.netflix.client.ClientException.ErrorType.CONNECT_EXCEPTION;
-import static com.netflix.client.ClientException.ErrorType.GENERAL;
-import static com.netflix.client.ClientException.ErrorType.READ_TIMEOUT_EXCEPTION;
-import static com.netflix.client.ClientException.ErrorType.SERVER_THROTTLED;
-import static com.netflix.client.ClientException.ErrorType.SOCKET_TIMEOUT_EXCEPTION;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_CLIENT_CANCELLED;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_LOCAL;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_LOCAL_THROTTLED_ORIGIN_CONCURRENCY;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_LOCAL_THROTTLED_ORIGIN_SERVER_MAXCONN;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_ORIGIN;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_ORIGIN_CONNECTIVITY;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_ORIGIN_NO_SERVERS;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_ORIGIN_READ_TIMEOUT;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_ORIGIN_RESET_CONNECTION;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_ORIGIN_THROTTLED;
+import com.netflix.zuul.stats.status.ZuulStatusCategory;
 
 /**
  * Outbound Error Type
@@ -43,22 +27,40 @@ import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_ORIGIN_TH
  * Date: November 28, 2017
  */
 public enum OutboundErrorType implements ErrorType {
-    READ_TIMEOUT(ERROR_TYPE_READ_TIMEOUT_STATUS.get(), FAILURE_ORIGIN_READ_TIMEOUT, READ_TIMEOUT_EXCEPTION),
-    CONNECT_ERROR(ERROR_TYPE_CONNECT_ERROR_STATUS.get(), FAILURE_ORIGIN_CONNECTIVITY, CONNECT_EXCEPTION),
-    SERVICE_UNAVAILABLE(ERROR_TYPE_SERVICE_UNAVAILABLE_STATUS.get(), FAILURE_ORIGIN_THROTTLED, SERVER_THROTTLED),
-    ERROR_STATUS_RESPONSE(ERROR_TYPE_ERROR_STATUS_RESPONSE_STATUS.get(), FAILURE_ORIGIN, GENERAL),
-    NO_AVAILABLE_SERVERS(ERROR_TYPE_NOSERVERS_STATUS.get(), FAILURE_ORIGIN_NO_SERVERS, CONNECT_EXCEPTION),
+    READ_TIMEOUT(
+            ERROR_TYPE_READ_TIMEOUT_STATUS.get(),
+            ZuulStatusCategory.FAILURE_ORIGIN_READ_TIMEOUT,
+            ClientException.ErrorType.READ_TIMEOUT_EXCEPTION),
+    CONNECT_ERROR(
+            ERROR_TYPE_CONNECT_ERROR_STATUS.get(),
+            ZuulStatusCategory.FAILURE_ORIGIN_CONNECTIVITY,
+            ClientException.ErrorType.CONNECT_EXCEPTION),
+    SERVICE_UNAVAILABLE(
+            ERROR_TYPE_SERVICE_UNAVAILABLE_STATUS.get(),
+            ZuulStatusCategory.FAILURE_ORIGIN_THROTTLED,
+            ClientException.ErrorType.SERVER_THROTTLED),
+    ERROR_STATUS_RESPONSE(
+            ERROR_TYPE_ERROR_STATUS_RESPONSE_STATUS.get(),
+            ZuulStatusCategory.FAILURE_ORIGIN,
+            ClientException.ErrorType.GENERAL),
+    NO_AVAILABLE_SERVERS(
+            ERROR_TYPE_NOSERVERS_STATUS.get(),
+            ZuulStatusCategory.FAILURE_ORIGIN_NO_SERVERS,
+            ClientException.ErrorType.CONNECT_EXCEPTION),
     ORIGIN_SERVER_MAX_CONNS(
             ERROR_TYPE_ORIGIN_SERVER_MAX_CONNS_STATUS.get(),
-            FAILURE_LOCAL_THROTTLED_ORIGIN_SERVER_MAXCONN,
-            CLIENT_THROTTLED),
-    RESET_CONNECTION(ERROR_TYPE_ORIGIN_RESET_CONN_STATUS.get(), FAILURE_ORIGIN_RESET_CONNECTION, CONNECT_EXCEPTION),
-    CANCELLED(400, FAILURE_CLIENT_CANCELLED, SOCKET_TIMEOUT_EXCEPTION),
+            ZuulStatusCategory.FAILURE_LOCAL_THROTTLED_ORIGIN_SERVER_MAXCONN,
+            ClientException.ErrorType.CLIENT_THROTTLED),
+    RESET_CONNECTION(
+            ERROR_TYPE_ORIGIN_RESET_CONN_STATUS.get(),
+            ZuulStatusCategory.FAILURE_ORIGIN_RESET_CONNECTION,
+            ClientException.ErrorType.CONNECT_EXCEPTION),
+    CANCELLED(400, ZuulStatusCategory.FAILURE_CLIENT_CANCELLED, ClientException.ErrorType.SOCKET_TIMEOUT_EXCEPTION),
     ORIGIN_CONCURRENCY_EXCEEDED(
             ERROR_TYPE_ORIGIN_CONCURRENCY_EXCEEDED_STATUS.get(),
-            FAILURE_LOCAL_THROTTLED_ORIGIN_CONCURRENCY,
-            SERVER_THROTTLED),
-    OTHER(ERROR_TYPE_OTHER_STATUS.get(), FAILURE_LOCAL, GENERAL);
+            ZuulStatusCategory.FAILURE_LOCAL_THROTTLED_ORIGIN_CONCURRENCY,
+            ClientException.ErrorType.SERVER_THROTTLED),
+    OTHER(ERROR_TYPE_OTHER_STATUS.get(), ZuulStatusCategory.FAILURE_LOCAL, ClientException.ErrorType.GENERAL);
 
     private static final String NAME_PREFIX = "ORIGIN_";
 

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/MutableFilterRegistry.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/MutableFilterRegistry.java
@@ -20,9 +20,8 @@ import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-
-import static java.util.Objects.requireNonNull;
 
 @Singleton
 public final class MutableFilterRegistry implements FilterRegistry {
@@ -31,18 +30,18 @@ public final class MutableFilterRegistry implements FilterRegistry {
     @Nullable
     @Override
     public ZuulFilter<?, ?> remove(String key) {
-        return filters.remove(requireNonNull(key, "key"));
+        return filters.remove(Objects.requireNonNull(key, "key"));
     }
 
     @Override
     @Nullable
     public ZuulFilter<?, ?> get(String key) {
-        return filters.get(requireNonNull(key, "key"));
+        return filters.get(Objects.requireNonNull(key, "key"));
     }
 
     @Override
     public void put(String key, ZuulFilter<?, ?> filter) {
-        filters.putIfAbsent(requireNonNull(key, "key"), requireNonNull(filter, "filter"));
+        filters.putIfAbsent(Objects.requireNonNull(key, "key"), Objects.requireNonNull(filter, "filter"));
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/SyncZuulFilterAdapter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/SyncZuulFilterAdapter.java
@@ -20,9 +20,6 @@ import com.netflix.zuul.message.ZuulMessage;
 import io.netty.handler.codec.http.HttpContent;
 import rx.Observable;
 
-import static com.netflix.zuul.filters.FilterSyncType.SYNC;
-import static com.netflix.zuul.filters.FilterType.ENDPOINT;
-
 /**
  * Base class to help implement SyncZuulFilter. Note that the class BaseSyncFilter does exist but it derives from
  * BaseFilter which in turn creates a new instance of CachedDynamicBooleanProperty for "filterDisabled" every time you
@@ -59,7 +56,7 @@ public abstract class SyncZuulFilterAdapter<I extends ZuulMessage, O extends Zuu
 
     @Override
     public FilterType filterType() {
-        return ENDPOINT;
+        return FilterType.ENDPOINT;
     }
 
     @Override
@@ -74,7 +71,7 @@ public abstract class SyncZuulFilterAdapter<I extends ZuulMessage, O extends Zuu
 
     @Override
     public FilterSyncType getSyncType() {
-        return SYNC;
+        return FilterSyncType.SYNC;
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/passport/InboundPassportStampingFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/passport/InboundPassportStampingFilter.java
@@ -21,12 +21,10 @@ import com.netflix.zuul.filters.FilterType;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.passport.PassportState;
 
-import static com.netflix.zuul.filters.FilterType.INBOUND;
-
 /**
  * Created by saroskar on 3/14/17.
  */
-@Filter(order = 0, type = INBOUND)
+@Filter(order = 0, type = FilterType.INBOUND)
 public final class InboundPassportStampingFilter extends PassportStampingFilter<HttpRequestMessage> {
 
     public InboundPassportStampingFilter(PassportState stamp) {
@@ -35,6 +33,6 @@ public final class InboundPassportStampingFilter extends PassportStampingFilter<
 
     @Override
     public FilterType filterType() {
-        return INBOUND;
+        return FilterType.INBOUND;
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/passport/OutboundPassportStampingFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/passport/OutboundPassportStampingFilter.java
@@ -21,12 +21,10 @@ import com.netflix.zuul.filters.FilterType;
 import com.netflix.zuul.message.http.HttpResponseMessage;
 import com.netflix.zuul.passport.PassportState;
 
-import static com.netflix.zuul.filters.FilterType.OUTBOUND;
-
 /**
  * Created by saroskar on 3/14/17.
  */
-@Filter(order = 0, type = OUTBOUND)
+@Filter(order = 0, type = FilterType.OUTBOUND)
 public final class OutboundPassportStampingFilter extends PassportStampingFilter<HttpResponseMessage> {
 
     public OutboundPassportStampingFilter(PassportState stamp) {
@@ -35,6 +33,6 @@ public final class OutboundPassportStampingFilter extends PassportStampingFilter
 
     @Override
     public FilterType filterType() {
-        return OUTBOUND;
+        return FilterType.OUTBOUND;
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
@@ -29,11 +29,10 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * An abstraction over a collection of http headers. Allows multiple headers with same name, and header names are
@@ -53,7 +52,7 @@ public final class Headers {
             Spectator.globalRegistry().counter("zuul.header.invalid.char");
 
     public static Headers copyOf(Headers original) {
-        return new Headers(requireNonNull(original, "original"));
+        return new Headers(Objects.requireNonNull(original, "original"));
     }
 
     public Headers() {
@@ -80,7 +79,7 @@ public final class Headers {
      */
     @Nullable
     public String getFirst(String headerName) {
-        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        String normalName = HeaderName.normalize(Objects.requireNonNull(headerName, "headerName"));
         return getFirstNormal(normalName);
     }
 
@@ -90,7 +89,7 @@ public final class Headers {
      */
     @Nullable
     public String getFirst(HeaderName headerName) {
-        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        String normalName = Objects.requireNonNull(headerName, "headerName").getNormalised();
         return getFirstNormal(normalName);
     }
 
@@ -109,7 +108,7 @@ public final class Headers {
      * return the specified defaultValue.
      */
     public String getFirst(String headerName, String defaultValue) {
-        requireNonNull(defaultValue, "defaultValue");
+        Objects.requireNonNull(defaultValue, "defaultValue");
         String value = getFirst(headerName);
         if (value != null) {
             return value;
@@ -122,7 +121,7 @@ public final class Headers {
      * return the specified defaultValue.
      */
     public String getFirst(HeaderName headerName, String defaultValue) {
-        requireNonNull(defaultValue, "defaultValue");
+        Objects.requireNonNull(defaultValue, "defaultValue");
         String value = getFirst(headerName);
         if (value != null) {
             return value;
@@ -134,7 +133,7 @@ public final class Headers {
      * Returns all header values associated with the name.
      */
     public List<String> getAll(String headerName) {
-        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        String normalName = HeaderName.normalize(Objects.requireNonNull(headerName, "headerName"));
         return getAllNormal(normalName);
     }
 
@@ -142,7 +141,7 @@ public final class Headers {
      * Returns all header values associated with the name.
      */
     public List<String> getAll(HeaderName headerName) {
-        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        String normalName = Objects.requireNonNull(headerName, "headerName").getNormalised();
         return getAllNormal(normalName);
     }
 
@@ -180,7 +179,7 @@ public final class Headers {
      * If value is {@code null}, then not added, but any existing header of same name is removed.
      */
     public void set(String headerName, @Nullable String value) {
-        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        String normalName = HeaderName.normalize(Objects.requireNonNull(headerName, "headerName"));
         setNormal(headerName, normalName, value);
     }
 
@@ -190,7 +189,7 @@ public final class Headers {
      * If value is {@code null}, then not added, but any existing header of same name is removed.
      */
     public void set(HeaderName headerName, String value) {
-        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        String normalName = Objects.requireNonNull(headerName, "headerName").getNormalised();
         setNormal(headerName.getName(), normalName, value);
     }
 
@@ -202,7 +201,7 @@ public final class Headers {
      * @throws ZuulException on invalid name or value
      */
     public void setAndValidate(String headerName, @Nullable String value) {
-        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        String normalName = HeaderName.normalize(Objects.requireNonNull(headerName, "headerName"));
         setNormal(validateField(headerName), validateField(normalName), validateField(value));
     }
 
@@ -212,7 +211,7 @@ public final class Headers {
      * If value is {@code null}, then not added, but any existing header of same name is removed.
      */
     public void setIfValid(HeaderName headerName, String value) {
-        requireNonNull(headerName, "headerName");
+        Objects.requireNonNull(headerName, "headerName");
         if (isValid(headerName.getName()) && isValid(value)) {
             String normalName = headerName.getNormalised();
             setNormal(headerName.getName(), normalName, value);
@@ -225,7 +224,7 @@ public final class Headers {
      * If value is {@code null}, then not added, but any existing header of same name is removed.
      */
     public void setIfValid(String headerName, @Nullable String value) {
-        requireNonNull(headerName, "headerName");
+        Objects.requireNonNull(headerName, "headerName");
         if (isValid(headerName) && isValid(value)) {
             String normalName = HeaderName.normalize(headerName);
             setNormal(headerName, normalName, value);
@@ -240,7 +239,7 @@ public final class Headers {
      * @throws ZuulException on invalid name or value
      */
     public void setAndValidate(HeaderName headerName, String value) {
-        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        String normalName = Objects.requireNonNull(headerName, "headerName").getNormalised();
         setNormal(validateField(headerName.getName()), validateField(normalName), validateField(value));
     }
 
@@ -300,8 +299,8 @@ public final class Headers {
      * @return if the value was successfully added.
      */
     public boolean setIfAbsent(String headerName, String value) {
-        requireNonNull(value, "value");
-        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        Objects.requireNonNull(value, "value");
+        String normalName = HeaderName.normalize(Objects.requireNonNull(headerName, "headerName"));
         return setIfAbsentNormal(headerName, normalName, value);
     }
 
@@ -312,8 +311,8 @@ public final class Headers {
      * @return if the value was successfully added.
      */
     public boolean setIfAbsent(HeaderName headerName, String value) {
-        requireNonNull(value, "value");
-        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        Objects.requireNonNull(value, "value");
+        String normalName = Objects.requireNonNull(headerName, "headerName").getNormalised();
         return setIfAbsentNormal(headerName.getName(), normalName, value);
     }
 
@@ -333,8 +332,8 @@ public final class Headers {
      * @return if the value was successfully added.
      */
     public boolean setIfAbsentAndValid(String headerName, String value) {
-        requireNonNull(value, "value");
-        requireNonNull(headerName, "headerName");
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(headerName, "headerName");
         if (isValid(headerName) && isValid(value)) {
             String normalName = HeaderName.normalize(headerName);
             return setIfAbsentNormal(headerName, normalName, value);
@@ -349,8 +348,8 @@ public final class Headers {
      * @return if the value was successfully added.
      */
     public boolean setIfAbsentAndValid(HeaderName headerName, String value) {
-        requireNonNull(value, "value");
-        requireNonNull(headerName, "headerName");
+        Objects.requireNonNull(value, "value");
+        Objects.requireNonNull(headerName, "headerName");
         if (isValid(headerName.getName()) && isValid((value))) {
             String normalName = headerName.getNormalised();
             return setIfAbsentNormal(headerName.getName(), normalName, value);
@@ -362,8 +361,8 @@ public final class Headers {
      * Adds the name and value to the headers.
      */
     public void add(String headerName, String value) {
-        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
-        requireNonNull(value, "value");
+        String normalName = HeaderName.normalize(Objects.requireNonNull(headerName, "headerName"));
+        Objects.requireNonNull(value, "value");
         addNormal(headerName, normalName, value);
     }
 
@@ -371,8 +370,8 @@ public final class Headers {
      * Adds the name and value to the headers.
      */
     public void add(HeaderName headerName, String value) {
-        String normalName = requireNonNull(headerName, "headerName").getNormalised();
-        requireNonNull(value, "value");
+        String normalName = Objects.requireNonNull(headerName, "headerName").getNormalised();
+        Objects.requireNonNull(value, "value");
         addNormal(headerName.getName(), normalName, value);
     }
 
@@ -382,8 +381,8 @@ public final class Headers {
      * @throws ZuulException on invalid name or value
      */
     public void addAndValidate(String headerName, String value) {
-        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
-        requireNonNull(value, "value");
+        String normalName = HeaderName.normalize(Objects.requireNonNull(headerName, "headerName"));
+        Objects.requireNonNull(value, "value");
         addNormal(validateField(headerName), validateField(normalName), validateField(value));
     }
 
@@ -393,8 +392,8 @@ public final class Headers {
      * @throws ZuulException on invalid name or value
      */
     public void addAndValidate(HeaderName headerName, String value) {
-        String normalName = requireNonNull(headerName, "headerName").getNormalised();
-        requireNonNull(value, "value");
+        String normalName = Objects.requireNonNull(headerName, "headerName").getNormalised();
+        Objects.requireNonNull(value, "value");
         addNormal(validateField(headerName.getName()), validateField(normalName), validateField(value));
     }
 
@@ -402,8 +401,8 @@ public final class Headers {
      * Adds the name and value to the headers if valid
      */
     public void addIfValid(String headerName, String value) {
-        requireNonNull(headerName, "headerName");
-        requireNonNull(value, "value");
+        Objects.requireNonNull(headerName, "headerName");
+        Objects.requireNonNull(value, "value");
         if (isValid(headerName) && isValid(value)) {
             String normalName = HeaderName.normalize(headerName);
             addNormal(headerName, normalName, value);
@@ -414,8 +413,8 @@ public final class Headers {
      * Adds the name and value to the headers if valid
      */
     public void addIfValid(HeaderName headerName, String value) {
-        requireNonNull(headerName, "headerName");
-        requireNonNull(value, "value");
+        Objects.requireNonNull(headerName, "headerName");
+        Objects.requireNonNull(value, "value");
         if (isValid(headerName.getName()) && isValid(value)) {
             String normalName = headerName.getNormalised();
             addNormal(headerName.getName(), normalName, value);
@@ -435,7 +434,7 @@ public final class Headers {
      * Removes the header entries that match the given header name, and returns them as a list.
      */
     public List<String> remove(String headerName) {
-        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        String normalName = HeaderName.normalize(Objects.requireNonNull(headerName, "headerName"));
         return removeNormal(normalName);
     }
 
@@ -443,7 +442,7 @@ public final class Headers {
      * Removes the header entries that match the given header name, and returns them as a list.
      */
     public List<String> remove(HeaderName headerName) {
-        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        String normalName = Objects.requireNonNull(headerName, "headerName").getNormalised();
         return removeNormal(normalName);
     }
 
@@ -460,7 +459,7 @@ public final class Headers {
      * @return if any elements were removed.
      */
     public boolean removeIf(Predicate<? super Map.Entry<HeaderName, String>> filter) {
-        requireNonNull(filter, "filter");
+        Objects.requireNonNull(filter, "filter");
         boolean removed = false;
         int w = 0;
         for (int r = 0; r < size(); r++) {
@@ -509,7 +508,7 @@ public final class Headers {
      * Returns if there is a header entry that matches the given name.
      */
     public boolean contains(String headerName) {
-        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
+        String normalName = HeaderName.normalize(Objects.requireNonNull(headerName, "headerName"));
         return findNormal(normalName) != ABSENT;
     }
 
@@ -517,7 +516,7 @@ public final class Headers {
      * Returns if there is a header entry that matches the given name.
      */
     public boolean contains(HeaderName headerName) {
-        String normalName = requireNonNull(headerName, "headerName").getNormalised();
+        String normalName = Objects.requireNonNull(headerName, "headerName").getNormalised();
         return findNormal(normalName) != ABSENT;
     }
 
@@ -525,8 +524,8 @@ public final class Headers {
      * Returns if there is a header entry that matches the given name and value.
      */
     public boolean contains(String headerName, String value) {
-        String normalName = HeaderName.normalize(requireNonNull(headerName, "headerName"));
-        requireNonNull(value, "value");
+        String normalName = HeaderName.normalize(Objects.requireNonNull(headerName, "headerName"));
+        Objects.requireNonNull(value, "value");
         return containsNormal(normalName, value);
     }
 
@@ -534,8 +533,8 @@ public final class Headers {
      * Returns if there is a header entry that matches the given name and value.
      */
     public boolean contains(HeaderName headerName, String value) {
-        String normalName = requireNonNull(headerName, "headerName").getNormalised();
-        requireNonNull(value, "value");
+        String normalName = Objects.requireNonNull(headerName, "headerName").getNormalised();
+        Objects.requireNonNull(value, "value");
         return containsNormal(normalName, value);
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolHandler.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
 import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
-import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason.SESSION_COMPLETE;
 
 /**
  * User: michaels@netflix.com
@@ -79,7 +78,7 @@ public class ConnectionPoolHandler extends ChannelDuplexHandler {
             // Return the connection to pool.
             CompleteEvent completeEvt = (CompleteEvent) evt;
             final CompleteReason reason = completeEvt.getReason();
-            if (reason == SESSION_COMPLETE) {
+            if (reason == CompleteReason.SESSION_COMPLETE) {
                 final PooledConnection conn = PooledConnection.getFromChannel(ctx.channel());
                 if (conn != null) {
                     if ("close".equalsIgnoreCase(getConnectionHeader(completeEvt))) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultOriginChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultOriginChannelInitializer.java
@@ -30,8 +30,6 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
 
-import static com.netflix.zuul.netty.server.BaseZuulChannelInitializer.HTTP_CODEC_HANDLER_NAME;
-
 /**
  * Default Origin Channel Initializer
  *
@@ -69,7 +67,7 @@ public class DefaultOriginChannelInitializer extends OriginChannelInitializer {
         }
 
         pipeline.addLast(
-                HTTP_CODEC_HANDLER_NAME,
+                BaseZuulChannelInitializer.HTTP_CODEC_HANDLER_NAME,
                 new HttpClientCodec(
                         BaseZuulChannelInitializer.MAX_INITIAL_LINE_LENGTH.get(),
                         BaseZuulChannelInitializer.MAX_HEADER_SIZE.get(),

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PooledConnection.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PooledConnection.java
@@ -30,8 +30,6 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import static com.netflix.zuul.netty.connectionpool.DefaultOriginChannelInitializer.ORIGIN_NETTY_LOGGER;
-
 /**
  * Created by saroskar on 3/15/16.
  */
@@ -219,7 +217,7 @@ public class PooledConnection {
         getChannel()
                 .pipeline()
                 .addBefore(
-                        ORIGIN_NETTY_LOGGER,
+                        DefaultOriginChannelInitializer.ORIGIN_NETTY_LOGGER,
                         READ_TIMEOUT_HANDLER_NAME,
                         new ReadTimeoutHandler(readTimeout.toMillis(), TimeUnit.MILLISECONDS));
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulEndPointRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulEndPointRunner.java
@@ -23,6 +23,7 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.impl.Preconditions;
 import com.netflix.zuul.FilterLoader;
 import com.netflix.zuul.FilterUsageNotifier;
+import com.netflix.zuul.context.CommonContextKeys;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.filters.Endpoint;
 import com.netflix.zuul.filters.FilterType;
@@ -44,8 +45,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-
-import static com.netflix.zuul.context.CommonContextKeys.ZUUL_ENDPOINT;
 
 /**
  * This class is supposed to be thread safe and hence should not have any non final member variables
@@ -74,14 +73,14 @@ public class ZuulEndPointRunner extends BaseZuulFilterRunner<HttpRequestMessage,
     public static ZuulFilter<HttpRequestMessage, HttpResponseMessage> getEndpoint(
             @Nullable final HttpRequestMessage zuulReq) {
         if (zuulReq != null) {
-            return zuulReq.getContext().get(ZUUL_ENDPOINT);
+            return zuulReq.getContext().get(CommonContextKeys.ZUUL_ENDPOINT);
         }
         return null;
     }
 
     public static void setEndpoint(
             HttpRequestMessage zuulReq, ZuulFilter<HttpRequestMessage, HttpResponseMessage> endpoint) {
-        zuulReq.getContext().put(ZUUL_ENDPOINT, endpoint);
+        zuulReq.getContext().put(CommonContextKeys.ZUUL_ENDPOINT, endpoint);
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
@@ -17,8 +17,10 @@
 package com.netflix.zuul.netty.filter;
 
 import com.google.common.base.Preconditions;
+import com.netflix.netty.common.HttpLifecycleChannelHandler;
 import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
 import com.netflix.netty.common.HttpRequestReadTimeoutEvent;
+import com.netflix.zuul.context.CommonContextKeys;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.filters.ZuulFilter;
 import com.netflix.zuul.filters.endpoint.ProxyEndpoint;
@@ -29,8 +31,10 @@ import com.netflix.zuul.message.http.HttpResponseMessageImpl;
 import com.netflix.zuul.netty.ChannelUtils;
 import com.netflix.zuul.netty.RequestCancelledEvent;
 import com.netflix.zuul.netty.SpectatorUtils;
+import com.netflix.zuul.netty.server.ClientRequestReceiver;
 import com.netflix.zuul.stats.status.StatusCategory;
 import com.netflix.zuul.stats.status.StatusCategoryUtils;
+import com.netflix.zuul.stats.status.ZuulStatusCategory;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.unix.Errors;
@@ -43,14 +47,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLException;
 import java.nio.channels.ClosedChannelException;
-
-import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason.SESSION_COMPLETE;
-import static com.netflix.zuul.context.CommonContextKeys.NETTY_SERVER_CHANNEL_HANDLER_CONTEXT;
-import static com.netflix.zuul.netty.server.ClientRequestReceiver.ATTR_ZUUL_RESP;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_CLIENT_CANCELLED;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_CLIENT_TIMEOUT;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_LOCAL;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_LOCAL_IDLE_TIMEOUT;
 
 /**
  * Created by saroskar on 5/18/17.
@@ -77,7 +73,7 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
 
             // Replace NETTY_SERVER_CHANNEL_HANDLER_CONTEXT in SessionContext
             final SessionContext zuulCtx = zuulRequest.getContext();
-            zuulCtx.put(NETTY_SERVER_CHANNEL_HANDLER_CONTEXT, ctx);
+            zuulCtx.put(CommonContextKeys.NETTY_SERVER_CHANNEL_HANDLER_CONTEXT, ctx);
 
             requestFilterChain.filter(zuulRequest);
         } else if ((msg instanceof HttpContent) && (zuulRequest != null)) {
@@ -93,16 +89,17 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
     public final void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof CompleteEvent) {
             final CompleteEvent completeEvent = (CompleteEvent) evt;
-            fireEndpointFinish(completeEvent.getReason() != SESSION_COMPLETE, ctx);
+            fireEndpointFinish(
+                    completeEvent.getReason() != HttpLifecycleChannelHandler.CompleteReason.SESSION_COMPLETE, ctx);
         } else if (evt instanceof HttpRequestReadTimeoutEvent) {
-            sendResponse(FAILURE_CLIENT_TIMEOUT, 408, ctx);
+            sendResponse(ZuulStatusCategory.FAILURE_CLIENT_TIMEOUT, 408, ctx);
         } else if (evt instanceof IdleStateEvent) {
-            sendResponse(FAILURE_LOCAL_IDLE_TIMEOUT, 504, ctx);
+            sendResponse(ZuulStatusCategory.FAILURE_LOCAL_IDLE_TIMEOUT, 504, ctx);
         } else if (evt instanceof RequestCancelledEvent) {
             if (zuulRequest != null) {
                 zuulRequest.getContext().cancel();
                 StatusCategoryUtils.storeStatusCategoryIfNotAlreadyFailure(
-                        zuulRequest.getContext(), FAILURE_CLIENT_CANCELLED);
+                        zuulRequest.getContext(), ZuulStatusCategory.FAILURE_CLIENT_CANCELLED);
             }
             fireEndpointFinish(true, ctx);
             ctx.close();
@@ -147,7 +144,7 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
         // check if there are any response filters awaiting a buffered body
         if (zuulRequest != null && responseFilterChain.isFilterAwaitingBody(zuulRequest.getContext())) {
             HttpResponseMessage zuulResponse =
-                    ctx.channel().attr(ATTR_ZUUL_RESP).get();
+                    ctx.channel().attr(ClientRequestReceiver.ATTR_ZUUL_RESP).get();
             if (zuulResponse != null) {
                 // fire a last content into the filter chain to unblock any filters awaiting a buffered body
                 responseFilterChain.filter(zuulResponse, new DefaultLastHttpContent());
@@ -173,7 +170,7 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
             final SessionContext zuulCtx = zuulRequest.getContext();
             zuulCtx.setError(cause);
             zuulCtx.setShouldSendErrorResponse(true);
-            sendResponse(FAILURE_LOCAL, 500, ctx);
+            sendResponse(ZuulStatusCategory.FAILURE_LOCAL, 500, ctx);
         } else {
             fireEndpointFinish(true, ctx);
             ctx.close();

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
@@ -16,6 +16,7 @@
 
 package com.netflix.zuul.netty.server;
 
+import com.google.common.base.Preconditions;
 import com.netflix.config.CachedDynamicIntProperty;
 import com.netflix.netty.common.CloseOnIdleStateHandler;
 import com.netflix.netty.common.Http1ConnectionCloseHandler;
@@ -55,6 +56,7 @@ import com.netflix.zuul.netty.insights.PassportLoggingHandler;
 import com.netflix.zuul.netty.insights.PassportStateHttpServerHandler;
 import com.netflix.zuul.netty.insights.ServerStateHandler;
 import com.netflix.zuul.netty.server.ssl.SslHandshakeInfoHandler;
+import com.netflix.zuul.passport.PassportState;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
@@ -68,12 +70,6 @@ import io.netty.util.AttributeKey;
 
 import java.util.SortedSet;
 import java.util.concurrent.TimeUnit;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.netflix.zuul.passport.PassportState.FILTERS_INBOUND_END;
-import static com.netflix.zuul.passport.PassportState.FILTERS_INBOUND_START;
-import static com.netflix.zuul.passport.PassportState.FILTERS_OUTBOUND_END;
-import static com.netflix.zuul.passport.PassportState.FILTERS_OUTBOUND_START;
 
 /**
  * User: Mike Smith
@@ -166,7 +162,7 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
             ChannelConfig channelDependencies,
             ChannelGroup channels) {
         this.port = port;
-        checkNotNull(metricId, "metricId");
+        Preconditions.checkNotNull(metricId, "metricId");
         this.metricId = metricId;
         this.channelConfig = channelConfig;
         this.channelDependencies = channelDependencies;
@@ -312,8 +308,8 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
 
     protected void addZuulFilterChainHandler(final ChannelPipeline pipeline) {
         final ZuulFilter<HttpResponseMessage, HttpResponseMessage>[] responseFilters = getFilters(
-                new OutboundPassportStampingFilter(FILTERS_OUTBOUND_START),
-                new OutboundPassportStampingFilter(FILTERS_OUTBOUND_END));
+                new OutboundPassportStampingFilter(PassportState.FILTERS_OUTBOUND_START),
+                new OutboundPassportStampingFilter(PassportState.FILTERS_OUTBOUND_END));
 
         // response filter chain
         final ZuulFilterChainRunner<HttpResponseMessage> responseFilterChain =
@@ -324,8 +320,8 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
                 getEndpointRunner(responseFilterChain, filterUsageNotifier, filterLoader);
 
         final ZuulFilter<HttpRequestMessage, HttpRequestMessage>[] requestFilters = getFilters(
-                new InboundPassportStampingFilter(FILTERS_INBOUND_START),
-                new InboundPassportStampingFilter(FILTERS_INBOUND_END));
+                new InboundPassportStampingFilter(PassportState.FILTERS_INBOUND_START),
+                new InboundPassportStampingFilter(PassportState.FILTERS_INBOUND_END));
 
         // request filter chain | end point | response filter chain
         final ZuulFilterChainRunner<HttpRequestMessage> requestFilterChain =

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -31,6 +31,7 @@ import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpRequestMessageImpl;
 import com.netflix.zuul.message.http.HttpResponseMessage;
 import com.netflix.zuul.netty.ChannelUtils;
+import com.netflix.zuul.netty.server.http2.Http2OrHttpHandler;
 import com.netflix.zuul.netty.server.ssl.SslHandshakeInfoHandler;
 import com.netflix.zuul.passport.CurrentPassport;
 import com.netflix.zuul.passport.PassportState;
@@ -74,8 +75,6 @@ import java.util.regex.Pattern;
 
 import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
 import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
-import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason.SESSION_COMPLETE;
-import static com.netflix.zuul.netty.server.http2.Http2OrHttpHandler.PROTOCOL_NAME;
 
 /**
  * Created by saroskar on 1/6/17.
@@ -230,7 +229,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
                         zuulRequest.getContext(), ZuulStatusCategory.FAILURE_CLIENT_PIPELINE_REJECT);
             }
 
-            if (reason != SESSION_COMPLETE && zuulRequest != null) {
+            if (reason != CompleteReason.SESSION_COMPLETE && zuulRequest != null) {
                 final SessionContext zuulCtx = zuulRequest.getContext();
                 if (clientRequest != null) {
                     if (LOG.isInfoEnabled()) {
@@ -343,7 +342,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
         }
 
         // Decide if this is HTTP/1 or HTTP/2.
-        String protocol = channel.attr(PROTOCOL_NAME).get();
+        String protocol = channel.attr(Http2OrHttpHandler.PROTOCOL_NAME).get();
         if (protocol == null) {
             protocol = nativeRequest.protocolVersion().text();
         }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/Server.java
@@ -17,6 +17,7 @@
 package com.netflix.zuul.netty.server;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.config.DynamicBooleanProperty;
 import com.netflix.netty.common.CategorizedThreadFactory;
@@ -80,8 +81,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  *
@@ -192,10 +191,11 @@ public class Server {
             EventLoopConfig eventLoopConfig) {
         this.registry = Objects.requireNonNull(registry);
         this.addressesToInitializers = Collections.unmodifiableMap(new LinkedHashMap<>(addressesToInitializers));
-        this.serverStatusManager = checkNotNull(serverStatusManager, "serverStatusManager");
-        this.clientConnectionsShutdown = checkNotNull(clientConnectionsShutdown, "clientConnectionsShutdown");
-        this.eventLoopConfig = checkNotNull(eventLoopConfig, "eventLoopConfig");
-        this.eventLoopGroupMetrics = checkNotNull(eventLoopGroupMetrics, "eventLoopGroupMetrics");
+        this.serverStatusManager = Preconditions.checkNotNull(serverStatusManager, "serverStatusManager");
+        this.clientConnectionsShutdown =
+                Preconditions.checkNotNull(clientConnectionsShutdown, "clientConnectionsShutdown");
+        this.eventLoopConfig = Preconditions.checkNotNull(eventLoopConfig, "eventLoopConfig");
+        this.eventLoopGroupMetrics = Preconditions.checkNotNull(eventLoopGroupMetrics, "eventLoopGroupMetrics");
         this.jvmShutdownHook = new Thread(this::stop, "Zuul-JVM-shutdown-hook");
     }
 
@@ -209,10 +209,11 @@ public class Server {
             Thread jvmShutdownHook) {
         this.registry = Objects.requireNonNull(registry);
         this.addressesToInitializers = Collections.unmodifiableMap(new LinkedHashMap<>(addressesToInitializers));
-        this.serverStatusManager = checkNotNull(serverStatusManager, "serverStatusManager");
-        this.clientConnectionsShutdown = checkNotNull(clientConnectionsShutdown, "clientConnectionsShutdown");
-        this.eventLoopConfig = checkNotNull(eventLoopConfig, "eventLoopConfig");
-        this.eventLoopGroupMetrics = checkNotNull(eventLoopGroupMetrics, "eventLoopGroupMetrics");
+        this.serverStatusManager = Preconditions.checkNotNull(serverStatusManager, "serverStatusManager");
+        this.clientConnectionsShutdown =
+                Preconditions.checkNotNull(clientConnectionsShutdown, "clientConnectionsShutdown");
+        this.eventLoopConfig = Preconditions.checkNotNull(eventLoopConfig, "eventLoopConfig");
+        this.eventLoopGroupMetrics = Preconditions.checkNotNull(eventLoopGroupMetrics, "eventLoopGroupMetrics");
         this.jvmShutdownHook = jvmShutdownHook;
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2OrHttpHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2OrHttpHandler.java
@@ -19,6 +19,7 @@ package com.netflix.zuul.netty.server.http2;
 import com.netflix.netty.common.channel.config.ChannelConfig;
 import com.netflix.netty.common.channel.config.CommonChannelConfigKeys;
 import com.netflix.netty.common.http2.DynamicHttp2FrameLogger;
+import com.netflix.zuul.netty.server.BaseZuulChannelInitializer;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -35,8 +36,6 @@ import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.util.AttributeKey;
 
 import java.util.function.Consumer;
-
-import static com.netflix.zuul.netty.server.BaseZuulChannelInitializer.HTTP_CODEC_HANDLER_NAME;
 
 /**
  * Http2 Or Http Handler
@@ -109,7 +108,7 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
 
         // The frame codec MUST be in the pipeline.
         pipeline.addBefore("codec_placeholder", /* name= */ null, frameCodec);
-        pipeline.replace("codec_placeholder", HTTP_CODEC_HANDLER_NAME, multiplexHandler);
+        pipeline.replace("codec_placeholder", BaseZuulChannelInitializer.HTTP_CODEC_HANDLER_NAME, multiplexHandler);
     }
 
     private void configureHttp1(ChannelPipeline pipeline) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2SslChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2SslChannelInitializer.java
@@ -16,6 +16,7 @@
 
 package com.netflix.zuul.netty.server.http2;
 
+import com.google.common.base.Preconditions;
 import com.netflix.netty.common.Http2ConnectionCloseHandler;
 import com.netflix.netty.common.Http2ConnectionExpiryHandler;
 import com.netflix.netty.common.SwallowSomeHttp2ExceptionsHandler;
@@ -33,8 +34,6 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * User: Mike Smith
@@ -63,7 +62,7 @@ public final class Http2SslChannelInitializer extends BaseZuulChannelInitializer
     public Http2SslChannelInitializer(
             String metricId, ChannelConfig channelConfig, ChannelConfig channelDependencies, ChannelGroup channels) {
         super(metricId, channelConfig, channelDependencies, channels);
-        this.metricId = checkNotNull(metricId, "metricId");
+        this.metricId = Preconditions.checkNotNull(metricId, "metricId");
 
         this.swallowSomeHttp2ExceptionsHandler = new SwallowSomeHttp2ExceptionsHandler(registry);
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2StreamErrorHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2StreamErrorHandler.java
@@ -21,8 +21,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.http2.DefaultHttp2ResetFrame;
 import io.netty.handler.codec.http2.Http2Error;
-
-import static io.netty.handler.codec.http2.Http2Exception.StreamException;
+import io.netty.handler.codec.http2.Http2Exception;
 
 /**
  * Author: Susheel Aroskar
@@ -33,8 +32,8 @@ public class Http2StreamErrorHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        if (cause instanceof StreamException) {
-            StreamException streamEx = (StreamException) cause;
+        if (cause instanceof Http2Exception.StreamException) {
+            Http2Exception.StreamException streamEx = (Http2Exception.StreamException) cause;
             ctx.writeAndFlush(new DefaultHttp2ResetFrame(streamEx.error()));
         } else if (cause instanceof DecoderException) {
             ctx.writeAndFlush(new DefaultHttp2ResetFrame(Http2Error.PROTOCOL_ERROR));

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2StreamInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2StreamInitializer.java
@@ -33,8 +33,6 @@ import io.netty.util.AttributeKey;
 
 import java.util.function.Consumer;
 
-import static com.netflix.zuul.netty.server.http2.Http2OrHttpHandler.PROTOCOL_NAME;
-
 /**
  * TODO - can this be done when we create the Http2StreamChannelBootstrap instead now?
  */
@@ -98,7 +96,7 @@ public class Http2StreamInitializer extends ChannelInboundHandlerAdapter {
             SourceAddressChannelHandler.ATTR_SERVER_LOCAL_ADDRESS,
             SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT,
             SourceAddressChannelHandler.ATTR_PROXY_PROTOCOL_DESTINATION_ADDRESS,
-            PROTOCOL_NAME,
+            Http2OrHttpHandler.PROTOCOL_NAME,
             SslHandshakeInfoHandler.ATTR_SSL_INFO,
             HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE,
             HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION,

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ssl/SslHandshakeInfoHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ssl/SslHandshakeInfoHandler.java
@@ -17,6 +17,7 @@
 package com.netflix.zuul.netty.server.ssl;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.netty.common.ssl.SslHandshakeInfo;
 import com.netflix.spectator.api.NoopRegistry;
@@ -43,8 +44,6 @@ import java.security.cert.X509Certificate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * Stores info about the client and server's SSL certificates in the context, after a successful handshake.
  * <p>
@@ -64,7 +63,7 @@ public class SslHandshakeInfoHandler extends ChannelInboundHandlerAdapter {
     private final boolean isSSlFromIntermediary;
 
     public SslHandshakeInfoHandler(Registry spectatorRegistry, boolean isSSlFromIntermediary) {
-        this.spectatorRegistry = checkNotNull(spectatorRegistry);
+        this.spectatorRegistry = Preconditions.checkNotNull(spectatorRegistry);
         this.isSSlFromIntermediary = isSSlFromIntermediary;
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOrigin.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/BasicNettyOrigin.java
@@ -38,6 +38,7 @@ import com.netflix.zuul.niws.RequestAttempt;
 import com.netflix.zuul.passport.CurrentPassport;
 import com.netflix.zuul.stats.status.StatusCategory;
 import com.netflix.zuul.stats.status.StatusCategoryUtils;
+import com.netflix.zuul.stats.status.ZuulStatusCategory;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Promise;
 
@@ -46,10 +47,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_ORIGIN;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.FAILURE_ORIGIN_THROTTLED;
-import static com.netflix.zuul.stats.status.ZuulStatusCategory.SUCCESS;
 
 /**
  * Netty Origin basic implementation that can be used for most apps, with the more complex methods having no-op
@@ -179,11 +176,11 @@ public class BasicNettyOrigin implements NettyOrigin {
             zuulCtx.put(CommonContextKeys.ORIGIN_STATUS, originStatusCode);
 
             // Mark origin StatusCategory based on http status code.
-            StatusCategory originNfs = SUCCESS;
+            StatusCategory originNfs = ZuulStatusCategory.SUCCESS;
             if (originStatusCode == 503) {
-                originNfs = FAILURE_ORIGIN_THROTTLED;
+                originNfs = ZuulStatusCategory.FAILURE_ORIGIN_THROTTLED;
             } else if (StatusCategoryUtils.isResponseHttpErrorStatus(originStatusCode)) {
-                originNfs = FAILURE_ORIGIN;
+                originNfs = ZuulStatusCategory.FAILURE_ORIGIN;
             }
             StatusCategoryUtils.setOriginStatusCategory(zuulCtx, originNfs);
             // Choose the zuul StatusCategory based on the origin one...

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulEndPointRunnerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulEndPointRunnerTest.java
@@ -22,6 +22,7 @@ import com.netflix.zuul.Filter;
 import com.netflix.zuul.FilterCategory;
 import com.netflix.zuul.FilterLoader;
 import com.netflix.zuul.FilterUsageNotifier;
+import com.netflix.zuul.context.CommonContextKeys;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.filters.Endpoint;
 import com.netflix.zuul.filters.FilterType;
@@ -40,9 +41,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import rx.Observable;
 
-import static com.netflix.zuul.context.CommonContextKeys.NETTY_SERVER_CHANNEL_HANDLER_CONTEXT;
-import static com.netflix.zuul.context.CommonContextKeys.ZUUL_ENDPOINT;
-import static com.netflix.zuul.netty.filter.ZuulEndPointRunner.DEFAULT_ERROR_ENDPOINT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -66,7 +64,7 @@ class ZuulEndPointRunnerTest {
         usageNotifier = mock(FilterUsageNotifier.class);
 
         filterLoader = mock(FilterLoader.class);
-        when(filterLoader.getFilterByNameAndType(DEFAULT_ERROR_ENDPOINT.get(), FilterType.ENDPOINT))
+        when(filterLoader.getFilterByNameAndType(ZuulEndPointRunner.DEFAULT_ERROR_ENDPOINT.get(), FilterType.ENDPOINT))
                 .thenReturn(new ErrorEndpoint());
         when(filterLoader.getFilterByNameAndType(BASIC_ENDPOINT, FilterType.ENDPOINT))
                 .thenReturn(new BasicEndpoint());
@@ -79,7 +77,7 @@ class ZuulEndPointRunnerTest {
         Headers headers = new Headers();
         ChannelHandlerContext chc = mock(ChannelHandlerContext.class);
         when(chc.executor()).thenReturn(ImmediateEventExecutor.INSTANCE);
-        context.put(NETTY_SERVER_CHANNEL_HANDLER_CONTEXT, chc);
+        context.put(CommonContextKeys.NETTY_SERVER_CHANNEL_HANDLER_CONTEXT, chc);
         request = new HttpRequestMessageImpl(
                 context,
                 "http",
@@ -98,10 +96,10 @@ class ZuulEndPointRunnerTest {
     void nonErrorEndpoint() {
         request.getContext().setShouldSendErrorResponse(false);
         request.getContext().setEndpoint(BASIC_ENDPOINT);
-        assertNull(request.getContext().get(ZUUL_ENDPOINT));
+        assertNull(request.getContext().get(CommonContextKeys.ZUUL_ENDPOINT));
         endpointRunner.filter(request);
         final ZuulFilter<HttpRequestMessage, HttpResponseMessage> filter =
-                request.getContext().get(ZUUL_ENDPOINT);
+                request.getContext().get(CommonContextKeys.ZUUL_ENDPOINT);
         assertTrue(filter instanceof BasicEndpoint);
 
         ArgumentCaptor<HttpResponseMessage> captor = ArgumentCaptor.forClass(HttpResponseMessage.class);
@@ -115,9 +113,9 @@ class ZuulEndPointRunnerTest {
     @Test
     void errorEndpoint() {
         request.getContext().setShouldSendErrorResponse(true);
-        assertNull(request.getContext().get(ZUUL_ENDPOINT));
+        assertNull(request.getContext().get(CommonContextKeys.ZUUL_ENDPOINT));
         endpointRunner.filter(request);
-        final ZuulFilter filter = request.getContext().get(ZUUL_ENDPOINT);
+        final ZuulFilter filter = request.getContext().get(CommonContextKeys.ZUUL_ENDPOINT);
         assertTrue(filter instanceof ErrorEndpoint);
 
         ArgumentCaptor<HttpResponseMessage> captor = ArgumentCaptor.forClass(HttpResponseMessage.class);

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunnerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunnerTest.java
@@ -18,6 +18,7 @@ package com.netflix.zuul.netty.filter;
 import com.netflix.spectator.api.Registry;
 import com.netflix.zuul.ExecutionStatus;
 import com.netflix.zuul.FilterUsageNotifier;
+import com.netflix.zuul.context.CommonContextKeys;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.filters.FilterType;
 import com.netflix.zuul.filters.ZuulFilter;
@@ -35,7 +36,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import rx.Observable;
 
-import static com.netflix.zuul.context.CommonContextKeys.NETTY_SERVER_CHANNEL_HANDLER_CONTEXT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -56,7 +56,7 @@ class ZuulFilterChainRunnerTest {
         Headers headers = new Headers();
         ChannelHandlerContext chc = mock(ChannelHandlerContext.class);
         when(chc.executor()).thenReturn(ImmediateEventExecutor.INSTANCE);
-        context.put(NETTY_SERVER_CHANNEL_HANDLER_CONTEXT, chc);
+        context.put(CommonContextKeys.NETTY_SERVER_CHANNEL_HANDLER_CONTEXT, chc);
         request = new HttpRequestMessageImpl(
                 context,
                 "http",

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/IoUringTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/IoUringTest.java
@@ -44,8 +44,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -136,7 +136,7 @@ class IoUringTest {
             checkConnection(inetAddress.getPort());
         });
 
-        await().atMost(1, SECONDS).until(() -> ioUringChannels.size() == 2);
+        await().atMost(1, TimeUnit.SECONDS).until(() -> ioUringChannels.size() == 2);
 
         s.stop();
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ServerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ServerTest.java
@@ -41,8 +41,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -108,7 +108,7 @@ class ServerTest {
             checkConnection(port);
         }
 
-        await().atMost(1, SECONDS).until(() -> nioChannels.size() == 2);
+        await().atMost(1, TimeUnit.SECONDS).until(() -> nioChannels.size() == 2);
 
         s.stop();
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/SocketAddressPropertyTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/SocketAddressPropertyTest.java
@@ -26,12 +26,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
 
-import static com.netflix.zuul.netty.server.SocketAddressProperty.BindType.ANY;
-import static com.netflix.zuul.netty.server.SocketAddressProperty.BindType.ANY_LOCAL;
-import static com.netflix.zuul.netty.server.SocketAddressProperty.BindType.IPV4_ANY;
-import static com.netflix.zuul.netty.server.SocketAddressProperty.BindType.IPV4_LOCAL;
-import static com.netflix.zuul.netty.server.SocketAddressProperty.BindType.IPV6_ANY;
-import static com.netflix.zuul.netty.server.SocketAddressProperty.BindType.IPV6_LOCAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -156,7 +150,13 @@ class SocketAddressPropertyTest {
 
     @Test
     void failsOnBadPort() {
-        for (BindType type : Arrays.asList(ANY, IPV4_ANY, IPV6_ANY, ANY_LOCAL, IPV4_LOCAL, IPV6_LOCAL)) {
+        for (BindType type : Arrays.asList(
+                BindType.ANY,
+                BindType.IPV4_ANY,
+                BindType.IPV6_ANY,
+                BindType.ANY_LOCAL,
+                BindType.IPV4_LOCAL,
+                BindType.IPV6_LOCAL)) {
             IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
                 SocketAddressProperty.Decoder.INSTANCE.apply(type.name() + "=bogus");
             });

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
@@ -31,7 +31,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 
-import static com.netflix.zuul.netty.timeouts.OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -74,7 +73,7 @@ class OriginTimeoutManagerTest {
     void computeReadTimeout_default() {
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
 
-        assertEquals(MAX_OUTBOUND_READ_TIMEOUT_MS.get(), timeout.toMillis());
+        assertEquals(OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS.get(), timeout.toMillis());
     }
 
     @Test
@@ -127,11 +126,15 @@ class OriginTimeoutManagerTest {
 
     @Test
     void computeReadTimeout_bolth_enforceMax() {
-        requestConfig.set(CommonClientConfigKey.ReadTimeout, (int) MAX_OUTBOUND_READ_TIMEOUT_MS.get() + 1000);
-        originConfig.set(CommonClientConfigKey.ReadTimeout, (int) MAX_OUTBOUND_READ_TIMEOUT_MS.get() + 10000);
+        requestConfig.set(
+                CommonClientConfigKey.ReadTimeout,
+                (int) OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS.get() + 1000);
+        originConfig.set(
+                CommonClientConfigKey.ReadTimeout,
+                (int) OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS.get() + 10000);
 
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
 
-        assertEquals(MAX_OUTBOUND_READ_TIMEOUT_MS.get(), timeout.toMillis());
+        assertEquals(OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS.get(), timeout.toMillis());
     }
 }


### PR DESCRIPTION
To assist with usage tracking, favor explicit import using qualified references over static member property imports.