### PR TITLE
Switch to io.netty.handler.codec.http.cookie.Cookie in order to support cookies with duplicate keys

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ versions_netty=4.1.107.Final
 versions_netty_io_uring=0.0.25.Final
 versions_brotli4j=1.16.0
 release.scope=patch
-release.version=2.5.1-SNAPSHOT
+release.version=2.5.0-SNAPSHOT
 org.gradle.jvmargs=-Xms1g -Xmx2g

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ versions_netty=4.1.107.Final
 versions_netty_io_uring=0.0.25.Final
 versions_brotli4j=1.16.0
 release.scope=patch
-release.version=2.4.1-SNAPSHOT
+release.version=2.5.1-SNAPSHOT
 org.gradle.jvmargs=-Xms1g -Xmx2g

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/Cookies.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/Cookies.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.message.http;
 
-import io.netty.handler.codec.http.Cookie;
+import io.netty.handler.codec.http.cookie.Cookie;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,16 +29,11 @@ import java.util.Map;
  * Time: 12:04 AM
  */
 public class Cookies {
-    private Map<String, List<Cookie>> map = new HashMap<>();
-    private List<Cookie> all = new ArrayList<>();
+    private final Map<String, List<Cookie>> map = new HashMap<>();
+    private final List<Cookie> all = new ArrayList<>();
 
     public void add(Cookie cookie) {
-        List<Cookie> existing = map.get(cookie.getName());
-        if (existing == null) {
-            existing = new ArrayList<>();
-            map.put(cookie.getName(), existing);
-        }
-        existing.add(cookie);
+        map.computeIfAbsent(cookie.name(), k -> new ArrayList<>(1)).add(cookie);
         all.add(cookie);
     }
 
@@ -52,7 +47,7 @@ public class Cookies {
 
     public Cookie getFirst(String name) {
         List<Cookie> found = map.get(name);
-        if (found == null || found.size() == 0) {
+        if (found == null || found.isEmpty()) {
             return null;
         }
         return found.get(0);
@@ -62,7 +57,7 @@ public class Cookies {
         Cookie c = getFirst(name);
         String value;
         if (c != null) {
-            value = c.getValue();
+            value = c.value();
         } else {
             value = null;
         }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
@@ -27,9 +27,9 @@ import com.netflix.zuul.message.Headers;
 import com.netflix.zuul.message.ZuulMessage;
 import com.netflix.zuul.message.ZuulMessageImpl;
 import com.netflix.zuul.util.HttpUtils;
-import io.netty.handler.codec.http.Cookie;
-import io.netty.handler.codec.http.CookieDecoder;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +41,6 @@ import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -389,7 +388,7 @@ public class HttpRequestMessageImpl implements HttpRequestMessage {
                     aCookieHeader = cleanCookieHeader(aCookieHeader);
                 }
 
-                Set<Cookie> decoded = CookieDecoder.decode(aCookieHeader, false);
+                List<Cookie> decoded = ServerCookieDecoder.LAX.decodeAll(aCookieHeader);
                 for (Cookie cookie : decoded) {
                     cookies.add(cookie);
                 }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessage.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessage.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.message.http;
 
-import io.netty.handler.codec.http.Cookie;
+import io.netty.handler.codec.http.cookie.Cookie;
 
 /**
  * User: Mike Smith

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushAuthHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushAuthHandler.java
@@ -22,8 +22,6 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.codec.http.Cookie;
-import io.netty.handler.codec.http.CookieDecoder;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
@@ -33,10 +31,12 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Set;
+import java.util.List;
 
 /**
  * Author: Susheel Aroskar
@@ -114,8 +114,8 @@ public abstract class PushAuthHandler extends SimpleChannelInboundHandler<FullHt
         final Cookies cookies = new Cookies();
         final String cookieStr = req.headers().get(HttpHeaderNames.COOKIE);
         if (!Strings.isNullOrEmpty(cookieStr)) {
-            final Set<Cookie> decoded = CookieDecoder.decode(cookieStr, false);
-            decoded.forEach(cookie -> cookies.add(cookie));
+            List<Cookie> decoded = ServerCookieDecoder.LAX.decodeAll(cookieStr);
+            decoded.forEach(cookies::add);
         }
         return cookies;
     }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
@@ -22,6 +22,7 @@ import com.netflix.zuul.context.CommonContextKeys;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.Headers;
 import io.netty.channel.local.LocalAddress;
+import io.netty.handler.codec.http.cookie.Cookie;
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -790,5 +792,30 @@ class HttpRequestMessageImplTest {
                 true);
 
         assertEquals(message.getClientDestinationPort(), Optional.of(443));
+    }
+
+    @Test
+    public void duplicateCookieNames() {
+        Headers headers = new Headers();
+        headers.add("cookie", "k=v1;k=v2");
+        HttpRequestMessageImpl message = new HttpRequestMessageImpl(
+                new SessionContext(),
+                "HTTP/1.1",
+                "POST",
+                "/some/where",
+                new HttpQueryParams(),
+                headers,
+                "192.168.0.2",
+                "https",
+                7002,
+                "localhost",
+                new InetSocketAddress("api.netflix.com", 443),
+                true);
+        Cookies cookies = message.parseCookies();
+        assertEquals(2, cookies.getAll().size());
+        List<Cookie> kCookies = cookies.get("k");
+        assertEquals(2, kCookies.size());
+        assertEquals("v1", kCookies.get(0).value());
+        assertEquals("v2", kCookies.get(1).value());
     }
 }

--- a/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SamplePushAuthHandler.java
+++ b/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SamplePushAuthHandler.java
@@ -21,9 +21,9 @@ import com.netflix.zuul.netty.server.push.PushAuthHandler;
 import com.netflix.zuul.netty.server.push.PushUserAuth;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.Cookie;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.cookie.Cookie;
 
 /**
  * Takes cookie value of the cookie "userAuthCookie" as a customerId WITHOUT ANY actual validation.
@@ -52,8 +52,8 @@ public class SamplePushAuthHandler extends PushAuthHandler {
     protected PushUserAuth doAuth(FullHttpRequest req) {
         final Cookies cookies = parseCookies(req);
         for (final Cookie c : cookies.getAll()) {
-            if (c.getName().equals("userAuthCookie")) {
-                final String customerId = c.getValue();
+            if (c.name().equals("userAuthCookie")) {
+                final String customerId = c.value();
                 if (!Strings.isNullOrEmpty(customerId)) {
                     return new SamplePushUserAuth(customerId);
                 }


### PR DESCRIPTION
We've been using the deprecated `io.netty.handler.codec.http.Cookie` and `CookieDecoder.decode`. `CookieDecoder` is unable to handle duplicate key names, so I had to switch us to the newer decoder. I'm also bumping to 2.5.0 since I had to make breaking changes to interfaces 