### PR TITLE
Fix broken log levels in sample project

### DIFF
--- a/zuul-sample/src/main/resources/log4j2.properties
+++ b/zuul-sample/src/main/resources/log4j2.properties
@@ -12,11 +12,15 @@ rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 
 # can be set to INFO for netty wire logging
-log4j.logger.zuul.server.nettylog=WARN
-log4j.logger.zuul.origin.nettylog=WARN
+logger.server.name = zuul.server.nettylog
+logger.server.level = WARN
+logger.origin.name = zuul.origin.nettylog
+logger.origin.level = WARN
 
-log4j.logger.com.netflix.loadbalancer=WARN
-log4j.logger.com.netflix.config=WARN
+logger.loadbalancer.name = com.netflix.loadbalancer
+logger.loadbalancer.level = WARN
+logger.config.name = com.netflix.config
+logger.config.level = WARN
 
 # async appender
 log4j.logger.asyncAppenders=INFO


### PR DESCRIPTION
Previous syntax is not working anymore with recent log4j versions