### PR TITLE
Checking if connection already exists for given client in registry

### DIFF
--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushRegistrationHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushRegistrationHandlerTest.java
@@ -116,6 +116,18 @@ class PushRegistrationHandlerTest {
     }
 
     @Test
+    void closeIfClientAlreadyRegistered() throws Exception {
+        doHandshakeComplete();
+        handler.userEventTriggered(context, successfulAuth);
+        PushConnection firstConnection = registry.get(successfulAuth.getClientIdentity());
+        assertNotNull(firstConnection);
+
+        handler.userEventTriggered(context, successfulAuth);
+        validateConnectionClosed(1009, "Connection already registered for this client");
+        assertEquals(firstConnection, registry.get(successfulAuth.getClientIdentity()));
+    }
+
+    @Test
     void authFailed() throws Exception {
         doHandshakeComplete();
         handler.userEventTriggered(context, new TestAuth(false));


### PR DESCRIPTION
If another connection is present for given client, the new connection is closed.
Issue #1825 
