### PR TITLE
Add timing metric for client request headers

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
@@ -32,6 +32,7 @@ import com.netflix.netty.common.ssl.ServerSslConfig;
 import com.netflix.netty.common.status.ServerStatusManager;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
 import com.netflix.zuul.FilterLoader;
 import com.netflix.zuul.FilterUsageNotifier;
 import com.netflix.zuul.RequestCompleteHandler;
@@ -168,6 +169,8 @@ public abstract class BaseServerStartup {
         channelDeps.set(ZuulDependencyKeys.requestCompleteHandler, reqCompleteHandler);
         Counter httpRequestHeadersReadTimeoutCounter = registry.counter("server.http.request.headers.read.timeout");
         channelDeps.set(ZuulDependencyKeys.httpRequestHeadersReadTimeoutCounter, httpRequestHeadersReadTimeoutCounter);
+        Timer httpRequestHeadersReadTimer = registry.timer("server.http.request.headers.read.timer");
+        channelDeps.set(ZuulDependencyKeys.httpRequestHeadersReadTimer, httpRequestHeadersReadTimer);
         Counter httpRequestReadTimeoutCounter = registry.counter("server.http.request.read.timeout");
         channelDeps.set(ZuulDependencyKeys.httpRequestReadTimeoutCounter, httpRequestReadTimeoutCounter);
         channelDeps.set(ZuulDependencyKeys.filterLoader, filterLoader);
@@ -193,6 +196,8 @@ public abstract class BaseServerStartup {
         channelDeps.set(ZuulDependencyKeys.requestCompleteHandler, reqCompleteHandler);
         Counter httpRequestHeadersReadTimeoutCounter = registry.counter("server.http.request.headers.read.timeout");
         channelDeps.set(ZuulDependencyKeys.httpRequestHeadersReadTimeoutCounter, httpRequestHeadersReadTimeoutCounter);
+        Timer httpRequestHeadersReadTimer = registry.timer("server.http.request.headers.read.timer");
+        channelDeps.set(ZuulDependencyKeys.httpRequestHeadersReadTimer, httpRequestHeadersReadTimer);
         Counter httpRequestReadTimeoutCounter = registry.counter("server.http.request.read.timeout");
         channelDeps.set(ZuulDependencyKeys.httpRequestReadTimeoutCounter, httpRequestReadTimeoutCounter);
         channelDeps.set(ZuulDependencyKeys.filterLoader, filterLoader);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
@@ -39,6 +39,7 @@ import com.netflix.netty.common.proxyprotocol.StripUntrustedProxyHeadersHandler;
 import com.netflix.netty.common.throttle.MaxInboundConnectionsHandler;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
 import com.netflix.zuul.FilterLoader;
 import com.netflix.zuul.FilterUsageNotifier;
 import com.netflix.zuul.RequestCompleteHandler;
@@ -137,6 +138,7 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
     protected final SessionContextDecorator sessionContextDecorator;
     protected final RequestCompleteHandler requestCompleteHandler;
     protected final Counter httpRequestHeadersReadTimeoutCounter;
+    protected final Timer httpRequestHeadersReadTimer;
     protected final Counter httpRequestReadTimeoutCounter;
     protected final FilterLoader filterLoader;
     protected final FilterUsageNotifier filterUsageNotifier;
@@ -214,6 +216,7 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
         this.sessionContextDecorator = channelDependencies.get(ZuulDependencyKeys.sessionCtxDecorator);
         this.requestCompleteHandler = channelDependencies.get(ZuulDependencyKeys.requestCompleteHandler);
         this.httpRequestHeadersReadTimeoutCounter = channelDependencies.get(ZuulDependencyKeys.httpRequestHeadersReadTimeoutCounter);
+        this.httpRequestHeadersReadTimer = channelDependencies.get(ZuulDependencyKeys.httpRequestHeadersReadTimer);
         this.httpRequestReadTimeoutCounter = channelDependencies.get(ZuulDependencyKeys.httpRequestReadTimeoutCounter);
 
         this.filterLoader = channelDependencies.get(ZuulDependencyKeys.filterLoader);
@@ -262,7 +265,8 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
         pipeline.addLast(new HttpHeadersTimeoutHandler.InboundHandler(
             HTTP_REQUEST_HEADERS_READ_TIMEOUT_ENABLED::get,
             HTTP_REQUEST_HEADERS_READ_TIMEOUT::get,
-            httpRequestHeadersReadTimeoutCounter
+            httpRequestHeadersReadTimeoutCounter,
+            httpRequestHeadersReadTimer
         ));
         pipeline.addLast(new PassportStateHttpServerHandler.InboundHandler());
         pipeline.addLast(new PassportStateHttpServerHandler.OutboundHandler());

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ZuulDependencyKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ZuulDependencyKeys.java
@@ -24,6 +24,7 @@ import com.netflix.netty.common.metrics.EventLoopGroupMetrics;
 import com.netflix.netty.common.status.ServerStatusManager;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
 import com.netflix.zuul.FilterLoader;
 import com.netflix.zuul.FilterUsageNotifier;
 import com.netflix.zuul.RequestCompleteHandler;
@@ -50,6 +51,8 @@ public class ZuulDependencyKeys {
             new ChannelConfigKey<>("requestCompleteHandler");
     public static final ChannelConfigKey<Counter> httpRequestHeadersReadTimeoutCounter =
             new ChannelConfigKey<>("httpRequestHeadersReadTimeoutCounter");
+public static final ChannelConfigKey<Timer> httpRequestHeadersReadTimer =
+            new ChannelConfigKey<>("httpRequestHeadersReadTimer");
     public static final ChannelConfigKey<Counter> httpRequestReadTimeoutCounter =
             new ChannelConfigKey<>("httpRequestReadTimeoutCounter");
     public static final ChannelConfigKey<FilterLoader> filterLoader = new ChannelConfigKey<>("filterLoader");


### PR DESCRIPTION
Turns out we don't have a timing metric around header reading internally, so this change adds one.