### PR TITLE
Upgrade to Netty 4.1.106

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 versions_groovy=3.0.19
 versions_ribbon=2.4.4
-versions_netty=4.1.105.Final
+versions_netty=4.1.106.Final
 versions_netty_io_uring=0.0.24.Final
 versions_brotli4j=1.13.0
 release.scope=patch

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -202,10 +202,10 @@
             "locked": "0.0.24.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final"
+            "locked": "4.1.106.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -223,7 +223,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -233,26 +233,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -271,7 +271,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -279,7 +279,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -287,7 +287,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -304,33 +304,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -659,10 +659,10 @@
             "locked": "0.0.24.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final"
+            "locked": "4.1.106.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -680,7 +680,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -690,26 +690,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -728,7 +728,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -736,7 +736,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -744,7 +744,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -761,33 +761,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1207,10 +1207,10 @@
             "locked": "0.0.24.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final"
+            "locked": "4.1.106.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1228,7 +1228,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -1238,26 +1238,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1276,7 +1276,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -1284,7 +1284,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1305,7 +1305,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1322,33 +1322,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1915,10 +1915,10 @@
             "locked": "0.0.24.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final"
+            "locked": "4.1.106.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1936,7 +1936,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -1946,26 +1946,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1984,7 +1984,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -1992,7 +1992,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2013,7 +2013,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2030,33 +2030,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2399,10 +2399,10 @@
             "locked": "0.0.24.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final"
+            "locked": "4.1.106.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2420,7 +2420,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2430,26 +2430,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2468,7 +2468,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -2476,7 +2476,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2484,7 +2484,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2501,33 +2501,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3012,10 +3012,10 @@
             "locked": "0.0.24.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final"
