### PR TITLE
fix Disabled Netty HTTP header validation OriginResponseReceiver CRLF Injection

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/OriginResponseReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/OriginResponseReceiver.java
@@ -172,7 +172,7 @@ public class OriginResponseReceiver extends ChannelDuplexHandler {
         customRequestProcessing(zuulRequest);
 
         DefaultHttpRequest nettyReq =
-                new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method), uri, false);
+                new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method), uri);
         // Copy headers across.
         for (Header h : zuulRequest.getHeaders().entries()) {
             nettyReq.headers().add(h.getKey(), h.getValue());


### PR DESCRIPTION
https://github.com/Netflix/zuul/blob/f7048c2602d126b7a087b8794942c99d6b0d1805/zuul-core/src/main/java/com/netflix/zuul/netty/server/OriginResponseReceiver.java#L175-L175

fix the issue need to enable Netty's internal header validation by using the `DefaultHttpRequest` constructor without the `validateHeaders` parameter (or with it set to `true`). This ensures that headers are validated for CRLF characters, mitigating the risk of HTTP request splitting vulnerabilities. The change will involve modifying the instantiation of `DefaultHttpRequest` on line 175 to remove the `false` parameter, which disables header validation. No additional imports or method definitions are required.


Directly writing user input (for example, an HTTP request parameter) to an HTTP header can lead to an HTTP request-splitting or response-splitting vulnerability. HTTP response splitting can lead to vulnerabilities such as XSS and cache poisoning.

HTTP request splitting can allow an attacker to inject an additional HTTP request into a client's outgoing socket connection. This can allow an attacker to perform an SSRF-like attack. n the context of a servlet container, if the user input includes blank lines and the servlet container does not escape the blank lines, then a remote user can cause the response to turn into two separate responses. The remote user can then control one or more responses, which is also HTTP response splitting.

The following shows the 'name' parameter being written to a cookie in two different ways. The first way writes it directly to the cookie, and thus is vulnerable to response-splitting attacks. The second way first removes all special characters, thus avoiding the potential problem.
```java
public class ResponseSplitting extends HttpServlet {
	protected void doGet(HttpServletRequest request, HttpServletResponse response)
	throws ServletException, IOException {
		// BAD: setting a cookie with an unvalidated parameter
		Cookie cookie = new Cookie("name", request.getParameter("name"));
		response.addCookie(cookie);

		// GOOD: remove special characters before putting them in the header
		String name = removeSpecial(request.getParameter("name"));
		Cookie cookie2 = new Cookie("name", name);
		response.addCookie(cookie2);
	}

	private static String removeSpecial(String str) {
		return str.replaceAll("[^a-zA-Z ]", "");
	}
}
```
The following shows the use of the library 'netty' with HTTP response-splitting verification configurations. The second way will verify the parameters before using them to build the HTTP response.
```java
import io.netty.handler.codec.http.DefaultHttpHeaders;

public class ResponseSplitting {
    // BAD: Disables the internal response splitting verification
    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);

    // GOOD: Verifies headers passed don't contain CRLF characters
    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();

    // BAD: Disables the internal response splitting verification
    private final DefaultHttpResponse badResponse = new DefaultHttpResponse(version, httpResponseStatus, false);

    // GOOD: Verifies headers passed don't contain CRLF characters
    private final DefaultHttpResponse goodResponse = new DefaultHttpResponse(version, httpResponseStatus);
}
```
The following shows the use of the netty library with configurations for verification of HTTP request splitting. The second recommended approach in the example verifies the parameters before using them to build the HTTP request.
```java
public class NettyRequestSplitting {
    // BAD: Disables the internal request splitting verification
    private final DefaultHttpHeaders badHeaders = new DefaultHttpHeaders(false);

    // GOOD: Verifies headers passed don't contain CRLF characters
    private final DefaultHttpHeaders goodHeaders = new DefaultHttpHeaders();

    // BAD: Disables the internal request splitting verification
    private final DefaultHttpRequest badRequest = new DefaultHttpRequest(httpVersion, method, uri, false);

    // GOOD: Verifies headers passed don't contain CRLF characters
    private final DefaultHttpRequest goodResponse = new DefaultHttpRequest(httpVersion, method, uri);
}
```
## References
[HTTP response splitting](https://seclists.org/bugtraq/2005/Apr/187)
[HTTP Response Splitting](https://www.owasp.org/index.php/HTTP_Response_Splitting)
[HTTP response splitting](http://en.wikipedia.org/wiki/HTTP_response_splitting)
[CAPEC-105: HTTP Request Splitting](https://capec.mitre.org/data/definitions/105.html)
[CWE-93](https://cwe.mitre.org/data/definitions/93.html)
[CWE-113](https://cwe.mitre.org/data/definitions/113.html)

