### PR TITLE
Fix fetching body content after buffer has been read

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessage.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessage.java
@@ -59,13 +59,15 @@ public interface ZuulMessage extends Cloneable {
     void setHasBody(boolean hasBody);
 
     /**
-     * Returns the message body.  If there is no message body, this returns {@code null}.
+     * Returns the message body.
+     * This is the entire buffered body, regardless of whether the underlying body chunks have been read or not.
+     * If there is no message body, this returns {@code null}.
      */
     @Nullable
     byte[] getBody();
 
     /**
-     * Returns the length of the message body, or {@code 0} if there isn't a message present.
+     * Returns the length of the entire buffered message body, or {@code 0} if there isn't a message present.
      */
     int getBodyLength();
 

--- a/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
@@ -147,16 +147,13 @@ public class ZuulMessageImpl implements ZuulMessage {
             return null;
         }
 
-        int size = 0;
-        for (final HttpContent chunk : bodyChunks) {
-            size += chunk.content().readableBytes();
-        }
+        int size = this.getBodyLength();
         final byte[] body = new byte[size];
         int offset = 0;
         for (final HttpContent chunk : bodyChunks) {
             final ByteBuf content = chunk.content();
-            final int len = content.readableBytes();
-            content.getBytes(content.readerIndex(), body, offset, len);
+            final int len = content.writerIndex(); // writer idx tracks the total readable bytes in the buffer
+            content.getBytes(0, body, offset, len);
             offset += len;
         }
         return body;
@@ -166,7 +163,8 @@ public class ZuulMessageImpl implements ZuulMessage {
     public int getBodyLength() {
         int size = 0;
         for (final HttpContent chunk : bodyChunks) {
-            size += chunk.content().readableBytes();
+            // writer index tracks the total number of bytes written to the buffer regardless of buffer reads
+            size += chunk.content().writerIndex();
         }
         return size;
     }


### PR DESCRIPTION
When fetching the body content of a `ZuulMessage`, the returned content differs based on if the body content chunks have been read, i.e. after it has been proxied to an upstream origin.

This change uses the `writerIndex` to instead track the total number of readable bytes of the bytebuf, so the entire content is always returned by the `getBody*` methods.

