### PR TITLE
run test suite with 'Xcheck:jni' JVM argument

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,12 @@ subprojects {
         ]
     }
 
+    tasks.withType(Test).all {
+        jvmArgs += [
+                "-Xcheck:jni"
+        ]
+    }
+
     test {
         useJUnitPlatform()
         testLogging {

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ subprojects {
         ]
     }
 
-    tasks.withType(Test).all {
+    tasks.withType(Test).configureEach {
         jvmArgs += [
                 "-Xcheck:jni"
         ]


### PR DESCRIPTION
# Motivation

We should run our testsuite with '-Xcheck:jni' to ensure we catch bugs in JNI code which could later cause issues like crashes

# Modifications

Add -Xcheck:jni

# Result

Testsuite will be able to catch more JNI bugs

# Related work

This PR was inspired by a Netty PR:
https://github.com/netty/netty/pull/13642


# Tweet from Norman Maurer (September 2023)

![image](https://github.com/Netflix/zuul/assets/30938/9bc49a82-a8e2-4a9b-bfcf-594319828e35)


# JDK documentation

https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html
