### PR TITLE
Detect chunked transfer-encoding as last value

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
@@ -16,6 +16,7 @@
 package com.netflix.zuul.util;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.netflix.zuul.message.Headers;
 import com.netflix.zuul.message.ZuulMessage;
@@ -25,6 +26,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http2.Http2StreamChannel;
+import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -148,7 +150,12 @@ public class HttpUtils {
         boolean isChunked = false;
         String teValue = msg.getHeaders().getFirst(com.netflix.zuul.message.http.HttpHeaderNames.TRANSFER_ENCODING);
         if (!Strings.isNullOrEmpty(teValue)) {
-            isChunked = teValue.toLowerCase(Locale.ROOT).equals("chunked");
+            List<String> encodings = Splitter.on(',').trimResults().splitToList(teValue.toLowerCase(Locale.ROOT));
+            if (!encodings.isEmpty()) {
+                // Get the last encoding - "chunked" must be the final encoding
+                String finalEncoding = encodings.get(encodings.size() - 1);
+                isChunked = finalEncoding.equals("chunked");
+            }
         }
         return isChunked;
     }

--- a/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
@@ -27,6 +27,7 @@ import com.netflix.zuul.message.Headers;
 import com.netflix.zuul.message.ZuulMessage;
 import com.netflix.zuul.message.ZuulMessageImpl;
 import com.netflix.zuul.message.http.HttpQueryParams;
+import com.netflix.zuul.message.http.HttpHeaderNames;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpRequestMessageImpl;
 import com.netflix.zuul.message.http.HttpResponseMessage;
@@ -120,5 +121,94 @@ class HttpUtilsTest {
         Headers headers = new Headers();
         ZuulMessage msg = new ZuulMessageImpl(context, headers);
         assertThat(HttpUtils.getBodySizeIfKnown(msg)).isNull();
+    }
+
+    @Test
+    void hasChunkedTransferEncodingHeader_singleTokenChunked() {
+        SessionContext context = new SessionContext();
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+        ZuulMessage msg = new ZuulMessageImpl(context, headers);
+        
+        assertTrue(HttpUtils.hasChunkedTransferEncodingHeader(msg));
+    }
+
+    @Test
+    void hasChunkedTransferEncodingHeader_singleTokenNotChunked() {
+        SessionContext context = new SessionContext();
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.TRANSFER_ENCODING, "gzip");
+        ZuulMessage msg = new ZuulMessageImpl(context, headers);
+        
+        assertFalse(HttpUtils.hasChunkedTransferEncodingHeader(msg));
+    }
+
+    @Test
+    void hasChunkedTransferEncodingHeader_multiTokenWithChunked() {
+        SessionContext context = new SessionContext();
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.TRANSFER_ENCODING, "gzip, chunked");
+        ZuulMessage msg = new ZuulMessageImpl(context, headers);
+        
+        assertTrue(HttpUtils.hasChunkedTransferEncodingHeader(msg));
+    }
+
+    @Test
+    void hasChunkedTransferEncodingHeader_multiTokenWithoutChunked() {
+        SessionContext context = new SessionContext();
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.TRANSFER_ENCODING, "gzip, deflate");
+        ZuulMessage msg = new ZuulMessageImpl(context, headers);
+        
+        assertFalse(HttpUtils.hasChunkedTransferEncodingHeader(msg));
+    }
+
+    @Test
+    void hasChunkedTransferEncodingHeader_multiTokenChunkedNotLast() {
+        SessionContext context = new SessionContext();
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.TRANSFER_ENCODING, "chunked, gzip");
+        ZuulMessage msg = new ZuulMessageImpl(context, headers);
+        
+        assertFalse(HttpUtils.hasChunkedTransferEncodingHeader(msg));
+    }
+
+    @Test
+    void hasChunkedTransferEncodingHeader_caseInsensitive() {
+        SessionContext context = new SessionContext();
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.TRANSFER_ENCODING, "GZIP, CHUNKED");
+        ZuulMessage msg = new ZuulMessageImpl(context, headers);
+        
+        assertTrue(HttpUtils.hasChunkedTransferEncodingHeader(msg));
+    }
+
+    @Test
+    void hasChunkedTransferEncodingHeader_withWhitespace() {
+        SessionContext context = new SessionContext();
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.TRANSFER_ENCODING, "gzip , chunked ");
+        ZuulMessage msg = new ZuulMessageImpl(context, headers);
+        
+        assertTrue(HttpUtils.hasChunkedTransferEncodingHeader(msg));
+    }
+
+    @Test
+    void hasChunkedTransferEncodingHeader_emptyHeader() {
+        SessionContext context = new SessionContext();
+        Headers headers = new Headers();
+        headers.add(HttpHeaderNames.TRANSFER_ENCODING, "");
+        ZuulMessage msg = new ZuulMessageImpl(context, headers);
+        
+        assertFalse(HttpUtils.hasChunkedTransferEncodingHeader(msg));
+    }
+
+    @Test
+    void hasChunkedTransferEncodingHeader_nullHeader() {
+        SessionContext context = new SessionContext();
+        Headers headers = new Headers();
+        ZuulMessage msg = new ZuulMessageImpl(context, headers);
+        
+        assertFalse(HttpUtils.hasChunkedTransferEncodingHeader(msg));
     }
 }


### PR DESCRIPTION
Hi,

Whilst `Transfer-Encoding: chunked` is commonplace, RFC 7230 does permit comma separated values, in which `chunked` should be the last value.

This has influence on early body detection, https://github.com/Netflix/zuul/blob/2232215881832a55e324ad7bc2e5d7b24f08007f/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java#L379-L381

Filters implementing `shouldFilter` relying on `request.hasBody()` evaluating to true may be skipped when subsequent HTTP content arrives after initial header processing in the pipeline.

More broadly, is the presence of the "Transfer-Encoding" header sufficient to call `request.setHasBody(true)`, rather than explicitly checking for `chunked`?

I initially filed this issue through HackerOne (report id 3333247) as custom security filters dependent on the body may be bypassed, but it was triaged as informative and closed by HackerOne.