### PR TITLE
Add a channel handler for HTTP request header read timeouts

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
@@ -166,6 +166,8 @@ public abstract class BaseServerStartup {
 
         channelDeps.set(ZuulDependencyKeys.sessionCtxDecorator, sessionCtxDecorator);
         channelDeps.set(ZuulDependencyKeys.requestCompleteHandler, reqCompleteHandler);
+        final Counter httpRequestHeadersReadTimeoutCounter = registry.counter("server.http.request.headers.read.timeout");
+        channelDeps.set(ZuulDependencyKeys.httpRequestHeadersReadTimeoutCounter, httpRequestHeadersReadTimeoutCounter);
         final Counter httpRequestReadTimeoutCounter = registry.counter("server.http.request.read.timeout");
         channelDeps.set(ZuulDependencyKeys.httpRequestReadTimeoutCounter, httpRequestReadTimeoutCounter);
         channelDeps.set(ZuulDependencyKeys.filterLoader, filterLoader);
@@ -189,6 +191,8 @@ public abstract class BaseServerStartup {
 
         channelDeps.set(ZuulDependencyKeys.sessionCtxDecorator, sessionCtxDecorator);
         channelDeps.set(ZuulDependencyKeys.requestCompleteHandler, reqCompleteHandler);
+        final Counter httpRequestHeadersReadTimeoutCounter = registry.counter("server.http.request.headers.read.timeout");
+        channelDeps.set(ZuulDependencyKeys.httpRequestHeadersReadTimeoutCounter, httpRequestHeadersReadTimeoutCounter);
         final Counter httpRequestReadTimeoutCounter = registry.counter("server.http.request.read.timeout");
         channelDeps.set(ZuulDependencyKeys.httpRequestReadTimeoutCounter, httpRequestReadTimeoutCounter);
         channelDeps.set(ZuulDependencyKeys.filterLoader, filterLoader);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
@@ -17,6 +17,7 @@
 package com.netflix.zuul.netty.server;
 
 import com.google.common.base.Preconditions;
+import com.netflix.config.CachedDynamicBooleanProperty;
 import com.netflix.config.CachedDynamicIntProperty;
 import com.netflix.netty.common.CloseOnIdleStateHandler;
 import com.netflix.netty.common.Http1ConnectionCloseHandler;
@@ -56,6 +57,7 @@ import com.netflix.zuul.netty.insights.PassportLoggingHandler;
 import com.netflix.zuul.netty.insights.PassportStateHttpServerHandler;
 import com.netflix.zuul.netty.insights.ServerStateHandler;
 import com.netflix.zuul.netty.server.ssl.SslHandshakeInfoHandler;
+import com.netflix.zuul.netty.timeouts.HttpHeadersTimeoutHandler;
 import com.netflix.zuul.passport.PassportState;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
@@ -87,6 +89,12 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
             new CachedDynamicIntProperty("server.http.decoder.maxHeaderSize", 32768);
     public static final CachedDynamicIntProperty MAX_CHUNK_SIZE =
             new CachedDynamicIntProperty("server.http.decoder.maxChunkSize", 32768);
+
+    public static final CachedDynamicBooleanProperty HTTP_REQUEST_HEADERS_READ_TIMEOUT_ENABLED =
+            new CachedDynamicBooleanProperty("server.http.request.headers.read.timeout.enabled", false);
+
+    public static final CachedDynamicIntProperty HTTP_REQUEST_HEADERS_READ_TIMEOUT =
+            new CachedDynamicIntProperty("server.http.request.headers.read.timeout", 5000);
 
     /**
      * The port that the server intends to listen on.  Subclasses should NOT use this field, as it may not be set, and
@@ -129,6 +137,7 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
     // protected final RequestRejectedChannelHandler requestRejectedChannelHandler;
     protected final SessionContextDecorator sessionContextDecorator;
     protected final RequestCompleteHandler requestCompleteHandler;
+    protected final Counter httpRequestHeadersReadTimeoutCounter;
     protected final Counter httpRequestReadTimeoutCounter;
     protected final FilterLoader filterLoader;
     protected final FilterUsageNotifier filterUsageNotifier;
@@ -206,6 +215,7 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
 
         this.sessionContextDecorator = channelDependencies.get(ZuulDependencyKeys.sessionCtxDecorator);
         this.requestCompleteHandler = channelDependencies.get(ZuulDependencyKeys.requestCompleteHandler);
+        this.httpRequestHeadersReadTimeoutCounter = channelDependencies.get(ZuulDependencyKeys.httpRequestHeadersReadTimeoutCounter);
         this.httpRequestReadTimeoutCounter = channelDependencies.get(ZuulDependencyKeys.httpRequestReadTimeoutCounter);
 
         this.filterLoader = channelDependencies.get(ZuulDependencyKeys.filterLoader);
@@ -251,6 +261,11 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
     }
 
     protected void addHttpRelatedHandlers(ChannelPipeline pipeline) {
+        pipeline.addLast(new HttpHeadersTimeoutHandler.InboundHandler(
+            HTTP_REQUEST_HEADERS_READ_TIMEOUT_ENABLED::get,
+            HTTP_REQUEST_HEADERS_READ_TIMEOUT::get,
+            httpRequestHeadersReadTimeoutCounter
+        ));
         pipeline.addLast(new PassportStateHttpServerHandler.InboundHandler());
         pipeline.addLast(new PassportStateHttpServerHandler.OutboundHandler());
         if (httpRequestReadTimeout > -1) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
@@ -94,7 +94,7 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
             new CachedDynamicBooleanProperty("server.http.request.headers.read.timeout.enabled", false);
 
     public static final CachedDynamicIntProperty HTTP_REQUEST_HEADERS_READ_TIMEOUT =
-            new CachedDynamicIntProperty("server.http.request.headers.read.timeout", 5000);
+            new CachedDynamicIntProperty("server.http.request.headers.read.timeout", 10000);
 
     /**
      * The port that the server intends to listen on.  Subclasses should NOT use this field, as it may not be set, and

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ZuulDependencyKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ZuulDependencyKeys.java
@@ -48,6 +48,8 @@ public class ZuulDependencyKeys {
             new ChannelConfigKey<>("sessionCtxDecorator");
     public static final ChannelConfigKey<RequestCompleteHandler> requestCompleteHandler =
             new ChannelConfigKey<>("requestCompleteHandler");
+    public static final ChannelConfigKey<Counter> httpRequestHeadersReadTimeoutCounter =
+            new ChannelConfigKey<>("httpRequestHeadersReadTimeoutCounter");
     public static final ChannelConfigKey<Counter> httpRequestReadTimeoutCounter =
             new ChannelConfigKey<>("httpRequestReadTimeoutCounter");
     public static final ChannelConfigKey<FilterLoader> filterLoader = new ChannelConfigKey<>("filterLoader");

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/HttpHeadersTimeoutHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/HttpHeadersTimeoutHandler.java
@@ -32,13 +32,13 @@ import io.netty.handler.timeout.ReadTimeoutException;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.ScheduledFuture;
 
-public final class HttpHeadersTimeoutHandler {
+public class HttpHeadersTimeoutHandler {
         private static final Logger LOG = LoggerFactory.getLogger(HttpHeadersTimeoutHandler.class);
 
         private static final AttributeKey<ScheduledFuture<Void>> HTTP_HEADERS_READ_TIMEOUT_FUTURE =
             AttributeKey.newInstance("httpHeadersReadTimeoutFuture");
 
-        public static final class InboundHandler extends ChannelInboundHandlerAdapter {
+        public static class InboundHandler extends ChannelInboundHandlerAdapter {
             private final BooleanSupplier httpHeadersReadTimeoutEnabledSupplier;
             private final IntSupplier httpHeadersReadTimeoutSupplier;
 
@@ -59,7 +59,7 @@ public final class HttpHeadersTimeoutHandler {
                         return;
                     int timeout = httpHeadersReadTimeoutSupplier.getAsInt();
                     ctx.channel().attr(HTTP_HEADERS_READ_TIMEOUT_FUTURE).set(
-                        ctx.channel().eventLoop().schedule(
+                        ctx.executor().schedule(
                             () -> {
                                 if (!closed) {
                                     ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/HttpHeadersTimeoutHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/HttpHeadersTimeoutHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.netty.timeouts;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.function.IntSupplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.spectator.api.Counter;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.timeout.ReadTimeoutException;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.ScheduledFuture;
+
+public final class HttpHeadersTimeoutHandler {
+        private static final Logger LOG = LoggerFactory.getLogger(HttpHeadersTimeoutHandler.class);
+
+        private static final AttributeKey<ScheduledFuture<Void>> HTTP_HEADERS_READ_TIMEOUT_FUTURE =
+            AttributeKey.newInstance("httpHeadersReadTimeoutFuture");
+
+        public static final class InboundHandler extends ChannelInboundHandlerAdapter {
+            private final BooleanSupplier httpHeadersReadTimeoutEnabledSupplier;
+            private final IntSupplier httpHeadersReadTimeoutSupplier;
+
+            private final Counter httpHeadersReadTimeoutCounter;
+
+            private boolean closed = false;
+
+            public InboundHandler(BooleanSupplier httpHeadersReadTimeoutEnabledSupplier, IntSupplier httpHeadersReadTimeoutSupplier, Counter httpHeadersReadTimeoutCounter) {
+                this.httpHeadersReadTimeoutEnabledSupplier = httpHeadersReadTimeoutEnabledSupplier;
+                this.httpHeadersReadTimeoutSupplier = httpHeadersReadTimeoutSupplier;
+                this.httpHeadersReadTimeoutCounter = httpHeadersReadTimeoutCounter;
+            }
+
+            @Override
+            public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                try {
+                    if (!httpHeadersReadTimeoutEnabledSupplier.getAsBoolean())
+                        return;
+                    int timeout = httpHeadersReadTimeoutSupplier.getAsInt();
+                    ctx.channel().attr(HTTP_HEADERS_READ_TIMEOUT_FUTURE).set(
+                        ctx.channel().eventLoop().schedule(
+                            () -> {
+                                if (!closed) {
+                                    ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
+                                    ctx.close();
+                                    closed = true;
+                                    httpHeadersReadTimeoutCounter.increment();
+                                    LOG.debug("[{}] HTTP headers read timeout handler timed out", ctx.channel().id());
+                                }
+                                return null;
+                            },
+                            timeout,
+                            TimeUnit.MILLISECONDS
+                        )
+                    );
+                    LOG.debug("[{}] Adding HTTP headers read timeout handler: {}", ctx.channel().id(), timeout);
+                } finally {
+                    super.channelActive(ctx);
+                }
+            }
+
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                try {
+                    if (msg instanceof HttpMessage) {
+                        ScheduledFuture<Void> future = ctx.channel().attr(HTTP_HEADERS_READ_TIMEOUT_FUTURE).get();
+                        if (future != null) {
+                            future.cancel(false);
+                            LOG.debug("[{}] Removing HTTP headers read timeout handler", ctx.channel().id());
+                        }
+                    }
+                } finally {
+                    super.channelRead(ctx, msg);
+                }
+            }
+        }
+}

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/HttpHeadersTimeoutHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/HttpHeadersTimeoutHandler.java
@@ -87,6 +87,7 @@ public class HttpHeadersTimeoutHandler {
                         ScheduledFuture<Void> future = ctx.channel().attr(HTTP_HEADERS_READ_TIMEOUT_FUTURE).get();
                         if (future != null) {
                             future.cancel(false);
+                            ctx.pipeline().remove(this);
                             LOG.debug("[{}] Removing HTTP headers read timeout handler", ctx.channel().id());
                         }
                     }

--- a/zuul-integration-test/src/test/java/com/netflix/zuul/integration/IntegrationTest.java
+++ b/zuul-integration-test/src/test/java/com/netflix/zuul/integration/IntegrationTest.java
@@ -142,7 +142,7 @@ class IntegrationTest {
     void beforeEachTest() {
         AbstractConfiguration config = ConfigurationManager.getConfigInstance();
         config.setProperty("server.http.request.headers.read.timeout.enabled", false);
-        config.setProperty("server.http.request.headers.read.timeout", 5000);
+        config.setProperty("server.http.request.headers.read.timeout", 10000);
 
         this.pathSegment = randomPathSegment();
         this.wmRuntimeInfo = wireMockExtension.getRuntimeInfo();

--- a/zuul-integration-test/src/test/java/com/netflix/zuul/integration/IntegrationTest.java
+++ b/zuul-integration-test/src/test/java/com/netflix/zuul/integration/IntegrationTest.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -139,6 +140,10 @@ class IntegrationTest {
 
     @BeforeEach
     void beforeEachTest() {
+        AbstractConfiguration config = ConfigurationManager.getConfigInstance();
+        config.setProperty("server.http.request.headers.read.timeout.enabled", false);
+        config.setProperty("server.http.request.headers.read.timeout", 5000);
+
         this.pathSegment = randomPathSegment();
         this.wmRuntimeInfo = wireMockExtension.getRuntimeInfo();
         this.wireMock = wireMockExtension.getRuntimeInfo().getWireMock();
@@ -262,6 +267,63 @@ class IntegrationTest {
         assertThat(response.code()).isEqualTo(504);
         assertThat(response.body().string()).isEqualTo("");
         verifyResponseHeaders(response);
+    }
+
+    @ParameterizedTest
+    @MethodSource("arguments")
+    void httpGetHappyPathWithHeadersReadTimeout(
+            final String description,
+            final OkHttpClient okHttp,
+            final boolean requestBodyBuffering,
+            final boolean responseBodyBuffering)
+            throws Exception {
+        AbstractConfiguration config = ConfigurationManager.getConfigInstance();
+        config.setProperty("server.http.request.headers.read.timeout.enabled", true);
+
+        wireMock.register(get(anyUrl()).willReturn(ok().withBody("hello world")));
+
+        Request request = setupRequestBuilder(requestBodyBuffering, responseBodyBuffering)
+                .get()
+                .build();
+        Response response = okHttp.newCall(request).execute();
+        assertThat(response.code()).isEqualTo(200);
+        assertThat(response.body().string()).isEqualTo("hello world");
+        verifyResponseHeaders(response);
+    }
+
+    @ParameterizedTest
+    @MethodSource("arguments")
+    void httpPostHappyPathWithHeadersReadTimeout(
+            final String description,
+            final OkHttpClient okHttp,
+            final boolean requestBodyBuffering,
+            final boolean responseBodyBuffering)
+            throws Exception {
+        AbstractConfiguration config = ConfigurationManager.getConfigInstance();
+        config.setProperty("server.http.request.headers.read.timeout.enabled", true);
+
+        wireMock.register(post(anyUrl()).willReturn(ok().withBody("Thank you next")));
+
+        Request request = setupRequestBuilder(requestBodyBuffering, responseBodyBuffering)
+                .post(RequestBody.create("Simple POST request body".getBytes(StandardCharsets.UTF_8)))
+                .build();
+        Response response = okHttp.newCall(request).execute();
+        assertThat(response.code()).isEqualTo(200);
+        assertThat(response.body().string()).isEqualTo("Thank you next");
+        verifyResponseHeaders(response);
+    }
+
+    @Test
+    void httpGetFailsDueToHeadersReadTimeout() throws Exception {
+        AbstractConfiguration config = ConfigurationManager.getConfigInstance();
+        config.setProperty("server.http.request.headers.read.timeout.enabled", true);
+        config.setProperty("server.http.request.headers.read.timeout", 100);
+
+        Socket slowClient = new Socket("localhost", ZUUL_SERVER_PORT);
+        Thread.sleep(500);
+        // end of stream reached because zuul closed the connection
+        assertThat(slowClient.getInputStream().read()).isEqualTo(-1);
+        slowClient.close();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
This lets us specify timeouts around HTTP headers, which proves useful for mitigating attacks on endpoints that have necessarily long overall request timeouts due to long request bodies. The handler is gated by a `server.http.request.headers.read.timeout.enabled` bool property and specified by a `server.http.request.headers.read.timeout` int property in milliseconds. Timeouts are reported to the `server.http.request.headers.read.timeout` counter metric.