### PR TITLE
Switch order of literals to prevent NullPointerException

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/context/Debug.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/Debug.java
@@ -127,7 +127,7 @@ public class Debug {
         Iterator<String> it = context.keySet().iterator();
         String key = it.next();
         while (key != null) {
-            if ((!key.equals("routingDebug") && !key.equals("requestDebug"))) {
+            if ((!"routingDebug".equals(key) && !"requestDebug".equals(key))) {
                 Object newValue = context.get(key);
                 Object oldValue = copy.get(key);
                 if (!(newValue instanceof ReferenceCounted) && !(oldValue instanceof ReferenceCounted)) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/insights/PassportLoggingHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/insights/PassportLoggingHandler.java
@@ -145,7 +145,7 @@ public class PassportLoggingHandler extends ChannelInboundHandlerAdapter {
     }
 
     protected boolean isHealthcheckRequest(HttpRequestMessage req) {
-        return req.getPath().equals("/healthcheck");
+        return "/healthcheck".equals(req.getPath());
     }
 
     protected String getRequestId(Channel channel, SessionContext ctx) {

--- a/zuul-core/src/main/java/com/netflix/zuul/passport/CurrentPassport.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/passport/CurrentPassport.java
@@ -400,7 +400,7 @@ public class CurrentPassport {
                     Matcher stateMatch = ptnState.matcher(stateStr);
                     if (stateMatch.matches()) {
                         String stateName = stateMatch.group(2);
-                        if (stateName.equals("NOW")) {
+                        if ("NOW".equals(stateName)) {
                             long startTime = passport.history.size() > 0 ? passport.firstTime() : 0;
                             long now = Long.parseLong(stateMatch.group(1)) + startTime;
                             ticker.setNow(now);


### PR DESCRIPTION
This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [https://cwe.mitre.org/data/definitions/476.html](https://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:java/switch-literal-first](https://docs.pixee.ai/codemods/java/pixee_java_switch-literal-first)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Java%2Fzuul%7Cfcacf1a93701561a61a32745fb3f5836a066e97d)

<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->