### PR TITLE
Downgrade netty to v4.1.119

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 versions_ribbon=2.4.4
-versions_netty=4.1.121.Final
+versions_netty=4.1.119.Final
 versions_netty_io_uring=0.0.26.Final
 versions_brotli4j=1.16.0
 release.scope=patch

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -331,10 +331,10 @@
             "locked": "0.0.26.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final"
+            "locked": "4.1.119.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -352,7 +352,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -362,26 +362,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -400,7 +400,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -408,7 +408,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -416,7 +416,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -433,33 +433,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -933,10 +933,10 @@
             "locked": "0.0.26.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final"
+            "locked": "4.1.119.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -954,7 +954,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -964,26 +964,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1002,7 +1002,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -1010,7 +1010,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1018,7 +1018,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1035,33 +1035,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1460,10 +1460,10 @@
             "locked": "0.0.26.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final"
+            "locked": "4.1.119.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1481,7 +1481,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -1491,26 +1491,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1529,7 +1529,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -1537,7 +1537,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1558,7 +1558,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -1575,33 +1575,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2159,10 +2159,10 @@
             "locked": "0.0.26.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final"
+            "locked": "4.1.119.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2180,7 +2180,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2190,26 +2190,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2228,7 +2228,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -2236,7 +2236,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2257,7 +2257,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2274,33 +2274,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2790,10 +2790,10 @@
             "locked": "0.0.26.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final"
+            "locked": "4.1.119.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2811,7 +2811,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2821,26 +2821,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2859,7 +2859,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -2867,7 +2867,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2875,7 +2875,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2892,33 +2892,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3384,10 +3384,10 @@
             "locked": "0.0.26.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final"
+            "locked": "4.1.119.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3405,7 +3405,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -3415,26 +3415,26 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http2"
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3453,7 +3453,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -3461,7 +3461,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3482,7 +3482,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3499,33 +3499,33 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -363,13 +363,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -388,7 +388,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -398,14 +398,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -413,14 +413,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -440,7 +440,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -449,7 +449,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -471,7 +471,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -489,35 +489,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -868,13 +868,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -888,7 +888,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -897,7 +897,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -905,14 +905,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -928,7 +928,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -937,7 +937,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -945,7 +945,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -958,13 +958,13 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1392,13 +1392,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1412,7 +1412,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -1421,7 +1421,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1429,14 +1429,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1452,7 +1452,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1461,7 +1461,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1469,7 +1469,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1482,13 +1482,13 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1981,13 +1981,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2006,7 +2006,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2016,14 +2016,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2031,14 +2031,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2058,7 +2058,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2067,7 +2067,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2089,7 +2089,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2107,35 +2107,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3020,13 +3020,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3045,7 +3045,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -3055,14 +3055,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3070,14 +3070,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3097,7 +3097,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3106,7 +3106,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3128,7 +3128,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3146,35 +3146,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3795,13 +3795,13 @@
             "locked": "0.0.26.Final"
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3816,7 +3816,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -3825,7 +3825,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3833,14 +3833,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3857,7 +3857,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3866,7 +3866,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3874,7 +3874,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3888,13 +3888,13 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -4745,13 +4745,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4770,7 +4770,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -4780,14 +4780,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4795,14 +4795,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4822,7 +4822,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -4831,7 +4831,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -4853,7 +4853,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -4871,35 +4871,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -340,13 +340,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -359,7 +359,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -368,7 +368,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -376,14 +376,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -398,7 +398,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -407,7 +407,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -415,7 +415,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -427,7 +427,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -882,13 +882,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -901,7 +901,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -910,7 +910,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -918,14 +918,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -940,7 +940,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -949,7 +949,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -957,7 +957,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -969,7 +969,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -1355,13 +1355,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1380,7 +1380,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -1390,14 +1390,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1405,14 +1405,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1432,7 +1432,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1441,7 +1441,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1463,7 +1463,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1481,35 +1481,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2053,13 +2053,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2078,7 +2078,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2088,14 +2088,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2103,14 +2103,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2130,7 +2130,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2139,7 +2139,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2161,7 +2161,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2179,35 +2179,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2730,13 +2730,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2755,7 +2755,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2765,14 +2765,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2780,14 +2780,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2807,7 +2807,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2816,7 +2816,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2838,7 +2838,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2856,35 +2856,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3268,13 +3268,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3287,7 +3287,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -3296,7 +3296,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3304,14 +3304,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3326,7 +3326,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3335,7 +3335,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3343,7 +3343,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3355,7 +3355,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -3785,13 +3785,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3810,7 +3810,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -3820,14 +3820,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3835,14 +3835,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3862,7 +3862,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3871,7 +3871,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3893,7 +3893,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3911,35 +3911,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -363,13 +363,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -388,7 +388,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -398,14 +398,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -413,14 +413,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -440,7 +440,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -449,7 +449,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -471,7 +471,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -489,35 +489,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -865,13 +865,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -884,7 +884,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -893,7 +893,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -901,14 +901,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -923,7 +923,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -932,7 +932,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -940,7 +940,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -952,7 +952,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -1394,13 +1394,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1413,7 +1413,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -1422,7 +1422,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1430,14 +1430,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1452,7 +1452,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1461,7 +1461,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1469,7 +1469,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1481,7 +1481,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -1868,13 +1868,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1893,7 +1893,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -1903,14 +1903,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1918,14 +1918,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1945,7 +1945,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -1954,7 +1954,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -1976,7 +1976,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -1994,35 +1994,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -2516,13 +2516,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2541,7 +2541,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -2551,14 +2551,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2566,14 +2566,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2593,7 +2593,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -2602,7 +2602,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -2624,7 +2624,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -2642,35 +2642,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",
@@ -3170,13 +3170,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3189,7 +3189,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-http",
@@ -3198,7 +3198,7 @@
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3206,14 +3206,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3228,7 +3228,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3237,7 +3237,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3245,7 +3245,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3257,7 +3257,7 @@
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler"
@@ -3602,13 +3602,13 @@
             ]
         },
         "io.netty:netty-bom": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core"
             ]
         },
         "io.netty:netty-buffer": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3627,7 +3627,7 @@
             ]
         },
         "io.netty:netty-codec": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-codec-haproxy",
@@ -3637,14 +3637,14 @@
             ]
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3652,14 +3652,14 @@
             ]
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3679,7 +3679,7 @@
             ]
         },
         "io.netty:netty-handler": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom",
@@ -3688,7 +3688,7 @@
             ]
         },
         "io.netty:netty-resolver": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-handler",
@@ -3710,7 +3710,7 @@
             ]
         },
         "io.netty:netty-transport": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
@@ -3728,35 +3728,35 @@
             ]
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-epoll"
             ]
         },
         "io.netty:netty-transport-classes-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty:netty-bom",
                 "io.netty:netty-transport-native-kqueue"
             ]
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "com.netflix.zuul:zuul-core",
                 "io.netty:netty-bom"
             ]
         },
         "io.netty:netty-transport-native-unix-common": {
-            "locked": "4.1.121.Final",
+            "locked": "4.1.119.Final",
             "transitive": [
                 "io.netty.incubator:netty-incubator-transport-classes-io_uring",
                 "io.netty:netty-bom",


### PR DESCRIPTION
Netty v4.1.121 in #1951 has some differences in ssl handshake handling with h2; downgrade to v4.1.119 for now