### PR TITLE
Resume filter chain in onComplete instead of onNext

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/BaseFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/BaseFilter.java
@@ -141,4 +141,8 @@ public abstract class BaseFilter<I extends ZuulMessage, O extends ZuulMessage> i
     public void decrementConcurrency() {
         concurrentCount.decrementAndGet();
     }
+
+    public int getConcurrency() {
+        return concurrentCount.get();
+    }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
@@ -55,7 +55,8 @@ import rx.functions.Action1;
 import rx.schedulers.Schedulers;
 
 /**
- * Subclasses of this class are supposed to be thread safe and hence should not have any non final member variables
+ * Subclasses of this class are supposed to be thread safe
+ *
  * Created by saroskar on 5/18/17.
  */
 @ThreadSafe
@@ -202,7 +203,6 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
                 filterRunStatus = ExecutionStatus.SKIPPED;
             }
 
-            ;
             try (TaskCloseable ignored2 = PerfMark.traceTask(filter, f -> f.filterName() + ".shouldSkipFilter")) {
                 if (shouldSkipFilter(inMesg, filter)) {
                     filterRunStatus = ExecutionStatus.SKIPPED;
@@ -239,7 +239,7 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
             inMesg.runBufferedBodyContentThroughFilter(filter);
 
             if (filter.getSyncType() == FilterSyncType.SYNC) {
-                SyncZuulFilter<I, O> syncFilter = (SyncZuulFilter) filter;
+                SyncZuulFilter<I, O> syncFilter = (SyncZuulFilter<I, O>) filter;
                 O outMesg;
                 try (TaskCloseable ignored2 = PerfMark.traceTask(filter, f -> f.filterName() + ".apply")) {
                     addPerfMarkTags(inMesg);
@@ -282,8 +282,10 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
         }
     }
 
-    /* This is typically set by a filter when wanting to reject a request and also reduce load on the server by
-    not processing any more filterChain */
+    /**
+     *  This is typically set by a filter when wanting to reject a request and also reduce load on the server by
+     *  not processing anymore filterChain
+     */
     protected final boolean shouldSkipFilter(I inMesg, ZuulFilter<I, O> filter) {
         if (filter.filterType() == FilterType.ENDPOINT) {
             // Endpoints may not be skipped
@@ -427,6 +429,8 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
         private final AtomicReference<Link> onErrorLinkOut = new AtomicReference<>();
         private final AtomicReference<Link> onCompletedLinkOut = new AtomicReference<>();
 
+        private O outMesg;
+
         public FilterChainResumer(I inMesg, ZuulFilter<I, O> filter, ZuulMessage snapshot, long startTime) {
             this.inMesg = Preconditions.checkNotNull(inMesg, "input message");
             this.filter = Preconditions.checkNotNull(filter, "filter");
@@ -446,11 +450,10 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
             try (TaskCloseable ignored = PerfMark.traceTask(filter, f -> f.filterName() + ".onNextAsync")) {
                 PerfMark.linkIn(onNextLinkOut.get());
                 addPerfMarkTags(inMesg);
-                recordFilterCompletion(ExecutionStatus.SUCCESS, filter, startTime, inMesg, snapshot);
                 if (outMesg == null) {
                     outMesg = filter.getDefaultOutput(inMesg);
                 }
-                resumeInBindingContext(outMesg, filter.filterName());
+                this.outMesg = outMesg;
             } catch (Exception e) {
                 decrementConcurrency();
                 handleException(inMesg, filter.filterName(), e);
@@ -475,6 +478,8 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
             try (TaskCloseable ignored = PerfMark.traceTask(filter, f -> f.filterName() + ".onCompletedAsync")) {
                 PerfMark.linkIn(onCompletedLinkOut.get());
                 decrementConcurrency();
+                recordFilterCompletion(ExecutionStatus.SUCCESS, filter, startTime, inMesg, snapshot);
+                resumeInBindingContext(outMesg, filter.filterName());
             }
         }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
@@ -475,12 +475,14 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
         public void onCompleted() {
             try (TaskCloseable ignored = PerfMark.traceTask(filter, f -> f.filterName() + ".onCompletedAsync")) {
                 PerfMark.linkIn(onCompletedLinkOut.get());
+                decrementConcurrency();
                 if (outMesg == null) {
                     outMesg = filter.getDefaultOutput(inMesg);
                 }
-                decrementConcurrency();
                 recordFilterCompletion(ExecutionStatus.SUCCESS, filter, startTime, inMesg, snapshot);
                 resumeInBindingContext(outMesg, filter.filterName());
+            } catch (Exception e) {
+                handleException(inMesg, filter.filterName(), e);
             }
         }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
@@ -179,7 +179,7 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
             req = (HttpRequestInfo) inMesg;
         }
         if (inMesg instanceof HttpResponseMessage msg) {
-            
+
             req = msg.getOutboundRequest();
             PerfMark.attachTag("statuscode", msg.getStatus());
         }
@@ -450,9 +450,6 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
             try (TaskCloseable ignored = PerfMark.traceTask(filter, f -> f.filterName() + ".onNextAsync")) {
                 PerfMark.linkIn(onNextLinkOut.get());
                 addPerfMarkTags(inMesg);
-                if (outMesg == null) {
-                    outMesg = filter.getDefaultOutput(inMesg);
-                }
                 this.outMesg = outMesg;
             } catch (Exception e) {
                 decrementConcurrency();
@@ -477,6 +474,9 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
         public void onCompleted() {
             try (TaskCloseable ignored = PerfMark.traceTask(filter, f -> f.filterName() + ".onCompletedAsync")) {
                 PerfMark.linkIn(onCompletedLinkOut.get());
+                if (outMesg == null) {
+                    outMesg = filter.getDefaultOutput(inMesg);
+                }
                 decrementConcurrency();
                 recordFilterCompletion(ExecutionStatus.SUCCESS, filter, startTime, inMesg, snapshot);
                 resumeInBindingContext(outMesg, filter.filterName());

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunner.java
@@ -429,6 +429,7 @@ public abstract class BaseZuulFilterRunner<I extends ZuulMessage, O extends Zuul
         private final AtomicReference<Link> onErrorLinkOut = new AtomicReference<>();
         private final AtomicReference<Link> onCompletedLinkOut = new AtomicReference<>();
 
+        // no synchronization needed since onNext and onCompleted are always called on the same thread
         private O outMesg;
 
         public FilterChainResumer(I inMesg, ZuulFilter<I, O> filter, ZuulMessage snapshot, long startTime) {

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunnerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunnerTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2025 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.netty.filter;
+
+import com.netflix.spectator.api.NoopRegistry;
+import com.netflix.spectator.api.Registry;
+import com.netflix.zuul.Filter;
+import com.netflix.zuul.FilterUsageNotifier;
+import com.netflix.zuul.context.CommonContextKeys;
+import com.netflix.zuul.context.SessionContext;
+import com.netflix.zuul.filters.BaseFilter;
+import com.netflix.zuul.filters.FilterSyncType;
+import com.netflix.zuul.filters.FilterType;
+import com.netflix.zuul.message.ZuulMessage;
+import com.netflix.zuul.message.util.HttpRequestBuilder;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.local.LocalChannel;
+import io.netty.handler.codec.http.HttpContent;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import rx.Observable;
+
+/**
+ * @author Justin Guerra
+ * @since 5/20/25
+ */
+@ExtendWith(MockitoExtension.class)
+public class BaseZuulFilterRunnerTest {
+
+    @Mock
+    private FilterUsageNotifier notifier;
+
+    @Mock
+    private FilterRunner<ZuulMessage, ZuulMessage> nextStage;
+
+    private ZuulMessage message;
+    private TestBaseZuulFilterRunner runner;
+    private EventLoopGroup group;
+    private TestResumer resumer;
+
+    @BeforeEach
+    public void setup() {
+        runner = new TestBaseZuulFilterRunner(FilterType.INBOUND, notifier, nextStage, new NoopRegistry());
+        SessionContext sessionContext = new SessionContext();
+        message = new HttpRequestBuilder(sessionContext).build();
+
+        group = new DefaultEventLoopGroup(1);
+        LocalChannel localChannel = new LocalChannel();
+        localChannel.pipeline().addLast(new ChannelInboundHandlerAdapter());
+        group.register(localChannel);
+        ChannelHandlerContext context = localChannel.pipeline().context(ChannelInboundHandlerAdapter.class);
+        sessionContext.set(CommonContextKeys.NETTY_SERVER_CHANNEL_HANDLER_CONTEXT, context);
+        resumer = new TestResumer(Function.identity());
+    }
+
+    @AfterEach
+    public void teardown() {
+        group.shutdownGracefully();
+    }
+
+    @Test
+    public void onCompleteCalledBeforeResume() {
+        AsyncFilter asyncFilter = new AsyncFilter();
+        resumer.validator = m -> {
+            assertEquals(0, asyncFilter.getConcurrency());
+            return m;
+        };
+
+        runner.filter(asyncFilter, message);
+        resumer.future.join();
+    }
+
+    @Filter(type = FilterType.INBOUND, sync = FilterSyncType.ASYNC, order = 1)
+    private static class AsyncFilter extends BaseFilter<ZuulMessage, ZuulMessage> {
+
+        @Override
+        public Observable<ZuulMessage> applyAsync(ZuulMessage input) {
+            return Observable.just(input);
+        }
+
+        @Override
+        public boolean shouldFilter(ZuulMessage msg) {
+            return true;
+        }
+    }
+
+    private static class TestResumer {
+
+        private final CompletableFuture<ZuulMessage> future;
+        private volatile Function<ZuulMessage, ZuulMessage> validator;
+
+        public TestResumer(Function<ZuulMessage, ZuulMessage> validator) {
+            this.future = new CompletableFuture<>();
+            this.validator = validator;
+        }
+
+        public void resume(ZuulMessage zuulMesg) {
+            try {
+                ZuulMessage zuulMessage = validator.apply(zuulMesg);
+                future.complete(zuulMessage);
+            } catch (Throwable e) {
+                future.completeExceptionally(e);
+            }
+        }
+    }
+
+    private class TestBaseZuulFilterRunner extends BaseZuulFilterRunner<ZuulMessage, ZuulMessage> {
+
+        protected TestBaseZuulFilterRunner(
+                FilterType filterType,
+                FilterUsageNotifier usageNotifier,
+                FilterRunner<ZuulMessage, ?> nextStage,
+                Registry registry) {
+            super(filterType, usageNotifier, nextStage, registry);
+        }
+
+        @Override
+        protected void resume(ZuulMessage zuulMesg) {
+            resumer.resume(zuulMesg);
+        }
+
+        @Override
+        public void filter(ZuulMessage zuulMesg) {}
+
+        @Override
+        public void filter(ZuulMessage zuulMesg, HttpContent chunk) {}
+    }
+}


### PR DESCRIPTION
Starting the next filter in onNext prevents onComplete from running until the next async filter is encountered