### PR TITLE
Add StatusCategory reason

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/stats/status/StatusCategory.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/stats/status/StatusCategory.java
@@ -27,5 +27,7 @@ public interface StatusCategory {
 
     StatusCategoryGroup getGroup();
 
+    String getReason();
+
     String name();
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/stats/status/ZuulStatusCategory.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/stats/status/ZuulStatusCategory.java
@@ -39,38 +39,46 @@ package com.netflix.zuul.stats.status;
  *    LOCAL
  */
 public enum ZuulStatusCategory implements StatusCategory {
-    SUCCESS(ZuulStatusCategoryGroup.SUCCESS, 1),
-    SUCCESS_NOT_FOUND(ZuulStatusCategoryGroup.SUCCESS, 3), // This is set on for all 404 responses
+    SUCCESS(ZuulStatusCategoryGroup.SUCCESS, 1, "Successfully proxied"),
+    SUCCESS_NOT_FOUND(
+            ZuulStatusCategoryGroup.SUCCESS,
+            3,
+            "Successful with no resource found"), // This is set on for all 404 responses
 
-    SUCCESS_LOCAL_NOTSET(ZuulStatusCategoryGroup.SUCCESS, 4), // This is set on the SessionContext as the default value.
-    SUCCESS_LOCAL_NO_ROUTE(ZuulStatusCategoryGroup.SUCCESS, 5),
+    SUCCESS_LOCAL_NOTSET(
+            ZuulStatusCategoryGroup.SUCCESS,
+            4,
+            "Default status"), // This is set on the SessionContext as the default value.
+    SUCCESS_LOCAL_NO_ROUTE(ZuulStatusCategoryGroup.SUCCESS, 5, "Successful with no origin determined"),
 
-    FAILURE_LOCAL(ZuulStatusCategoryGroup.FAILURE, 1),
+    FAILURE_LOCAL(ZuulStatusCategoryGroup.FAILURE, 1, "Failed internally"),
     FAILURE_LOCAL_THROTTLED_ORIGIN_SERVER_MAXCONN(
-            ZuulStatusCategoryGroup.FAILURE, 7), // NIWS client throttling based on max connections per origin server.
+            ZuulStatusCategoryGroup.FAILURE, 7, "Throttled due to reaching max number of connections to origin"),
     FAILURE_LOCAL_THROTTLED_ORIGIN_CONCURRENCY(
-            ZuulStatusCategoryGroup.FAILURE, 8), // when zuul throttles for a vip because concurrency is too high.
-    FAILURE_LOCAL_IDLE_TIMEOUT(ZuulStatusCategoryGroup.FAILURE, 9),
+            ZuulStatusCategoryGroup.FAILURE, 8, "Throttled due to reaching concurrency limit to origin"),
+    FAILURE_LOCAL_IDLE_TIMEOUT(ZuulStatusCategoryGroup.FAILURE, 9, "Idle timeout due to channel inactivity"),
 
-    FAILURE_CLIENT_BAD_REQUEST(ZuulStatusCategoryGroup.FAILURE, 12),
-    FAILURE_CLIENT_CANCELLED(
-            ZuulStatusCategoryGroup.FAILURE, 13), // client abandoned/closed the connection before origin responded.
-    FAILURE_CLIENT_PIPELINE_REJECT(ZuulStatusCategoryGroup.FAILURE, 17),
-    FAILURE_CLIENT_TIMEOUT(ZuulStatusCategoryGroup.FAILURE, 18),
+    FAILURE_CLIENT_BAD_REQUEST(ZuulStatusCategoryGroup.FAILURE, 12, "Invalid request provided"),
+    FAILURE_CLIENT_CANCELLED(ZuulStatusCategoryGroup.FAILURE, 13, "Client abandoned/closed the connection"),
+    FAILURE_CLIENT_PIPELINE_REJECT(ZuulStatusCategoryGroup.FAILURE, 17, "Client rejected due to HTTP Pipelining"),
+    FAILURE_CLIENT_TIMEOUT(ZuulStatusCategoryGroup.FAILURE, 18, "Timeout reading the client request"),
 
