### PR TITLE
Fix automatic lint bugs from yoda-condition

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/common/SurgicalDebugFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/common/SurgicalDebugFilter.java
@@ -25,6 +25,7 @@ import com.netflix.zuul.filters.FilterType;
 import com.netflix.zuul.filters.http.HttpInboundSyncFilter;
 import com.netflix.zuul.message.http.HttpQueryParams;
 import com.netflix.zuul.message.http.HttpRequestMessage;
+import java.util.Objects;
 
 /**
  * This is an abstract filter that will route requests that match the patternMatches() method to a debug Eureka "VIP" or
@@ -68,8 +69,8 @@ public class SurgicalDebugFilter extends HttpInboundSyncFilter {
         }
 
         String isSurgicalFilterRequest = request.getHeaders().getFirst(ZuulHeaders.X_ZUUL_SURGICAL_FILTER);
-        // dont' apply filter if it was already applied
-        boolean notAlreadyFiltered = !isSurgicalFilterRequest.equals("true");
+        // don't apply filter if it was already applied
+        boolean notAlreadyFiltered = !Objects.equals(isSurgicalFilterRequest, "true");
 
         return notAlreadyFiltered && patternMatches(request);
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -72,6 +72,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.net.ssl.SSLException;
@@ -247,7 +248,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
                         // of response to the channel, which causes this CompleteEvent to fire before we have cleaned up
                         // state. But
                         // thats ok, so don't log in that case.
-                        if (zuulRequest.getProtocol().equals("HTTP/2")) {
+                        if (Objects.equals(zuulRequest.getProtocol(), "HTTP/2")) {
                             LOG.debug(
                                     "Client {} request UUID {} to {} completed with reason = {}, {}",
                                     clientRequest.method(),

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/OriginResponseReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/OriginResponseReceiver.java
@@ -16,9 +16,6 @@
 
 package com.netflix.zuul.netty.server;
 
-import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
-import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
-
 import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
 import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
 import com.netflix.zuul.exception.OutboundErrorType;
@@ -50,6 +47,7 @@ import io.perfmark.PerfMark;
 import io.perfmark.TaskCloseable;
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,7 +113,7 @@ public class OriginResponseReceiver extends ChannelDuplexHandler {
             CompleteReason reason = completeEvent.getReason();
             if ((reason != CompleteReason.SESSION_COMPLETE) && (edgeProxy != null)) {
                 if (reason == CompleteReason.CLOSE
-                        && ctx.channel().attr(SSL_CLOSE_NOTIFY_SEEN).get().equals(Boolean.TRUE)) {
+                        && Objects.equals(ctx.channel().attr(SSL_CLOSE_NOTIFY_SEEN).get(), Boolean.TRUE)) {
                     logger.warn(
                             "Origin request completed with close, after getting a SslCloseCompletionEvent event: {}",
                             ChannelUtils.channelInfoForLogging(ctx.channel()));

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushAuthHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushAuthHandler.java
@@ -78,7 +78,7 @@ public abstract class PushAuthHandler extends SimpleChannelInboundHandler<FullHt
         }
 
         String path = req.uri();
-        if (path.equals("/healthcheck")) {
+        if (Objects.equals(path, "/healthcheck")) {
             sendHttpResponse(req, ctx, HttpResponseStatus.OK);
         } else if (pushConnectionPath.equals(path)) {
             // CSRF protection

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ssl/SslHandshakeInfoHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ssl/SslHandshakeInfoHandler.java
@@ -39,6 +39,7 @@ import io.netty.util.AttributeKey;
 import java.nio.channels.ClosedChannelException;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.net.ssl.SSLException;
@@ -105,10 +106,11 @@ public class SslHandshakeInfoHandler extends ChannelInboundHandlerAdapter {
                     }
 
                     // if attribute is true, then true. If null or false then false
-                    boolean tlsHandshakeUsingExternalPSK = ctx.channel()
-                            .attr(ZuulPskServer.TLS_HANDSHAKE_USING_EXTERNAL_PSK)
-                            .get()
-                            .equals(Boolean.TRUE);
+                    boolean tlsHandshakeUsingExternalPSK = Objects.equals(
+                            ctx.channel()
+                                    .attr(ZuulPskServer.TLS_HANDSHAKE_USING_EXTERNAL_PSK)
+                                    .get(),
+                            Boolean.TRUE);
 
                     ClientPSKIdentityInfo clientPSKIdentityInfo = ctx.channel()
                             .attr(TlsPskHandler.CLIENT_PSK_IDENTITY_ATTRIBUTE_KEY)
@@ -138,8 +140,8 @@ public class SslHandshakeInfoHandler extends ChannelInboundHandlerAdapter {
                     PassportState passportState =
                             CurrentPassport.fromChannel(ctx.channel()).getState();
                     if (cause instanceof ClosedChannelException
-                            && (passportState.equals(PassportState.SERVER_CH_INACTIVE)
-                                    || passportState.equals(PassportState.SERVER_CH_IDLE_TIMEOUT))) {
+                            && (passportState == PassportState.SERVER_CH_INACTIVE
+                                    || passportState == PassportState.SERVER_CH_IDLE_TIMEOUT)) {
                         // Either client closed the connection without/before having completed a handshake, or
                         // the connection idle timed-out before handshake.
                         // NOTE: we were seeing a lot of these in prod and can repro by just telnetting to port and then


### PR DESCRIPTION
The yoda-condition linter doesn't always account for null-ability of fields. Manually fix up those which can be null.