### PR TITLE
Don't throw ReadTimeoutException for HttpHeadersTimeoutHandler

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/HttpHeadersTimeoutHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/HttpHeadersTimeoutHandler.java
@@ -70,7 +70,6 @@ public class HttpHeadersTimeoutHandler {
                                 .schedule(
                                         () -> {
                                             if (!closed) {
-                                                ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
                                                 ctx.close();
                                                 closed = true;
                                                 if (httpHeadersReadTimeoutCounter != null)


### PR DESCRIPTION
We won't be able to catch it in any future handler as we immediately close the context. Normally we would catch it later in order to return an HTTP status code, but that doesn't make sense to do before the request headers have been recieved.