### PR TITLE
Add defaultValueSupplier for typed SessionContext keys

### DIFF
--- a/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
@@ -15,13 +15,15 @@
  */
 package com.netflix.zuul.context;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.google.common.truth.Truth;
 import com.netflix.zuul.context.SessionContext.Key;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
 class SessionContextTest {
@@ -91,6 +93,13 @@ class SessionContextTest {
         context.put(key, "bar");
 
         assertThrows(NullPointerException.class, () -> context.getOrDefault(key, null));
+    }
+
+    @Test
+    void getUsesDefaultValueSupplier() {
+        SessionContext context = new SessionContext();
+        Key<String> key = SessionContext.newKey("foo", () -> "bar");
+        assertEquals("bar", context.get(key));
     }
 
     @Test


### PR DESCRIPTION
This adds a `defaultValueSupplier` for typed keys to enable returning a default value, set during allocation of the typed key.

For example:
```
public static final SessionContext.Key<RequestPolicy> REQUEST_POLICY = SessionContext.newKey("request_policy", () -> RequestPolicy.Builder.setPolicy("foo").build());
```

This allows centralization of default values rather than handling individually via the `getOrDefault` at the call-site. This is particularly useful when the default value is an object so can skip initialization unless the default is required. 