### PR TITLE
Update Headers.java

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
@@ -581,7 +581,10 @@ public final class Headers {
 
         return asMap().equals(other.asMap());
     }
-    /* asMap is an expensive function, use only when necessary. Avoid calling on a hot path. */
+    
+    /** 
+    * asMap is an expensive function, use only when necessary. Avoid calling on a hot path. 
+    */
     private Map<String, List<String>> asMap() {
         Map<String, List<String>> map = new LinkedHashMap<>(size());
         for (int i = 0; i < size(); i++) {

--- a/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
@@ -581,7 +581,7 @@ public final class Headers {
 
         return asMap().equals(other.asMap());
     }
-
+    /* asMap is an expensive function, use only when necessary. Avoid calling on a hot path. */
     private Map<String, List<String>> asMap() {
         Map<String, List<String>> map = new LinkedHashMap<>(size());
         for (int i = 0; i < size(); i++) {


### PR DESCRIPTION
asMap() in zuul/message/Headers.java is related to many operations described as expensive (such as toString, hashing). Add a comment to asMap() to better communicate this high computational complexity.