### PR TITLE
Change access modifier for teardown method

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushRegistrationHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushRegistrationHandler.java
@@ -76,7 +76,7 @@ public class PushRegistrationHandler extends ChannelInboundHandlerAdapter {
         return (authEvent != null && authEvent.isSuccess());
     }
 
-    private void tearDown() {
+    protected void tearDown() {
         if (!destroyed.getAndSet(true)) {
             if (authEvent != null) {
                 // We should only remove the PushConnection entry from the registry if it's still this pushConnection.


### PR DESCRIPTION
Setting tearDown method to protected to allow subclasses to override the behavior. 