### PR TITLE
Add new retry policy adjustment method

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -89,10 +89,6 @@ import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 import io.perfmark.PerfMark;
 import io.perfmark.TaskCloseable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.URLDecoder;
@@ -104,6 +100,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Not thread safe! New instance of this class is created per HTTP/1.1 request proxied to the origin but NOT for each
@@ -908,7 +907,8 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
 
         boolean retryable5xxResponse = isRetryable5xxResponse(zuulRequest, originResponse);
         if (retryable5xxResponse) {
-            origin.adjustRetryPolicyIfNeeded(zuulRequest, originResponse);
+            origin.originRetryPolicyAdjustmentIfNeeded(zuulRequest, originResponse);
+            origin.adjustRetryPolicyIfNeeded(zuulRequest);
         }
 
         if (retryable5xxResponse && isBelowRetryLimit()) {

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -738,8 +738,8 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
         if ((err == OutboundErrorType.RESET_CONNECTION)
                 || (err == OutboundErrorType.CONNECT_ERROR)
                 || (err == OutboundErrorType.READ_TIMEOUT
-                && IDEMPOTENT_HTTP_METHODS.contains(
-                zuulRequest.getMethod().toUpperCase()))) {
+                        && IDEMPOTENT_HTTP_METHODS.contains(
+                                zuulRequest.getMethod().toUpperCase()))) {
             return isRequestReplayable();
         }
         return false;
@@ -908,7 +908,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
 
         boolean retryable5xxResponse = isRetryable5xxResponse(zuulRequest, originResponse);
         if (retryable5xxResponse) {
-            origin.adjustRetryPolicyIfNeeded(zuulRequest);
+            origin.adjustRetryPolicyIfNeeded(zuulRequest, originResponse);
         }
 
         if (retryable5xxResponse && isBelowRetryLimit()) {

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/NettyOrigin.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/NettyOrigin.java
@@ -26,7 +26,10 @@ import com.netflix.zuul.netty.connectionpool.PooledConnection;
 import com.netflix.zuul.niws.RequestAttempt;
 import com.netflix.zuul.passport.CurrentPassport;
 import io.netty.channel.EventLoop;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.util.concurrent.Promise;
+
+import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -77,4 +80,8 @@ public interface NettyOrigin extends InstrumentedOrigin {
     IClientConfig getClientConfig();
 
     Registry getSpectatorRegistry();
+
+    default void adjustRetryPolicyIfNeeded(HttpRequestMessage zuulRequest, @Nullable HttpResponse response) {
+        adjustRetryPolicyIfNeeded(zuulRequest);
+    }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/origins/NettyOrigin.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/origins/NettyOrigin.java
@@ -28,8 +28,6 @@ import com.netflix.zuul.passport.CurrentPassport;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.util.concurrent.Promise;
-
-import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -81,7 +79,5 @@ public interface NettyOrigin extends InstrumentedOrigin {
 
     Registry getSpectatorRegistry();
 
-    default void adjustRetryPolicyIfNeeded(HttpRequestMessage zuulRequest, @Nullable HttpResponse response) {
-        adjustRetryPolicyIfNeeded(zuulRequest);
-    }
+    default void originRetryPolicyAdjustmentIfNeeded(HttpRequestMessage zuulReq, HttpResponse nettyResponse) {}
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/ProxyEndpointTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/ProxyEndpointTest.java
@@ -222,7 +222,7 @@ class ProxyEndpointTest {
             return null;
         };
         doAnswer(answer).when(nettyOrigin).adjustRetryPolicyIfNeeded(request);
-        doAnswer(answer).when(nettyOrigin).adjustRetryPolicyIfNeeded(request, any(HttpResponse.class));
+        doAnswer(answer).when(nettyOrigin).adjustRetryPolicyIfNeeded(eq(request), any(HttpResponse.class));
     }
 
     private static DiscoveryResult createDiscoveryResult() {


### PR DESCRIPTION
Adds a more specific adjustRetryPolicyIfNeeded for cases when we have a HttpResponse from the origin (e.g. origin returned 503)