### PR TITLE
Allow custom overrides with global filter concurrency limits

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/BaseFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/BaseFilter.java
@@ -124,12 +124,17 @@ public abstract class BaseFilter<I extends ZuulMessage, O extends ZuulMessage> i
 
     @Override
     public void incrementConcurrency() throws ZuulFilterConcurrencyExceededException {
-        final int limit = Math.max(filterConcurrencyCustom.get(), filterConcurrencyDefault.get());
+        final int limit = calculateConcurency();
         if ((concurrencyProtectionEnabled.get()) && (concurrentCount.get() >= limit)) {
             concurrencyRejections.increment();
             throw new ZuulFilterConcurrencyExceededException(this, limit);
         }
         concurrentCount.incrementAndGet();
+    }
+
+    protected int calculateConcurency() {
+        final int customLimit = filterConcurrencyCustom.get();
+        return customLimit != DEFAULT_FILTER_CONCURRENCY_LIMIT ? customLimit : filterConcurrencyDefault.get();
     }
 
     @Override


### PR DESCRIPTION
On second thought, there might still be reasons for individual concurrency overrides(esp. on the lower end) out there in the wild. While we wan the ability to raise the default globally, this would allow for lowering the limit for individual filters.