### PR TITLE
Allow ACCESS logs fields overrides

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/accesslog/AccessLogChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/accesslog/AccessLogChannelHandler.java
@@ -39,6 +39,8 @@ public final class AccessLogChannelHandler {
     private static final AttributeKey<RequestState> ATTR_REQ_STATE =
             AttributeKey.newInstance("_accesslog_requeststate");
 
+    private static final AttributeKey<String> ATTR_CLIENT_IP = AttributeKey.valueOf("client_ip");
+
     private static final Logger LOG = LoggerFactory.getLogger(AccessLogChannelHandler.class);
 
     public static final class AccessLogInboundChannelHandler extends ChannelInboundHandlerAdapter {
@@ -77,9 +79,16 @@ public final class AccessLogChannelHandler {
 
                 // Response complete, so now write to access log.
                 long durationNs = System.nanoTime() - state.startTimeNs;
+
                 String remoteIp = ctx.channel()
                         .attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS)
                         .get();
+
+                String originalRemoteIp = "";
+                if (ATTR_CLIENT_IP != null) {
+                    originalRemoteIp = ctx.channel().attr(ATTR_CLIENT_IP).get();
+                }
+
                 Integer localPort = ctx.channel()
                         .attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT)
                         .get();
@@ -100,6 +109,7 @@ public final class AccessLogChannelHandler {
                         state.dateTime,
                         localPort,
                         remoteIp,
+                        originalRemoteIp,
                         durationNs,
                         state.requestBodySize,
                         state.responseBodySize);

--- a/zuul-core/src/main/java/com/netflix/netty/common/accesslog/AccessLogPublisher.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/accesslog/AccessLogPublisher.java
@@ -95,7 +95,6 @@ public class AccessLogPublisher {
                 .append(DELIM)
                 .append(remoteIpStr)
                 .append(DELIM)
-                .append(DELIM)
                 .append(port)
                 .append(DELIM)
                 .append(method)

--- a/zuul-core/src/main/java/com/netflix/netty/common/accesslog/AccessLogPublisher.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/accesslog/AccessLogPublisher.java
@@ -59,6 +59,7 @@ public class AccessLogPublisher {
             LocalDateTime dateTime,
             Integer localPort,
             String remoteIp,
+            String originalRemoteIp,
             Long durationNs,
             Integer requestBodySize,
             Integer responseBodySize) {
@@ -66,6 +67,7 @@ public class AccessLogPublisher {
 
         String dateTimeStr = dateTime != null ? dateTime.format(DATE_TIME_FORMATTER) : "-----T-:-:-";
         String remoteIpStr = (remoteIp != null && !remoteIp.isEmpty()) ? remoteIp : "-";
+        String originalRemoteIpStr = (originalRemoteIp != null && !originalRemoteIp.isEmpty()) ? originalRemoteIp : "-";
         String port = localPort != null ? localPort.toString() : "-";
         String method = request != null ? request.method().toString().toUpperCase() : "-";
         String uri = request != null ? request.uri() : "-";
@@ -94,6 +96,8 @@ public class AccessLogPublisher {
         sb.append(dateTimeStr)
                 .append(DELIM)
                 .append(remoteIpStr)
+                .append(DELIM)
+                .append(originalRemoteIpStr)
                 .append(DELIM)
                 .append(port)
                 .append(DELIM)

--- a/zuul-core/src/main/java/com/netflix/netty/common/accesslog/AccessLogPublisher.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/accesslog/AccessLogPublisher.java
@@ -59,15 +59,13 @@ public class AccessLogPublisher {
             LocalDateTime dateTime,
             Integer localPort,
             String remoteIp,
-            String originalRemoteIp,
             Long durationNs,
-            Integer requestBodySize,
-            Integer responseBodySize) {
-        StringBuilder sb = new StringBuilder();
+            Long requestBodySize,
+            Long responseBodySize) {
+        StringBuilder sb = new StringBuilder(512);
 
         String dateTimeStr = dateTime != null ? dateTime.format(DATE_TIME_FORMATTER) : "-----T-:-:-";
         String remoteIpStr = (remoteIp != null && !remoteIp.isEmpty()) ? remoteIp : "-";
-        String originalRemoteIpStr = (originalRemoteIp != null && !originalRemoteIp.isEmpty()) ? originalRemoteIp : "-";
         String port = localPort != null ? localPort.toString() : "-";
         String method = request != null ? request.method().toString().toUpperCase() : "-";
         String uri = request != null ? request.uri() : "-";
@@ -97,7 +95,6 @@ public class AccessLogPublisher {
                 .append(DELIM)
                 .append(remoteIpStr)
                 .append(DELIM)
-                .append(originalRemoteIpStr)
                 .append(DELIM)
                 .append(port)
                 .append(DELIM)
@@ -138,6 +135,6 @@ public class AccessLogPublisher {
 
     String headerAsString(HttpHeaders headers, String headerName) {
         List<String> values = headers.getAll(headerName);
-        return (values.size() == 0) ? "-" : String.join(",", values);
+        return values.isEmpty() ? "-" : String.join(",", values);
     }
 }


### PR DESCRIPTION
Add `AccessLogInboundChannelHandler ` field overrides to allow child classes to inject data.