-    FAILURE_ORIGIN(ZuulStatusCategoryGroup.FAILURE, 2),
-    FAILURE_ORIGIN_READ_TIMEOUT(ZuulStatusCategoryGroup.FAILURE, 3),
-    FAILURE_ORIGIN_CONNECTIVITY(ZuulStatusCategoryGroup.FAILURE, 4),
-    FAILURE_ORIGIN_THROTTLED(ZuulStatusCategoryGroup.FAILURE, 6), // Throttled by origin by returning 503
-    FAILURE_ORIGIN_NO_SERVERS(ZuulStatusCategoryGroup.FAILURE, 14), // No UP origin servers available in Discovery.
-    FAILURE_ORIGIN_RESET_CONNECTION(ZuulStatusCategoryGroup.FAILURE, 15);
+    FAILURE_ORIGIN(ZuulStatusCategoryGroup.FAILURE, 2, "Origin returned an error status"),
+    FAILURE_ORIGIN_READ_TIMEOUT(ZuulStatusCategoryGroup.FAILURE, 3, "Timeout reading the response from origin"),
+    FAILURE_ORIGIN_CONNECTIVITY(ZuulStatusCategoryGroup.FAILURE, 4, "Connection to origin failed"),
+    FAILURE_ORIGIN_THROTTLED(ZuulStatusCategoryGroup.FAILURE, 6, "Throttled by origin returning 503 status"),
+    FAILURE_ORIGIN_NO_SERVERS(ZuulStatusCategoryGroup.FAILURE, 14, "No UP origin servers available in Discovery"),
+    FAILURE_ORIGIN_RESET_CONNECTION(
+            ZuulStatusCategoryGroup.FAILURE, 15, "Connection reset on an established origin connection");
 
     private final StatusCategoryGroup group;
     private final String id;
+    private final String reason;
 
-    ZuulStatusCategory(StatusCategoryGroup group, int index) {
+    ZuulStatusCategory(StatusCategoryGroup group, int index, String reason) {
         this.group = group;
         this.id = (group.getId() + "_" + index).intern();
+        this.reason = reason;
     }
 
     @Override
@@ -81,5 +89,10 @@ public enum ZuulStatusCategory implements StatusCategory {
     @Override
     public StatusCategoryGroup getGroup() {
         return group;
+    }
+
+    @Override
+    public String getReason() {
+        return reason;
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/stats/status/ZuulStatusCategory.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/stats/status/ZuulStatusCategory.java
@@ -49,7 +49,7 @@ public enum ZuulStatusCategory implements StatusCategory {
             ZuulStatusCategoryGroup.SUCCESS,
             4,
             "Default status"), // This is set on the SessionContext as the default value.
-    SUCCESS_LOCAL_NO_ROUTE(ZuulStatusCategoryGroup.SUCCESS, 5, "Successful with no origin determined"),
+    SUCCESS_LOCAL_NO_ROUTE(ZuulStatusCategoryGroup.SUCCESS, 5, "Unable to determine an origin to handle request"),
 
     FAILURE_LOCAL(ZuulStatusCategoryGroup.FAILURE, 1, "Failed internally"),
     FAILURE_LOCAL_THROTTLED_ORIGIN_SERVER_MAXCONN(

--- a/zuul-core/src/main/java/com/netflix/zuul/stats/status/ZuulStatusCategory.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/stats/status/ZuulStatusCategory.java
@@ -43,7 +43,7 @@ public enum ZuulStatusCategory implements StatusCategory {
     SUCCESS_NOT_FOUND(
             ZuulStatusCategoryGroup.SUCCESS,
             3,
-            "Successful with no resource found"), // This is set on for all 404 responses
+            "Successfully proxied, origin responded with no resource found"), // This is set on for all 404 responses
 
     SUCCESS_LOCAL_NOTSET(
             ZuulStatusCategoryGroup.SUCCESS,


### PR DESCRIPTION
Add a `reason` field to `StatusCategory` with default explanations for each `ZuulStatusCategory` type.