+            "locked": "4.1.106.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3033,7 +3033,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -3043,26 +3043,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3081,7 +3081,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -3089,7 +3089,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3110,7 +3110,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3127,33 +3127,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -222,13 +222,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -241,7 +241,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -250,7 +250,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -258,14 +258,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -280,7 +280,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -289,7 +289,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -297,7 +297,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -309,7 +309,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -825,13 +825,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -844,7 +844,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -853,7 +853,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -861,14 +861,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -883,7 +883,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -892,7 +892,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -900,7 +900,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -912,7 +912,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -1543,13 +1543,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1568,7 +1568,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -1578,14 +1578,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1593,14 +1593,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1620,7 +1620,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1629,7 +1629,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1651,7 +1651,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1669,35 +1669,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2526,13 +2526,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2551,7 +2551,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2561,14 +2561,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2576,14 +2576,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2603,7 +2603,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2612,7 +2612,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2634,7 +2634,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2652,35 +2652,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3333,13 +3333,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3352,7 +3352,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -3361,7 +3361,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3369,14 +3369,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3391,7 +3391,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3400,7 +3400,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3408,7 +3408,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3420,7 +3420,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -4082,13 +4082,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4107,7 +4107,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -4117,14 +4117,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4132,14 +4132,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4159,7 +4159,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4168,7 +4168,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -4190,7 +4190,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4208,35 +4208,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -216,13 +216,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -235,7 +235,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -244,7 +244,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -252,14 +252,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -274,7 +274,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -283,7 +283,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -291,7 +291,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -303,7 +303,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -622,13 +622,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -641,7 +641,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -650,7 +650,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -658,14 +658,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -680,7 +680,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -689,7 +689,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -697,7 +697,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -709,7 +709,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -1125,13 +1125,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1150,7 +1150,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -1160,14 +1160,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1175,14 +1175,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1202,7 +1202,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1211,7 +1211,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1233,7 +1233,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1251,35 +1251,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1859,13 +1859,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1884,7 +1884,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -1894,14 +1894,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1909,14 +1909,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1936,7 +1936,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1945,7 +1945,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1967,7 +1967,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1985,35 +1985,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2380,13 +2380,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2399,7 +2399,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -2408,7 +2408,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2416,14 +2416,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2438,7 +2438,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2447,7 +2447,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2455,7 +2455,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2467,7 +2467,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -2943,13 +2943,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2968,7 +2968,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2978,14 +2978,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2993,14 +2993,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3020,7 +3020,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3029,7 +3029,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3051,7 +3051,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3069,35 +3069,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -311,13 +311,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -336,7 +336,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -346,14 +346,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -361,14 +361,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -388,7 +388,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -397,7 +397,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -419,7 +419,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -437,35 +437,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -828,13 +828,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -848,7 +848,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -857,7 +857,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -865,14 +865,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -888,7 +888,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -897,7 +897,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -905,7 +905,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -918,13 +918,13 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1251,13 +1251,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1271,7 +1271,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -1280,7 +1280,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1288,14 +1288,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1311,7 +1311,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1320,7 +1320,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1328,7 +1328,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1341,13 +1341,13 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1880,13 +1880,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1905,7 +1905,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -1915,14 +1915,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1930,14 +1930,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1957,7 +1957,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1966,7 +1966,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1988,7 +1988,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2006,35 +2006,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2942,13 +2942,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2967,7 +2967,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2977,14 +2977,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2992,14 +2992,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3019,7 +3019,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3028,7 +3028,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3050,7 +3050,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3068,35 +3068,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3582,13 +3582,13 @@
             "locked": "0.0.24.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3603,7 +3603,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -3612,7 +3612,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3620,14 +3620,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3644,7 +3644,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3653,7 +3653,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3661,7 +3661,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3675,13 +3675,13 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -4568,13 +4568,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4593,7 +4593,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -4603,14 +4603,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4618,14 +4618,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4645,7 +4645,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4654,7 +4654,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -4676,7 +4676,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4694,35 +4694,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -216,13 +216,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -235,7 +235,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -244,7 +244,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -252,14 +252,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -274,7 +274,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -283,7 +283,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -291,7 +291,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -303,7 +303,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -622,13 +622,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -641,7 +641,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -650,7 +650,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -658,14 +658,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -680,7 +680,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -689,7 +689,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -697,7 +697,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -709,7 +709,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -1125,13 +1125,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1150,7 +1150,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -1160,14 +1160,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1175,14 +1175,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1202,7 +1202,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1211,7 +1211,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1233,7 +1233,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1251,35 +1251,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1831,13 +1831,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1856,7 +1856,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -1866,14 +1866,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1881,14 +1881,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1908,7 +1908,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1917,7 +1917,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1939,7 +1939,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1957,35 +1957,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2432,13 +2432,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2457,7 +2457,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2467,14 +2467,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2482,14 +2482,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2509,7 +2509,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2518,7 +2518,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2540,7 +2540,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2558,35 +2558,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2953,13 +2953,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2972,7 +2972,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -2981,7 +2981,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2989,14 +2989,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3011,7 +3011,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3020,7 +3020,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3028,7 +3028,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3040,7 +3040,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -3495,13 +3495,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3520,7 +3520,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -3530,14 +3530,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3545,14 +3545,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3572,7 +3572,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3581,7 +3581,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3603,7 +3603,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3621,35 +3621,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -311,13 +311,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -336,7 +336,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -346,14 +346,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -361,14 +361,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -388,7 +388,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -397,7 +397,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -419,7 +419,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -437,35 +437,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -834,13 +834,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -853,7 +853,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -862,7 +862,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -870,14 +870,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -892,7 +892,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -901,7 +901,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -909,7 +909,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -921,7 +921,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -1447,13 +1447,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1466,7 +1466,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -1475,7 +1475,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1483,14 +1483,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1505,7 +1505,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1514,7 +1514,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1522,7 +1522,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1534,7 +1534,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -2170,13 +2170,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2195,7 +2195,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2205,14 +2205,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2220,14 +2220,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2247,7 +2247,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2256,7 +2256,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2278,7 +2278,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2296,35 +2296,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3147,13 +3147,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3172,7 +3172,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -3182,14 +3182,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3197,14 +3197,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3224,7 +3224,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3233,7 +3233,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3255,7 +3255,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3273,35 +3273,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3970,13 +3970,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3989,7 +3989,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -3998,7 +3998,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4006,14 +4006,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4028,7 +4028,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4037,7 +4037,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -4045,7 +4045,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4057,7 +4057,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -4651,13 +4651,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4676,7 +4676,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -4686,14 +4686,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4701,14 +4701,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4728,7 +4728,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4737,7 +4737,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -4759,7 +4759,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4777,35 +4777,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.105.Final",
+            "locked": "4.1.106.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",


### PR DESCRIPTION
Fixes an issue with header corruption on large header payloads https://netty.io/news/2024/01/19/4-1-106-Final.html