### PR TITLE
Break keepalive interval out to protected helper to allow override

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushRegistrationHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushRegistrationHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.util.concurrent.ScheduledFuture;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -179,6 +180,10 @@ public class PushRegistrationHandler extends ChannelInboundHandlerAdapter {
         super.userEventTriggered(ctx, evt);
     }
 
+    protected int getKeepAliveInterval() {
+        return KEEP_ALIVE_INTERVAL.get();
+    }
+
     /**
      * Register authenticated client  - represented by PushAuthEvent - with PushConnectionRegistry of this instance.
      *
@@ -202,7 +207,7 @@ public class PushRegistrationHandler extends ChannelInboundHandlerAdapter {
         if (KEEP_ALIVE_ENABLED.get()) {
             scheduledFutures.add(ctx.executor()
                     .scheduleWithFixedDelay(
-                            this::keepAlive, KEEP_ALIVE_INTERVAL.get(), KEEP_ALIVE_INTERVAL.get(), TimeUnit.SECONDS));
+                            this::keepAlive, getKeepAliveInterval(), getKeepAliveInterval(), TimeUnit.SECONDS));
         }
     }
 


### PR DESCRIPTION
This will enable us to have more flexibility around the interval that the keepalive Ping messages are sent to the device.

For example, we can then override this and have a different interval for a different category of connections (e.g. maybe we have clients we want to check more frequently).