### PR TITLE
Pin junit to 5.11.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,10 +235,10 @@ subprojects {
         libraries = [
                 guava: "com.google.guava:guava:33.3.0-jre",
                 okhttp: 'com.squareup.okhttp3:okhttp:4.12.0',
-                jupiterApi: 'org.junit.jupiter:junit-jupiter-api:5.+',
-                jupiterParams: 'org.junit.jupiter:junit-jupiter-params:5.+',
-                jupiterEngine: 'org.junit.jupiter:junit-jupiter-engine:5.+',
-                jupiterMockito: 'org.mockito:mockito-junit-jupiter:5.+',
+                jupiterApi: 'org.junit.jupiter:junit-jupiter-api:5.11.+',
+                jupiterParams: 'org.junit.jupiter:junit-jupiter-params:5.11.+',
+                jupiterEngine: 'org.junit.jupiter:junit-jupiter-engine:5.11.+',
+                jupiterMockito: 'org.mockito:mockito-junit-jupiter:5.11.+',
                 mockito: 'org.mockito:mockito-core:5.+',
 
                 slf4j: "org.slf4j:slf4j-api:2.0.16",

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -154,7 +154,7 @@
             ]
         },
         "org.projectlombok:lombok": {
-            "locked": "1.18.30"
+            "locked": "1.18.36"
         }
     },
     "compileClasspath": {
@@ -293,7 +293,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6"
+            "locked": "1.8.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -565,7 +565,7 @@
             ]
         },
         "org.projectlombok:lombok": {
-            "locked": "1.18.30"
+            "locked": "1.18.36"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.16",
@@ -925,7 +925,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6"
+            "locked": "1.8.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -1243,7 +1243,7 @@
             ]
         },
         "org.projectlombok:lombok": {
-            "locked": "1.18.30"
+            "locked": "1.18.36"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.16",
@@ -1467,7 +1467,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6"
+            "locked": "1.8.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -1898,13 +1898,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.16.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.objenesis:objenesis": {
             "locked": "3.3",
@@ -2179,7 +2179,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6"
+            "locked": "1.8.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -2838,7 +2838,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6"
+            "locked": "1.8.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -3204,13 +3204,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.16.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.opentest4j:opentest4j": {
             "locked": "1.3.0",
@@ -3447,7 +3447,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6"
+            "locked": "1.8.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -3866,13 +3866,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.16.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.objenesis:objenesis": {
             "locked": "3.3",

--- a/zuul-discovery/dependencies.lock
+++ b/zuul-discovery/dependencies.lock
@@ -1251,7 +1251,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2"
+            "locked": "5.16.0"
         },
         "org.objenesis:objenesis": {
             "locked": "3.3",
@@ -2114,7 +2114,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2"
+            "locked": "5.16.0"
         },
         "org.opentest4j:opentest4j": {
             "locked": "1.3.0",
@@ -2545,7 +2545,7 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2"
+            "locked": "5.16.0"
         },
         "org.objenesis:objenesis": {
             "locked": "3.3",

--- a/zuul-groovy/dependencies.lock
+++ b/zuul-groovy/dependencies.lock
@@ -310,7 +310,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -1080,7 +1080,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -1760,7 +1760,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -2386,7 +2386,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.codehaus.groovy:groovy-test-junit5",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -2396,14 +2396,14 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.codehaus.groovy:groovy-test-junit5",
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit:junit-bom"
             ]
@@ -2432,7 +2432,7 @@
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -2443,13 +2443,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.16.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.objenesis:objenesis": {
             "locked": "3.3",
@@ -2750,7 +2750,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -3759,7 +3759,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -4165,7 +4165,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.codehaus.groovy:groovy-test-junit5",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -4174,13 +4174,13 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit:junit-bom"
             ]
@@ -4201,7 +4201,7 @@
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -4211,13 +4211,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.16.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.opentest4j:opentest4j": {
             "locked": "1.3.0",
@@ -4475,7 +4475,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -5146,13 +5146,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.16.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.objenesis:objenesis": {
             "locked": "3.3",

--- a/zuul-guice/dependencies.lock
+++ b/zuul-guice/dependencies.lock
@@ -304,7 +304,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -877,7 +877,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -1354,7 +1354,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -1813,13 +1813,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.16.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.objenesis:objenesis": {
             "locked": "3.3",
@@ -2095,7 +2095,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -2806,7 +2806,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -3096,13 +3096,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.16.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.opentest4j:opentest4j": {
             "locked": "1.3.0",
@@ -3348,7 +3348,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -3795,13 +3795,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.16.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.objenesis:objenesis": {
             "locked": "3.3",

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -278,7 +278,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -873,7 +873,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -1463,7 +1463,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -2033,7 +2033,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -2382,13 +2382,13 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.14.12",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.14.12",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -2746,7 +2746,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -2755,13 +2755,13 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit:junit-bom"
             ]
@@ -2782,7 +2782,7 @@
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -2792,13 +2792,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.11.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.objenesis:objenesis": {
             "locked": "3.3",
@@ -3128,7 +3128,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -3911,7 +3911,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -4165,13 +4165,13 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.14.12",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.14.12",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -4451,7 +4451,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -4459,13 +4459,13 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit:junit-bom"
             ]
@@ -4486,7 +4486,7 @@
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -4496,13 +4496,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.11.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.opentest4j:opentest4j": {
             "locked": "1.3.0",
@@ -4878,7 +4878,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -5227,13 +5227,13 @@
             ]
         },
         "net.bytebuddy:byte-buddy": {
-            "locked": "1.15.11",
+            "locked": "1.14.12",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
         },
         "net.bytebuddy:byte-buddy-agent": {
-            "locked": "1.15.11",
+            "locked": "1.14.12",
             "transitive": [
                 "org.mockito:mockito-core"
             ]
@@ -5630,13 +5630,13 @@
             ]
         },
         "org.mockito:mockito-core": {
-            "locked": "5.15.2",
+            "locked": "5.11.0",
             "transitive": [
                 "org.mockito:mockito-junit-jupiter"
             ]
         },
         "org.mockito:mockito-junit-jupiter": {
-            "locked": "5.15.2"
+            "locked": "5.11.0"
         },
         "org.objenesis:objenesis": {
             "locked": "3.3",

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -304,7 +304,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -877,7 +877,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -1354,7 +1354,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -1755,7 +1755,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -1763,13 +1763,13 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit:junit-bom"
             ]
@@ -1790,7 +1790,7 @@
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -2067,7 +2067,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -2740,7 +2740,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -3339,7 +3339,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -3572,7 +3572,7 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-engine",
                 "org.junit.jupiter:junit-jupiter-params",
@@ -3580,13 +3580,13 @@
             ]
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit:junit-bom"
             ]
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit:junit-bom"
             ]
@@ -3607,7 +3607,7 @@
             ]
         },
         "org.junit:junit-bom": {
-            "locked": "5.12.0-RC2",
+            "locked": "5.11.4",
             "transitive": [
                 "org.junit.jupiter:junit-jupiter-api",
                 "org.junit.jupiter:junit-jupiter-engine",
@@ -3860,7 +3860,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -278,7 +278,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -876,7 +876,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -1656,7 +1656,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -2336,7 +2336,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -3315,7 +3315,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -4345,7 +4345,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
@@ -4983,7 +4983,7 @@
             ]
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.8.6",
+            "locked": "1.8.7",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]


### PR DESCRIPTION
Junit v5.12.x has an incompatibility with a junit transitive dependency from groovy; pin back to v5.11.x until it is fixed