### PR TITLE
Add status category reason tracking

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
@@ -39,8 +39,12 @@ import java.util.Map;
 public class CommonContextKeys {
 
     public static final SessionContext.Key<StatusCategory> STATUS_CATEGORY = SessionContext.newKey("status_category");
+    public static final SessionContext.Key<String> STATUS_CATEGORY_REASON =
+            SessionContext.newKey("status_category_reason");
     public static final SessionContext.Key<StatusCategory> ORIGIN_STATUS_CATEGORY =
             SessionContext.newKey("origin_status_category");
+    public static final SessionContext.Key<String> ORIGIN_STATUS_CATEGORY_REASON =
+            SessionContext.newKey("origin_status_category_reason");
     public static final SessionContext.Key<Integer> ORIGIN_STATUS = SessionContext.newKey("origin_status");
     public static final SessionContext.Key<RequestAttempts> REQUEST_ATTEMPTS =
             SessionContext.newKey("request_attempts");

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -1122,7 +1122,10 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
             SessionContext context, HttpRequestMessage request, String restClientName, Origin primaryOrigin) {
         if (primaryOrigin == null) {
             // If no origin found then add specific error-cause metric tag, and throw an exception with 404 status.
-            StatusCategoryUtils.setStatusCategory(context, ZuulStatusCategory.SUCCESS_LOCAL_NO_ROUTE);
+            StatusCategoryUtils.setStatusCategory(
+                    context,
+                    ZuulStatusCategory.SUCCESS_LOCAL_NO_ROUTE,
+                    "Unable to find an origin client matching `" + restClientName + "` to handle request");
             String causeName = "RESTCLIENT_NOTFOUND";
             originNotFound(context, causeName);
             ZuulException ze = new ZuulException(

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -147,7 +147,9 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
                         ChannelUtils.channelInfoForLogging(ctx.channel()),
                         clientRequest.decoderResult().cause());
                 StatusCategoryUtils.setStatusCategory(
-                        zuulRequest.getContext(), ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
+                        zuulRequest.getContext(),
+                        ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST,
+                        "Invalid request provided: Decode failure");
                 RejectionUtils.rejectByClosingConnection(
                         ctx,
                         ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST,
@@ -163,7 +165,10 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
                 final ZuulException ze = new ZuulException(errorMsg);
                 ze.setStatusCode(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE.code());
                 StatusCategoryUtils.setStatusCategory(
-                        zuulRequest.getContext(), ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
+                        zuulRequest.getContext(),
+                        ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST,
+                        "Invalid request provided: Request body size " + zuulRequest.getBodyLength()
+                                + " above limit of " + zuulRequest.getMaxBodySize());
                 zuulRequest.getContext().setError(ze);
                 zuulRequest.getContext().setShouldSendErrorResponse(true);
             } else if (zuulRequest
@@ -179,7 +184,9 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
                 final ZuulException ze = new ZuulException("Multiple Host headers");
                 ze.setStatusCode(HttpResponseStatus.BAD_REQUEST.code());
                 StatusCategoryUtils.setStatusCategory(
-                        zuulRequest.getContext(), ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
+                        zuulRequest.getContext(),
+                        ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST,
+                        "Invalid request provided: Multiple Host headers");
                 zuulRequest.getContext().setError(ze);
                 zuulRequest.getContext().setShouldSendErrorResponse(true);
             }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -168,7 +168,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
                         zuulRequest.getContext(),
                         ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST,
                         "Invalid request provided: Request body size " + zuulRequest.getBodyLength()
-                                + " above limit of " + zuulRequest.getMaxBodySize());
+                                + " is above limit of " + zuulRequest.getMaxBodySize());
                 zuulRequest.getContext().setError(ze);
                 zuulRequest.getContext().setShouldSendErrorResponse(true);
             } else if (zuulRequest

--- a/zuul-core/src/main/java/com/netflix/zuul/stats/status/StatusCategoryUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/stats/status/StatusCategoryUtils.java
@@ -20,8 +20,6 @@ import com.netflix.zuul.context.CommonContextKeys;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.ZuulMessage;
 import com.netflix.zuul.message.http.HttpResponseMessage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -31,7 +29,6 @@ import javax.annotation.Nullable;
  * Time: 2:48 PM
  */
 public class StatusCategoryUtils {
-    private static final Logger LOG = LoggerFactory.getLogger(StatusCategoryUtils.class);
 
     public static StatusCategory getStatusCategory(ZuulMessage msg) {
         return getStatusCategory(msg.getContext());
@@ -42,12 +39,23 @@ public class StatusCategoryUtils {
         return ctx.get(CommonContextKeys.STATUS_CATEGORY);
     }
 
+    @Nullable
+    public static String getStatusCategoryReason(SessionContext ctx) {
+        return ctx.get(CommonContextKeys.STATUS_CATEGORY_REASON);
+    }
+
     public static void setStatusCategory(SessionContext ctx, StatusCategory statusCategory) {
+        setStatusCategory(ctx, statusCategory, statusCategory.getReason());
+    }
+
+    public static void setStatusCategory(SessionContext ctx, StatusCategory statusCategory, String reason) {
         ctx.put(CommonContextKeys.STATUS_CATEGORY, statusCategory);
+        ctx.put(CommonContextKeys.STATUS_CATEGORY_REASON, reason);
     }
 
     public static void clearStatusCategory(SessionContext ctx) {
         ctx.remove(CommonContextKeys.STATUS_CATEGORY);
+        ctx.remove(CommonContextKeys.STATUS_CATEGORY_REASON);
     }
 
     @Nullable
@@ -55,12 +63,23 @@ public class StatusCategoryUtils {
         return ctx.get(CommonContextKeys.ORIGIN_STATUS_CATEGORY);
     }
 
+    @Nullable
+    public static String getOriginStatusCategoryReason(SessionContext ctx) {
+        return ctx.get(CommonContextKeys.ORIGIN_STATUS_CATEGORY_REASON);
+    }
+
     public static void setOriginStatusCategory(SessionContext ctx, StatusCategory statusCategory) {
+        setOriginStatusCategory(ctx, statusCategory, statusCategory.getReason());
+    }
+
+    public static void setOriginStatusCategory(SessionContext ctx, StatusCategory statusCategory, String reason) {
         ctx.put(CommonContextKeys.ORIGIN_STATUS_CATEGORY, statusCategory);
+        ctx.put(CommonContextKeys.ORIGIN_STATUS_CATEGORY_REASON, reason);
     }
 
     public static void clearOriginStatusCategory(SessionContext ctx) {
         ctx.remove(CommonContextKeys.ORIGIN_STATUS_CATEGORY);
+        ctx.remove(CommonContextKeys.ORIGIN_STATUS_CATEGORY_REASON);
     }
 
     public static boolean isResponseHttpErrorStatus(HttpResponseMessage response) {

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
@@ -228,6 +228,9 @@ class ClientRequestReceiverTest {
         assertNotNull(result.getContext().getError());
         assertTrue(result.getContext().getError().getMessage().contains("too large"));
         assertTrue(result.getContext().shouldSendErrorResponse());
+        assertEquals(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST, StatusCategoryUtils.getStatusCategory(result));
+        assertTrue(StatusCategoryUtils.getStatusCategoryReason(result.getContext())
+                .startsWith("Invalid request provided: Request body size "));
         channel.close();
     }
 
@@ -264,6 +267,9 @@ class ClientRequestReceiverTest {
         assertEquals(
                 ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST,
                 StatusCategoryUtils.getStatusCategory(request.getContext()));
+        assertEquals(
+                "Invalid request provided: Decode failure",
+                StatusCategoryUtils.getStatusCategoryReason(request.getContext()));
     }
 
     @Test
@@ -292,6 +298,9 @@ class ClientRequestReceiverTest {
         SessionContext context = request.getContext();
         assertEquals(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST, StatusCategoryUtils.getStatusCategory(context));
         assertEquals("Multiple Host headers", context.getError().getMessage());
+        assertEquals(
+                "Invalid request provided: Multiple Host headers",
+                StatusCategoryUtils.getStatusCategoryReason(context));
     }
 
     @Test


### PR DESCRIPTION
Added `status_category_reason` and `origin_status_category_reason` session context keys & tracking via `StatusCategoryUtils`. Annotate better reason info for `ClientRequestReceiver` error causes.