### PR TITLE
Add overload for `getOrDefault` method to always return a non-null value

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
@@ -153,6 +153,15 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
 
         return value;
     }
+    
+    /**
+     * Returns the value in the context, or default value from the
+     * typed key default value supplier if absent.
+     */
+    @NonNull
+    public <T> T getOrDefault(@NonNull Key<T> key) {
+        return Objects.requireNonNull(this.get(key), "expected non-null value or defaultValue supplier");
+    }
 
     /**
      * Returns the value in the context, or {@code defaultValue} if absent.

--- a/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
@@ -103,6 +103,20 @@ class SessionContextTest {
     }
 
     @Test
+    void getOrDefaultUsesDefaultValueSupplier() {
+        SessionContext context = new SessionContext();
+        Key<String> key = SessionContext.newKey("foo", () -> "bar");
+        assertEquals("bar", context.getOrDefault(key));
+    }
+
+    @Test
+    void getOrDefaultUsesDefaultValueSupplierFailsWithout() {
+        SessionContext context = new SessionContext();
+        Key<String> key = SessionContext.newKey("foo");
+        assertThrows(NullPointerException.class, () -> context.getOrDefault(key));
+    }
+
+    @Test
     void remove() {
         SessionContext context = new SessionContext();
         Key<String> key = SessionContext.newKey("foo");


### PR DESCRIPTION
When utilizing the `defaultValue` supplier in a typed `SessionContext.Key`, a value is always available. This PR adds an overload for `getOrDefault` method which uses the default value supplier to always return a non-null value. This allows for direct usage of `context.getOrDefault(somekey)`  without having to null-check the return value.

e.g.

```
SessionContext.Key<String> FOO_BAR = SessionContext.newKey("foo", () -> "bar");
...
String value = request.getContext().get(FOO_BAR);
if (value != null) {
  log.info("Always have a " + value);
}
```

becomes

```
SessionContext.Key<String> FOO_BAR = SessionContext.newKey("foo", () -> "bar");
...
String value = request.getContext().getOrDefault(FOO_BAR)
log.info("Always have a " + value);
```
