### PR TITLE
add a listener spec and wire for channelDeps

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
@@ -52,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class BaseServerStartup {
+
     protected static final Logger LOG = LoggerFactory.getLogger(BaseServerStartup.class);
 
     protected final ServerStatusManager serverStatusManager;
@@ -124,6 +125,7 @@ public abstract class BaseServerStartup {
     }
 
     // TODO(carl-mastrangelo): remove this after 2.1.7
+
     /**
      * Use {@link #chooseAddrsAndChannels(ChannelGroup)} instead.
      */
@@ -143,6 +145,12 @@ public abstract class BaseServerStartup {
     protected ChannelConfig defaultChannelDependencies(String listenAddressName) {
         ChannelConfig channelDependencies = new ChannelConfig();
         addChannelDependencies(channelDependencies, listenAddressName);
+        return channelDependencies;
+    }
+
+    protected ChannelConfig defaultChannelDependencies(ListenerSpec listenSpec) {
+        ChannelConfig channelDependencies = new ChannelConfig();
+        addChannelDependencies(channelDependencies, listenSpec.addressName());
         return channelDependencies;
     }
 
@@ -193,7 +201,7 @@ public abstract class BaseServerStartup {
         String listenAddressPropertyName = "server." + listenAddressName + "." + propertySuffix;
 
         Boolean value = new ChainedDynamicProperty.DynamicBooleanPropertyThatSupportsNull(
-                        listenAddressPropertyName, null)
+                listenAddressPropertyName, null)
                 .get();
         if (value == null) {
             value = new DynamicBooleanProperty(globalPropertyName, defaultValue)
@@ -293,6 +301,7 @@ public abstract class BaseServerStartup {
     }
 
     // TODO(carl-mastrangelo): remove this after 2.1.7
+
     /**
      * Use {@link #logAddrConfigured(SocketAddress)} instead.
      */
@@ -302,6 +311,7 @@ public abstract class BaseServerStartup {
     }
 
     // TODO(carl-mastrangelo): remove this after 2.1.7
+
     /**
      * Use {@link #logAddrConfigured(SocketAddress, ServerSslConfig)} instead.
      */
@@ -311,6 +321,7 @@ public abstract class BaseServerStartup {
     }
 
     // TODO(carl-mastrangelo): remove this after 2.1.7
+
     /**
      * Use {@link #logAddrConfigured(SocketAddress, AsyncMapping)} instead.
      */

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ListenerSpec.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ListenerSpec.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.netty.server;
+
+/**
+ * @author Argha C
+ * @since 10/2/24
+ */
+
+import java.net.SocketAddress;
+import java.util.Objects;
+
+/**
+ * A specification of an address to listen on.
+ */
+
+public record ListenerSpec(String addressName, boolean defaultAddressEnabled, SocketAddress defaultAddressValue) {
+
+    public ListenerSpec {
+        Objects.requireNonNull(addressName, "addressName");
+        Objects.requireNonNull(defaultAddressEnabled, "defaultAddressEnabled");
+        Objects.requireNonNull(defaultAddressValue, "defaultAddressValue");
+    }
+
+    /**
+     * The fast property name that indicates if this address is enabled.  This is used when overriding
+     * {@link #defaultAddressEnabled}.
+     */
+    public String addressEnabledPropertyName() {
+        return "zuul.server." + addressName + ".enabled";
+    }
+
+    /**
+     * The fast property to override the default port for the address name
+     */
+    @Deprecated
+    public String portPropertyName() {
+        return "zuul.server.port." + addressName;
+    }
+
+    /**
+     * The fast property to override the default address name
+     */
+    public String addressPropertyName() {
+        return "zuul.server.addr." + addressName;
+    }
+}


### PR DESCRIPTION
Move `ListenSpec` to OSS and expose a new API vs stringly typed addr names.