### PR TITLE
Extract client ip method

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -321,7 +321,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
             context = new SessionContext();
         }
 
-        // Get the client IP
+        // Get the client IP (ignore XFF headers at this point, as that can be app specific).
         Channel channel = clientCtx.channel();
         String clientIp = getClientIp(channel);
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -16,6 +16,8 @@
 
 package com.netflix.zuul.netty.server;
 
+import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
+import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.netty.common.ssl.SslHandshakeInfo;
 import com.netflix.netty.common.throttle.RejectionUtils;
@@ -63,10 +65,6 @@ import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import io.perfmark.PerfMark;
 import io.perfmark.TaskCloseable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.SSLException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Iterator;
@@ -76,9 +74,9 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
-import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
+import javax.net.ssl.SSLException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Created by saroskar on 1/6/17.


### PR DESCRIPTION
There are cases where the client ip set in the http request object is not correct. We should use the ATTR_CLIENT_IP value  set in ClientIpChannelHandler instead, which takes into account ppv2 and XFF headers. 
The only issue is that this value is scoped to edgezuul-netty, but the http request is created in zuul oss in ClientRequestReceiver, which means it is not accessible. 
To deal with this, we can extract the code to get the client ip and then override it in edgezuul-netty by creating an EdgeClientRequestReceiver class that returns the client ip using ClientIpChannelHandler.ATTR_CLIENT_IP instead. That PR will follow this one.