### PR TITLE
Fix typo when converting originalHost toString

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpRequestMessageImpl.java
@@ -704,7 +704,7 @@ public class HttpRequestMessageImpl implements HttpRequestMessage {
                 + inboundRequest + ", parsedCookies="
                 + parsedCookies + ", reconstructedUri='"
                 + reconstructedUri + '\'' + ", pathAndQuery='"
-                + pathAndQuery + '\'' + "/ originalHost='"
+                + pathAndQuery + '\'' + ", originalHost='"
                 + originalHost + '\'' + ", infoForLogging='"
                 + infoForLogging + '\'' + '}';
     }


### PR DESCRIPTION
Fix typo when converting originalHost toString