### PR TITLE
Return `UNSPECIFIED` filter category when not implemented by ZuulFilter

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/FilterCategory.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/FilterCategory.java
@@ -33,6 +33,7 @@ public enum FilterCategory {
     OBSERVABILITY("observability", "Filters providing observability features"),
     OVERLOAD("overload", "Filters to respond on the server being in an overloaded state such as brownout"),
     ROUTING("routing", "Filters which make routing decisions"),
+    UNSPECIFIED("unspecified", "Default category when no category is specified"),
     ;
 
     private final String code;

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
@@ -71,8 +71,9 @@ public interface ZuulFilter<I extends ZuulMessage, O extends ZuulMessage> extend
         Filter f = getClass().getAnnotation(Filter.class);
         if (f != null) {
             return f.category();
+        } else {
+            return FilterCategory.UNSPECIFIED;
         }
-        throw new UnsupportedOperationException("not implemented");
     }
 
     /**


### PR DESCRIPTION
Rather than throw an exception when a category is not defined on a `ZuulFilter` subclass, return an `UNSPECIFIED` category instead. There are cases when filters are instantiated per request (like `ProxyEndpoint`) or in anonymous classes (like out static response handler), so this provides a better default safe-guard when the `Filter` annotation is not in use.