### PR TITLE
Pass ChannelHandlerContext to doAuth call

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushAuthHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushAuthHandler.java
@@ -87,7 +87,7 @@ public abstract class PushAuthHandler extends SimpleChannelInboundHandler<FullHt
                 // client auth will happen later, continue with WebSocket upgrade handshake
                 ctx.fireChannelRead(req.retain());
             } else {
-                final PushUserAuth authEvent = doAuth(req);
+                final PushUserAuth authEvent = doAuth(req, ctx);
                 if (authEvent.isSuccess()) {
                     ctx.fireChannelRead(req.retain()); // continue with WebSocket upgrade handshake
                     ctx.fireUserEventTriggered(authEvent);
@@ -125,5 +125,5 @@ public abstract class PushAuthHandler extends SimpleChannelInboundHandler<FullHt
      */
     protected abstract boolean isDelayedAuth(FullHttpRequest req, ChannelHandlerContext ctx);
 
-    protected abstract PushUserAuth doAuth(FullHttpRequest req);
+    protected abstract PushUserAuth doAuth(FullHttpRequest req, ChannelHandlerContext ctx);
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushAuthHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushAuthHandlerTest.java
@@ -58,7 +58,7 @@ class PushAuthHandlerTest {
         }
 
         @Override
-        protected PushUserAuth doAuth(FullHttpRequest req) {
+        protected PushUserAuth doAuth(FullHttpRequest req, ChannelHandlerContext ctx) {
             return null;
         }
     }

--- a/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SamplePushAuthHandler.java
+++ b/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SamplePushAuthHandler.java
@@ -49,7 +49,7 @@ public class SamplePushAuthHandler extends PushAuthHandler {
     }
 
     @Override
-    protected PushUserAuth doAuth(FullHttpRequest req) {
+    protected PushUserAuth doAuth(FullHttpRequest req, ChannelHandlerContext ctx) {
         final Cookies cookies = parseCookies(req);
         for (final Cookie c : cookies.getAll()) {
             if (c.name().equals("userAuthCookie")) {


### PR DESCRIPTION
Allow any class implementing doAuth method to have access to any ChannelHandlerContext and any session related information.  