### PR TITLE
Move connection pool metric creation to a separate class for easier reuse

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetrics.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetrics.java
@@ -46,30 +46,28 @@ public record ConnectionPoolMetrics(Counter createNewConnCounter,
                                     AtomicInteger connsInPool,
                                     AtomicInteger connsInUse) {
 
-    public static final String METRIC_PREFIX = "connectionpool_";
-
     public static ConnectionPoolMetrics create(OriginName originName, Registry registry) {
-        Counter createNewConnCounter = newCounter("create", originName, registry);
-        Counter createConnSucceededCounter = newCounter("create_success", originName, registry);
-        Counter createConnFailedCounter = newCounter("create_fail", originName, registry);
+        Counter createNewConnCounter = newCounter("connectionpool_create", originName, registry);
+        Counter createConnSucceededCounter = newCounter("connectionpool_create_success", originName, registry);
+        Counter createConnFailedCounter = newCounter("connectionpool_create_fail", originName, registry);
 
-        Counter closeConnCounter = newCounter("close", originName, registry);
-        Counter closeAbovePoolHighWaterMarkCounter = newCounter("closeAbovePoolHighWaterMark", originName, registry);
-        Counter closeExpiredConnLifetimeCounter = newCounter("closeExpiredConnLifetime", originName, registry);
-        Counter requestConnCounter = newCounter("request", originName, registry);
-        Counter reuseConnCounter = newCounter("reuse", originName, registry);
-        Counter releaseConnCounter = newCounter("release", originName, registry);
-        Counter alreadyClosedCounter = newCounter("alreadyClosed", originName, registry);
-        Counter connTakenFromPoolIsNotOpen = newCounter("fromPoolIsClosed", originName, registry);
-        Counter maxConnsPerHostExceededCounter = newCounter("maxConnsPerHostExceeded", originName, registry);
-        Counter closeWrtBusyConnCounter = newCounter("closeWrtBusyConnCounter", originName, registry);
-        Counter circuitBreakerClose = newCounter("closeCircuitBreaker", originName, registry);
+        Counter closeConnCounter = newCounter("connectionpool_close", originName, registry);
+        Counter closeAbovePoolHighWaterMarkCounter = newCounter("connectionpool_closeAbovePoolHighWaterMark", originName, registry);
+        Counter closeExpiredConnLifetimeCounter = newCounter("connectionpool_closeExpiredConnLifetime", originName, registry);
+        Counter requestConnCounter = newCounter("connectionpool_request", originName, registry);
+        Counter reuseConnCounter = newCounter("connectionpool_reuse", originName, registry);
+        Counter releaseConnCounter = newCounter("connectionpool_release", originName, registry);
+        Counter alreadyClosedCounter = newCounter("connectionpool_alreadyClosed", originName, registry);
+        Counter connTakenFromPoolIsNotOpen = newCounter("connectionpool_fromPoolIsClosed", originName, registry);
+        Counter maxConnsPerHostExceededCounter = newCounter("connectionpool_maxConnsPerHostExceeded", originName, registry);
+        Counter closeWrtBusyConnCounter = newCounter("connectionpool_closeWrtBusyConnCounter", originName, registry);
+        Counter circuitBreakerClose = newCounter("connectionpool_closeCircuitBreaker", originName, registry);
 
         PercentileTimer connEstablishTimer = PercentileTimer.get(
-                registry, registry.createId(METRIC_PREFIX + "createTiming", "id", originName.getMetricId()));
+                registry, registry.createId("connectionpool_createTiming", "id", originName.getMetricId()));
 
-        AtomicInteger connsInPool = newGauge("inPool", originName, registry);
-        AtomicInteger connsInUse = newGauge("inUse", originName, registry);
+        AtomicInteger connsInPool = newGauge("connectionpool_inPool", originName, registry);
+        AtomicInteger connsInUse = newGauge("connectionpool_inUse", originName, registry);
 
         return new ConnectionPoolMetrics(createNewConnCounter, createConnSucceededCounter, createConnFailedCounter,
                 closeConnCounter, closeAbovePoolHighWaterMarkCounter, closeExpiredConnLifetimeCounter, requestConnCounter,
@@ -78,12 +76,12 @@ public record ConnectionPoolMetrics(Counter createNewConnCounter,
     }
 
     private static Counter newCounter(String metricName, OriginName originName, Registry registry) {
-        return registry.counter(METRIC_PREFIX + metricName, "id", originName.getMetricId());
+        return registry.counter(metricName, "id", originName.getMetricId());
     }
 
     private static AtomicInteger newGauge(String metricName, OriginName originName, Registry registry) {
         return PolledMeter.using(registry)
-                .withName(METRIC_PREFIX + metricName)
+                .withName(metricName)
                 .withTag("id", originName.getMetricId())
                 .monitorValue(new AtomicInteger());
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetrics.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetrics.java
@@ -42,7 +42,8 @@ public record ConnectionPoolMetrics(Counter createNewConnCounter,
                                     Counter maxConnsPerHostExceededCounter,
                                     Counter closeWrtBusyConnCounter,
                                     Counter circuitBreakerClose,
-                                    PercentileTimer connEstablishTimer, AtomicInteger connsInPool,
+                                    PercentileTimer connEstablishTimer,
+                                    AtomicInteger connsInPool,
                                     AtomicInteger connsInUse) {
 
     public static final String METRIC_PREFIX = "connectionpool_";

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetrics.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetrics.java
@@ -1,0 +1,60 @@
+package com.netflix.zuul.netty.connectionpool;
+
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.histogram.PercentileTimer;
+import com.netflix.zuul.origins.OriginName;
+
+/**
+ * @author Justin Guerra
+ * @since 2/26/25
+ */
+public record ConnectionPoolMetrics(Counter createNewConnCounter,
+                                    Counter createConnSucceededCounter,
+                                    Counter createConnFailedCounter,
+                                    Counter closeConnCounter,
+                                    Counter closeAbovePoolHighWaterMarkCounter,
+                                    Counter closeExpiredConnLifetimeCounter,
+                                    Counter requestConnCounter,
+                                    Counter reuseConnCounter,
+                                    Counter releaseConnCounter,
+                                    Counter alreadyClosedCounter,
+                                    Counter connTakenFromPoolIsNotOpen,
+                                    Counter maxConnsPerHostExceededCounter,
+                                    Counter closeWrtBusyConnCounter,
+                                    Counter circuitBreakerClose,
+                                    PercentileTimer connEstablishTimer) {
+
+    public static final String METRIC_PREFIX = "connectionpool_";
+
+
+    public static ConnectionPoolMetrics create(OriginName originName, Registry registry) {
+        Counter createNewConnCounter = newCounter("create", originName, registry);
+        Counter createConnSucceededCounter = newCounter("create_success", originName, registry);
+        Counter createConnFailedCounter = newCounter("create_fail", originName, registry);
+
+        Counter closeConnCounter = newCounter("close", originName, registry);
+        Counter closeAbovePoolHighWaterMarkCounter = newCounter("closeAbovePoolHighWaterMark", originName, registry);
+        Counter closeExpiredConnLifetimeCounter = newCounter("closeExpiredConnLifetime", originName, registry);
+        Counter requestConnCounter = newCounter("request", originName, registry);
+        Counter reuseConnCounter = newCounter("reuse", originName, registry);
+        Counter releaseConnCounter = newCounter("release", originName, registry);
+        Counter alreadyClosedCounter = newCounter("alreadyClosed", originName, registry);
+        Counter connTakenFromPoolIsNotOpen = newCounter("fromPoolIsClosed", originName, registry);
+        Counter maxConnsPerHostExceededCounter = newCounter("maxConnsPerHostExceeded", originName, registry);
+        Counter closeWrtBusyConnCounter = newCounter("closeWrtBusyConnCounter", originName, registry);
+        Counter circuitBreakerClose = newCounter("closeCircuitBreaker", originName, registry);
+
+        PercentileTimer connEstablishTimer = PercentileTimer.get(
+                registry, registry.createId(METRIC_PREFIX + "createTiming", "id", originName.getMetricId()));
+        return new ConnectionPoolMetrics(createNewConnCounter, createConnSucceededCounter, createConnFailedCounter,
+                closeConnCounter, closeAbovePoolHighWaterMarkCounter, closeExpiredConnLifetimeCounter, requestConnCounter,
+                reuseConnCounter, releaseConnCounter, alreadyClosedCounter, connTakenFromPoolIsNotOpen,
+                maxConnsPerHostExceededCounter, closeWrtBusyConnCounter, circuitBreakerClose, connEstablishTimer);
+    }
+
+    private static Counter newCounter(String metricName, OriginName originName, Registry registry) {
+        return registry.counter(METRIC_PREFIX + metricName, "id", originName.getMetricId());
+    }
+
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetrics.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetrics.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
 package com.netflix.zuul.netty.connectionpool;
 
 import com.netflix.spectator.api.Counter;
@@ -30,7 +46,6 @@ public record ConnectionPoolMetrics(Counter createNewConnCounter,
                                     AtomicInteger connsInUse) {
 
     public static final String METRIC_PREFIX = "connectionpool_";
-
 
     public static ConnectionPoolMetrics create(OriginName originName, Registry registry) {
         Counter createNewConnCounter = newCounter("create", originName, registry);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
@@ -22,7 +22,6 @@ import com.netflix.client.config.IClientConfig;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.histogram.PercentileTimer;
-import com.netflix.spectator.api.patterns.PolledMeter;
 import com.netflix.zuul.discovery.DiscoveryResult;
 import com.netflix.zuul.discovery.DynamicServerResolver;
 import com.netflix.zuul.discovery.ResolverResult;
@@ -62,8 +61,6 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class DefaultClientChannelManager implements ClientChannelManager {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultClientChannelManager.class);
-
-    public static final String METRIC_PREFIX = "connectionpool_";
 
     private final Resolver<DiscoveryResult> dynamicServerResolver;
     private final ConnectionPoolConfig connPoolConfig;
@@ -136,8 +133,8 @@ public class DefaultClientChannelManager implements ClientChannelManager {
 
         this.connEstablishTimer = metrics.connEstablishTimer();
 
-        this.connsInPool = newGauge("inPool");
-        this.connsInUse = newGauge("inUse");
+        this.connsInPool = metrics.connsInPool();
+        this.connsInUse = metrics.connsInUse();
     }
 
     @Override
@@ -490,12 +487,5 @@ public class DefaultClientChannelManager implements ClientChannelManager {
      */
     protected SocketAddress pickAddress(DiscoveryResult chosenServer) {
         return pickAddressInternal(chosenServer, connPoolConfig.getOriginName());
-    }
-
-    private AtomicInteger newGauge(String name) {
-        return PolledMeter.using(registry)
-                .withName(METRIC_PREFIX + name)
-                .withTag("id", originName.getMetricId())
-                .monitorValue(new AtomicInteger());
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetricsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetricsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.netty.connectionpool;
+
+import com.google.common.collect.Lists;
+import com.netflix.spectator.api.Counter;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Tag;
+import com.netflix.zuul.origins.OriginName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Justin Guerra
+ * @since 2/28/25
+ */
+class ConnectionPoolMetricsTest {
+
+    @Test
+    public void validateMetricNames() {
+        DefaultRegistry registry = new DefaultRegistry();
+        OriginName originName = OriginName.fromVipAndApp("whatever", "whatever");
+        ConnectionPoolMetrics metrics = ConnectionPoolMetrics.create(originName, registry);
+
+        validateCounter("connectionpool_create", metrics.createNewConnCounter());
+        validateCounter("connectionpool_create_success", metrics.createConnSucceededCounter());
+        validateCounter("connectionpool_create_fail", metrics.createConnFailedCounter());
+
+        validateCounter("connectionpool_close", metrics.closeConnCounter());
+        validateCounter("connectionpool_closeAbovePoolHighWaterMark", metrics.closeAbovePoolHighWaterMarkCounter());
+        validateCounter("connectionpool_closeExpiredConnLifetime", metrics.closeExpiredConnLifetimeCounter());
+        validateCounter("connectionpool_request", metrics.requestConnCounter());
+        validateCounter("connectionpool_reuse", metrics.reuseConnCounter());
+        validateCounter("connectionpool_release", metrics.releaseConnCounter());
+        validateCounter("connectionpool_alreadyClosed", metrics.alreadyClosedCounter());
+        validateCounter("connectionpool_fromPoolIsClosed", metrics.connTakenFromPoolIsNotOpen());
+        validateCounter("connectionpool_maxConnsPerHostExceeded", metrics.maxConnsPerHostExceededCounter());
+        validateCounter("connectionpool_closeWrtBusyConnCounter", metrics.closeWrtBusyConnCounter());
+        validateCounter("connectionpool_closeCircuitBreaker", metrics.circuitBreakerClose());
+    }
+
+    private void validateCounter(String name, Counter counter) {
+        assertEquals(name, counter.id().name());
+        Map<String, String> tags = Lists.newArrayList(counter.id().tags().iterator()).stream()
+                .collect(Collectors.toMap(Tag::key, Tag::value));
+        assertEquals("whatever", tags.get("id"));
+    }
+}


### PR DESCRIPTION
DefaultClientChannelManager creates a ton of counters that get passed around to various connection pooling classes. I created a new data class that can hold all of the various counters. I didn't try and tackle the ugly methods that take all of the counters as an argument since i'd have to make a lot of breaking changes to change them 