### PR TITLE
Mark BaseFilterTest test methods as public

### DIFF
--- a/zuul-core/src/test/java/com/netflix/zuul/filters/BaseFilterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/BaseFilterTest.java
@@ -47,7 +47,7 @@ class BaseFilterTest {
     }
 
     @Test
-    void testShouldFilter() {
+    public void testShouldFilter() {
         class TestZuulFilter extends BaseSyncFilter {
 
             @Override
@@ -79,7 +79,7 @@ class BaseFilterTest {
     }
 
     @Test
-    void validateDefaultConcurrencyLimit() {
+    public void validateDefaultConcurrencyLimit() {
         final int[] limit = {0};
         class ConcInboundFilter extends BaseFilter {
 
@@ -104,7 +104,7 @@ class BaseFilterTest {
     }
 
     @Test
-    void validateFilterGlobalConcurrencyLimitOverride() {
+    public void validateFilterGlobalConcurrencyLimitOverride() {
         config.setProperty("zuul.filter.concurrency.limit.default", 7000);
         config.setProperty("zuul.ConcInboundFilter.in.concurrency.limit", 4000);
         final int[] limit = {0};
@@ -132,7 +132,7 @@ class BaseFilterTest {
     }
 
     @Test
-    void validateFilterSpecificConcurrencyLimitOverride() {
+    public void validateFilterSpecificConcurrencyLimitOverride() {
         config.setProperty("zuul.filter.concurrency.limit.default", 7000);
         config.setProperty("zuul.ConcInboundFilter.in.concurrency.limit", 4300);
         final int[] limit = {0};


### PR DESCRIPTION
When running tests through VSCode's testing plugin, the BaseFilterTest tests would fail to initialize with the MockitoTestRunner error:

> org.mockito.exceptions.base.MockitoException:
>
> No tests found in BaseFilterTest
> Is the method annotated with @Test?
> Is the method public?

This commit fixes this issue by marking the related tests as public, enabling Mockito to discover the tests.