### PR TITLE
Fix netty-transport-native-epoll classifier usage 

### DIFF
--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     api "io.netty:netty-transport"
 
     implementation "io.netty:netty-codec-haproxy"
-    implementation "io.netty:netty-transport-native-epoll:linux-x86_64"
-    implementation "io.netty:netty-transport-native-kqueue:osx-x86_64"
+    implementation (group: "io.netty", "name": "netty-transport-native-epoll", "classifier": "linux-x86_64")
+    implementation (group: "io.netty", "name": "netty-transport-native-kqueue", "classifier": "osx-x86_64")
 
     implementation "io.netty.incubator:netty-incubator-transport-native-io_uring:${versions_netty_io_uring}:linux-x86_64"
 


### PR DESCRIPTION
With this shorthand syntax we are using the classifier in place of the version. The dependency resolution looks like 

```
io.netty:netty-transport-native-epoll:linux-x86_64 -> 4.1.115.Final
\--- runtimeClasspath
```

i.e., we don't include the `linux-x86_64` jar as a transitive dependency. 

With the new syntax:
```
io.netty:netty-transport-native-epoll -> 4.1.115.Final
\--- runtimeClasspath
```

