### PR TITLE
Unwrap DecoderExceptions on connections (OriginConnectExceptions) into RequestAttempts

### DIFF
--- a/zuul-core/src/test/java/com/netflix/zuul/niws/RequestAttemptTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/niws/RequestAttemptTest.java
@@ -1,0 +1,64 @@
+package com.netflix.zuul.niws;
+
+import com.netflix.zuul.exception.OutboundErrorType;
+import com.netflix.zuul.netty.connectionpool.OriginConnectException;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLHandshakeException;
+import java.io.IOException;
+import java.security.cert.CertificateException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RequestAttemptTest {
+
+    @Test
+    void exceptionHandled() {
+
+        RequestAttempt attempt = new RequestAttempt(1, null, null, "target", "chosen", 200, null, null, 0, 0, 0);
+        attempt.setException(new RuntimeException("runtime failure"));
+
+        assertEquals("runtime failure", attempt.getError());
+    }
+
+    @Test
+    void originConnectExceptionUnwrapped() {
+
+        RequestAttempt attempt = new RequestAttempt(1, null, null, "target", "chosen", 200, null, null, 0, 0, 0);
+        attempt.setException(new OriginConnectException(
+                "origin connect failure",
+                new SSLHandshakeException("Invalid tls cert"),
+                OutboundErrorType.CONNECT_ERROR));
+
+        assertEquals("ORIGIN_CONNECT_ERROR", attempt.getError());
+        assertEquals("Invalid tls cert", attempt.getCause());
+    }
+
+    @Test
+    void originConnectExceptionWithSSLHandshakeCauseUnwrapped() {
+
+        SSLHandshakeException handshakeException = mock(SSLHandshakeException.class);
+        when(handshakeException.getCause()).thenReturn(new CertificateException("Cert doesn't match expected"));
+
+        RequestAttempt attempt = new RequestAttempt(1, null, null, "target", "chosen", 200, null, null, 0, 0, 0);
+        attempt.setException(new OriginConnectException(
+                "origin connect failure", handshakeException, OutboundErrorType.CONNECT_ERROR));
+
+        assertEquals("ORIGIN_CONNECT_ERROR", attempt.getError());
+        assertEquals("Cert doesn't match expected", attempt.getCause());
+    }
+
+    @Test
+    void originConnectExceptionWithCauseNotUnwrapped() {
+        RequestAttempt attempt = new RequestAttempt(1, null, null, "target", "chosen", 200, null, null, 0, 0, 0);
+        attempt.setException(new OriginConnectException(
+                "origin connect failure",
+                new IOException(new RuntimeException("socket failure")),
+                OutboundErrorType.CONNECT_ERROR));
+
+        assertEquals("ORIGIN_CONNECT_ERROR", attempt.getError());
+        assertEquals("java.lang.RuntimeException: socket failure", attempt.getCause());
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/niws/RequestAttemptTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/niws/RequestAttemptTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
 package com.netflix.zuul.niws;
 
 import com.netflix.zuul.exception.OutboundErrorType;


### PR DESCRIPTION
During origin connection failures, netty throws a `DecoderException`. Currently it is passed through to `RequestAttempt` and falls into the basic `OriginConnectException` handling, that is, only the base class name is emitted.

This change unwraps the `DecoderException` before creating the `OriginConnectException` so the underlying cause is better propagated. This change also then further unwraps the`OriginConnectException` in the `RequestAttempt` class during ssl handshake failures so we know the _actual cause_ of the ssl handshake failure.

Before:
```
{
  "error": "ORIGIN_CONNECT_ERROR",
  "exceptionType": "DecoderException",
  "status": -1,
  "duration": 42266,
  "attempt": 1,
  "region": "us-east-1",
  "availabilityZone": "us-east-1c",
  "asg": "myapp-v103",
  "instanceId": "i-123abc",
  "vip": "myapp-",
  "ipAddress": "10.0.0.1",
  "port": 443,
  "readTimeout": 600000,
  "connectTimeout": 1500
}
```

After:
```
{
  "error": "ORIGIN_CONNECT_ERROR",
  "cause": "Certificate application name (myapp) does not match expected name: mysecondapp",
  "exceptionType": "SSLHandshakeException",
  "status": -1,
  "duration": 42266,
  "attempt": 1,
  "region": "us-east-1",
  "availabilityZone": "us-east-1c",
  "asg": "myapp-v103",
  "instanceId": "i-123abc",
  "vip": "myapp-",
  "ipAddress": "10.0.0.1",
  "port": 443,
  "readTimeout": 600000,
  "connectTimeout": 1500
}
```