### PR TITLE
Replace google truth with assertj and ensure junit5 used across codebase

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ allprojects {
             rootProject.hasProperty('spotlessJavaTarget') ? target(rootProject.getProperty('spotlessJavaTarget').split(",")) : target('src/*/java/**/*.java')
             removeUnusedImports('cleanthat-javaparser-unnecessaryimport')
             palantirJavaFormat()
-            formatAnnotations()
         }
     }
 }
@@ -126,7 +125,7 @@ subprojects {
                 mockito: 'org.mockito:mockito-core:5.+',
 
                 slf4j: "org.slf4j:slf4j-api:2.0.16",
-                truth: 'com.google.truth:truth:1.4.4',
+                assertj: 'org.assertj:assertj-core:3.26.3',
                 awaitility: 'org.awaitility:awaitility:4.2.2',
                 lombok: 'org.projectlombok:lombok:1.18.42'
         ]

--- a/zuul-core/build.gradle
+++ b/zuul-core/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 
     testImplementation libraries.jupiterApi, libraries.jupiterParams, libraries.jupiterEngine, libraries.junitPlatformLauncher, libraries.jupiterMockito,
             libraries.mockito,
-            libraries.truth,
+            libraries.assertj,
             libraries.awaitility
 
 

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -7,7 +7,7 @@
             "locked": "0.12.4"
         },
         "org.projectlombok:lombok": {
-            "locked": "1.18.36"
+            "locked": "1.18.42"
         }
     },
     "compileClasspath": {
@@ -105,7 +105,7 @@
             "locked": "1.78.1"
         },
         "org.projectlombok:lombok": {
-            "locked": "1.18.36"
+            "locked": "1.18.42"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.16"
@@ -239,7 +239,7 @@
             "locked": "1.37"
         },
         "org.projectlombok:lombok": {
-            "locked": "1.18.36"
+            "locked": "1.18.42"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.16"
@@ -257,9 +257,6 @@
                 "com.netflix.zuul:zuul-discovery"
             ],
             "locked": "33.3.0-jre"
-        },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
         },
         "com.netflix.archaius:archaius-core": {
             "locked": "0.7.12"
@@ -357,6 +354,9 @@
         "jakarta.inject:jakarta.inject-api": {
             "locked": "2.0.1"
         },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
+        },
         "org.awaitility:awaitility": {
             "locked": "4.2.2"
         },
@@ -382,7 +382,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.19.0"
+            "locked": "5.20.0"
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.13.0"
@@ -546,9 +546,6 @@
         "com.google.guava:guava": {
             "locked": "33.3.0-jre"
         },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
-        },
         "com.netflix.archaius:archaius-core": {
             "locked": "0.7.12"
         },
@@ -627,6 +624,9 @@
         "jakarta.inject:jakarta.inject-api": {
             "locked": "2.0.1"
         },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
+        },
         "org.awaitility:awaitility": {
             "locked": "4.2.2"
         },
@@ -652,7 +652,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.19.0"
+            "locked": "5.20.0"
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.13.0"
@@ -673,9 +673,6 @@
                 "com.netflix.zuul:zuul-discovery"
             ],
             "locked": "33.3.0-jre"
-        },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
         },
         "com.netflix.archaius:archaius-core": {
             "locked": "0.7.12"
@@ -773,6 +770,9 @@
         "jakarta.inject:jakarta.inject-api": {
             "locked": "2.0.1"
         },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
+        },
         "org.awaitility:awaitility": {
             "locked": "4.2.2"
         },
@@ -798,7 +798,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.19.0"
+            "locked": "5.20.0"
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.13.0"

--- a/zuul-core/src/main/java/com/netflix/netty/common/SourceAddressChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/SourceAddressChannelHandler.java
@@ -126,7 +126,8 @@ public final class SourceAddressChannelHandler extends ChannelInboundHandlerAdap
      * Returns the String form of a socket address, or {@code null} if there isn't one.
      */
     @VisibleForTesting
-    @Nullable static String getHostAddress(InetSocketAddress socketAddress) {
+    @Nullable
+    static String getHostAddress(InetSocketAddress socketAddress) {
         InetAddress address = socketAddress.getAddress();
         if (address instanceof Inet6Address) {
             // Strip the scope from the address since some other classes choke on it.

--- a/zuul-core/src/main/java/com/netflix/zuul/Attrs.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/Attrs.java
@@ -48,7 +48,8 @@ public final class Attrs {
         /**
          * Returns the value in the attributes, or {@code null} if absent.
          */
-        @Nullable @SuppressWarnings("unchecked")
+        @Nullable
+        @SuppressWarnings("unchecked")
         public T get(Attrs attrs) {
             Objects.requireNonNull(attrs, "attrs");
             return (T) attrs.storage.get(this);

--- a/zuul-core/src/main/java/com/netflix/zuul/BasicRequestCompleteHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/BasicRequestCompleteHandler.java
@@ -30,7 +30,8 @@ import javax.annotation.Nullable;
  */
 public class BasicRequestCompleteHandler implements RequestCompleteHandler {
     @Inject
-    @Nullable private RequestMetricsPublisher requestMetricsPublisher;
+    @Nullable
+    private RequestMetricsPublisher requestMetricsPublisher;
 
     @Override
     public void handle(HttpRequestInfo inboundRequest, HttpResponseMessage response) {

--- a/zuul-core/src/main/java/com/netflix/zuul/StaticFilterLoader.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/StaticFilterLoader.java
@@ -138,7 +138,8 @@ public final class StaticFilterLoader implements FilterLoader {
     }
 
     @Override
-    @Nullable public ZuulFilter<?, ?> getFilterByNameAndType(String name, FilterType type) {
+    @Nullable
+    public ZuulFilter<?, ?> getFilterByNameAndType(String name, FilterType type) {
         Map<String, ZuulFilter<?, ?>> filtersByName = filtersByTypeAndName.get(type);
         if (filtersByName == null) {
             return null;

--- a/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
@@ -145,7 +145,8 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
      * Returns the value in the context, or {@code null} if absent.
      */
     @SuppressWarnings("unchecked")
-    @Nullable public <T> T get(@NonNull Key<T> key) {
+    @Nullable
+    public <T> T get(@NonNull Key<T> key) {
         T value = (T) typedMap.get(key);
         if (value == null) {
             value = key.defaultValue();
@@ -153,7 +154,7 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
 
         return value;
     }
-    
+
     /**
      * Returns the value in the context, or default value from the
      * typed key default value supplier if absent.
@@ -208,7 +209,8 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
      * Returns the previous value associated with key, or {@code null} if there was no mapping for key.  Unlike
      * {@link #put(String, Object)}, this will never return a null value if the key is present in the map.
      */
-    @Nullable @CanIgnoreReturnValue
+    @Nullable
+    @CanIgnoreReturnValue
     public <T> T put(Key<T> key, T value) {
         Objects.requireNonNull(key, "key");
         Objects.requireNonNull(value, "value");

--- a/zuul-core/src/main/java/com/netflix/zuul/exception/OutboundErrorType.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/exception/OutboundErrorType.java
@@ -64,7 +64,8 @@ public enum OutboundErrorType implements ErrorType {
             ERROR_TYPE_ORIGIN_CONCURRENCY_EXCEEDED_STATUS.get(),
             ZuulStatusCategory.FAILURE_LOCAL_THROTTLED_ORIGIN_CONCURRENCY,
             ClientException.ErrorType.SERVER_THROTTLED),
-    HEADER_FIELDS_TOO_LARGE(431, ZuulStatusCategory.FAILURE_LOCAL_HEADER_FIELDS_TOO_LARGE, ClientException.ErrorType.GENERAL),
+    HEADER_FIELDS_TOO_LARGE(
+            431, ZuulStatusCategory.FAILURE_LOCAL_HEADER_FIELDS_TOO_LARGE, ClientException.ErrorType.GENERAL),
     OTHER(ERROR_TYPE_OTHER_STATUS.get(), ZuulStatusCategory.FAILURE_LOCAL, ClientException.ErrorType.GENERAL);
 
     private static final String NAME_PREFIX = "ORIGIN_";

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/FilterRegistry.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/FilterRegistry.java
@@ -19,7 +19,8 @@ import java.util.Collection;
 import javax.annotation.Nullable;
 
 public interface FilterRegistry {
-    @Nullable ZuulFilter<?, ?> get(String key);
+    @Nullable
+    ZuulFilter<?, ?> get(String key);
 
     int size();
 
@@ -37,7 +38,8 @@ public interface FilterRegistry {
      *
      * @throws IllegalStateException if this registry is not mutable.
      */
-    @Nullable ZuulFilter<?, ?> remove(String key);
+    @Nullable
+    ZuulFilter<?, ?> remove(String key);
 
     /**
      * Stores the filter into the registry.  If an existing filter was present with the same key,

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/MutableFilterRegistry.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/MutableFilterRegistry.java
@@ -27,13 +27,15 @@ import javax.annotation.Nullable;
 public final class MutableFilterRegistry implements FilterRegistry {
     private final ConcurrentHashMap<String, ZuulFilter<?, ?>> filters = new ConcurrentHashMap<>();
 
-    @Nullable @Override
+    @Nullable
+    @Override
     public ZuulFilter<?, ?> remove(String key) {
         return filters.remove(Objects.requireNonNull(key, "key"));
     }
 
     @Override
-    @Nullable public ZuulFilter<?, ?> get(String key) {
+    @Nullable
+    public ZuulFilter<?, ?> get(String key) {
         return filters.get(Objects.requireNonNull(key, "key"));
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
@@ -76,7 +76,8 @@ public final class Headers {
      * Get the first value found for this key even if there are multiple. If none, then
      * return {@code null}.
      */
-    @Nullable public String getFirst(String headerName) {
+    @Nullable
+    public String getFirst(String headerName) {
         String normalName = HeaderName.normalize(Objects.requireNonNull(headerName, "headerName"));
         return getFirstNormal(normalName);
     }
@@ -85,7 +86,8 @@ public final class Headers {
      * Get the first value found for this key even if there are multiple. If none, then
      * return {@code null}.
      */
-    @Nullable public String getFirst(HeaderName headerName) {
+    @Nullable
+    public String getFirst(HeaderName headerName) {
         String normalName = Objects.requireNonNull(headerName, "headerName").getNormalised();
         return getFirstNormal(normalName);
     }
@@ -116,7 +118,8 @@ public final class Headers {
         return defaultValue;
     }
 
-    @Nullable private String getFirstNormal(String name) {
+    @Nullable
+    private String getFirstNormal(String name) {
         for (int i = 0; i < size(); i++) {
             if (name(i).equals(name)) {
                 return value(i);

--- a/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessage.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessage.java
@@ -63,7 +63,8 @@ public interface ZuulMessage extends Cloneable {
      * This is the entire buffered body, regardless of whether the underlying body chunks have been read or not.
      * If there is no message body, this returns {@code null}.
      */
-    @Nullable byte[] getBody();
+    @Nullable
+    byte[] getBody();
 
     /**
      * Returns the length of the entire buffered message body, or {@code 0} if there isn't a message present.
@@ -123,7 +124,8 @@ public interface ZuulMessage extends Cloneable {
     /**
      * Gets the body of this message as UTF-8 text, or {@code null} if there is no body.
      */
-    @Nullable String getBodyAsText();
+    @Nullable
+    String getBodyAsText();
 
     /**
      * Reset the chunked body reader indexes. Users SHOULD call this method before retrying requests

--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnTimer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnTimer.java
@@ -52,7 +52,8 @@ public final class ConnTimer {
     // TODO(carl-mastrangelo): make this changeable.
     private final Id metricBase;
 
-    @Nullable private final Id preciseMetricBase;
+    @Nullable
+    private final Id preciseMetricBase;
 
     private final Map<String, Long> timings = new LinkedHashMap<>();
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolHandler.java
@@ -45,7 +45,6 @@ public class ConnectionPoolHandler extends ChannelDuplexHandler {
     private final ConnectionPoolMetrics metrics;
     private final OriginName originName;
 
-
     @Deprecated
     public ConnectionPoolHandler(OriginName originName) {
         this(ConnectionPoolMetrics.create(Objects.requireNonNull(originName), Spectator.globalRegistry()));

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPool.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/PerServerConnectionPool.java
@@ -448,7 +448,8 @@ public class PerServerConnectionPool implements IConnectionPool {
         return connsInUse.get();
     }
 
-    @Nullable protected InetAddress getSelectedHostString(SocketAddress addr) {
+    @Nullable
+    protected InetAddress getSelectedHostString(SocketAddress addr) {
         if (addr instanceof InetSocketAddress) {
             return ((InetSocketAddress) addr).getAddress();
         } else {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulEndPointRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulEndPointRunner.java
@@ -68,7 +68,8 @@ public class ZuulEndPointRunner extends BaseZuulFilterRunner<HttpRequestMessage,
         this.filterLoader = filterLoader;
     }
 
-    @Nullable public static ZuulFilter<HttpRequestMessage, HttpResponseMessage> getEndpoint(
+    @Nullable
+    public static ZuulFilter<HttpRequestMessage, HttpResponseMessage> getEndpoint(
             @Nullable HttpRequestMessage zuulReq) {
         if (zuulReq != null) {
             return zuulReq.getContext().get(CommonContextKeys.ZUUL_ENDPOINT);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainHandler.java
@@ -87,7 +87,7 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
     @Override
     public final void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof CompleteEvent completeEvent) {
-            
+
             fireEndpointFinish(
                     completeEvent.getReason() != HttpLifecycleChannelHandler.CompleteReason.SESSION_COMPLETE, ctx);
         } else if (evt instanceof HttpRequestReadTimeoutEvent) {
@@ -133,7 +133,7 @@ public class ZuulFilterChainHandler extends ChannelInboundHandlerAdapter {
 
         ZuulFilter endpoint = ZuulEndPointRunner.getEndpoint(zuulRequest);
         if (endpoint instanceof ProxyEndpoint edgeProxyEndpoint) {
-            
+
             edgeProxyEndpoint.finish(error);
         }
         zuulRequest = null;

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
@@ -169,7 +169,8 @@ public abstract class BaseServerStartup {
         channelDeps.set(ZuulDependencyKeys.requestCompleteHandler, reqCompleteHandler);
         Counter httpRequestHeadersReadTimeoutCounter = registry.counter("server.http.request.headers.read.timeout");
         channelDeps.set(ZuulDependencyKeys.httpRequestHeadersReadTimeoutCounter, httpRequestHeadersReadTimeoutCounter);
-        PercentileTimer httpRequestHeadersReadTimer = PercentileTimer.get(registry, registry.createId("server.http.request.headers.read.timer"));
+        PercentileTimer httpRequestHeadersReadTimer =
+                PercentileTimer.get(registry, registry.createId("server.http.request.headers.read.timer"));
         channelDeps.set(ZuulDependencyKeys.httpRequestHeadersReadTimer, httpRequestHeadersReadTimer);
         Counter httpRequestReadTimeoutCounter = registry.counter("server.http.request.read.timeout");
         channelDeps.set(ZuulDependencyKeys.httpRequestReadTimeoutCounter, httpRequestReadTimeoutCounter);
@@ -196,7 +197,8 @@ public abstract class BaseServerStartup {
         channelDeps.set(ZuulDependencyKeys.requestCompleteHandler, reqCompleteHandler);
         Counter httpRequestHeadersReadTimeoutCounter = registry.counter("server.http.request.headers.read.timeout");
         channelDeps.set(ZuulDependencyKeys.httpRequestHeadersReadTimeoutCounter, httpRequestHeadersReadTimeoutCounter);
-        PercentileTimer httpRequestHeadersReadTimer = PercentileTimer.get(registry, registry.createId("server.http.request.headers.read.timer"));
+        PercentileTimer httpRequestHeadersReadTimer =
+                PercentileTimer.get(registry, registry.createId("server.http.request.headers.read.timer"));
         channelDeps.set(ZuulDependencyKeys.httpRequestHeadersReadTimer, httpRequestHeadersReadTimer);
         Counter httpRequestReadTimeoutCounter = registry.counter("server.http.request.read.timeout");
         channelDeps.set(ZuulDependencyKeys.httpRequestReadTimeoutCounter, httpRequestReadTimeoutCounter);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
@@ -215,7 +215,8 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
 
         this.sessionContextDecorator = channelDependencies.get(ZuulDependencyKeys.sessionCtxDecorator);
         this.requestCompleteHandler = channelDependencies.get(ZuulDependencyKeys.requestCompleteHandler);
-        this.httpRequestHeadersReadTimeoutCounter = channelDependencies.get(ZuulDependencyKeys.httpRequestHeadersReadTimeoutCounter);
+        this.httpRequestHeadersReadTimeoutCounter =
+                channelDependencies.get(ZuulDependencyKeys.httpRequestHeadersReadTimeoutCounter);
         this.httpRequestHeadersReadTimer = channelDependencies.get(ZuulDependencyKeys.httpRequestHeadersReadTimer);
         this.httpRequestReadTimeoutCounter = channelDependencies.get(ZuulDependencyKeys.httpRequestReadTimeoutCounter);
 
@@ -263,11 +264,10 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
 
     protected void addHttpRelatedHandlers(ChannelPipeline pipeline) {
         pipeline.addLast(new HttpHeadersTimeoutHandler.InboundHandler(
-            HTTP_REQUEST_HEADERS_READ_TIMEOUT_ENABLED::get,
-            HTTP_REQUEST_HEADERS_READ_TIMEOUT::get,
-            httpRequestHeadersReadTimeoutCounter,
-            httpRequestHeadersReadTimer
-        ));
+                HTTP_REQUEST_HEADERS_READ_TIMEOUT_ENABLED::get,
+                HTTP_REQUEST_HEADERS_READ_TIMEOUT::get,
+                httpRequestHeadersReadTimeoutCounter,
+                httpRequestHeadersReadTimer));
         pipeline.addLast(new PassportStateHttpServerHandler.InboundHandler());
         pipeline.addLast(new PassportStateHttpServerHandler.OutboundHandler());
         if (httpRequestReadTimeout > -1) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientConnectionsShutdown.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientConnectionsShutdown.java
@@ -74,7 +74,6 @@ public class ClientConnectionsShutdown {
     private void initDiscoveryListener() {
         this.discoveryClient.registerEventListener(event -> {
             if (event instanceof StatusChangeEvent sce) {
-                
 
                 LOG.info("Received {}", sce);
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -18,6 +18,7 @@ package com.netflix.zuul.netty.server;
 
 import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
 import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
+
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.netty.common.ssl.SslHandshakeInfo;
 import com.netflix.netty.common.throttle.RejectionUtils;

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
@@ -92,7 +92,6 @@ public class ClientResponseWriter extends ChannelInboundHandlerAdapter {
         Channel channel = ctx.channel();
 
         if (msg instanceof HttpResponseMessage resp) {
-            
 
             if (skipProcessing(resp)) {
                 return;
@@ -138,7 +137,7 @@ public class ClientResponseWriter extends ChannelInboundHandlerAdapter {
                 channel.close();
             }
         } else if (msg instanceof HttpContent chunk) {
-            
+
             if (channel.isActive()) {
                 channel.writeAndFlush(chunk);
             } else {
@@ -287,7 +286,7 @@ public class ClientResponseWriter extends ChannelInboundHandlerAdapter {
         int status = 500;
 
         if (cause instanceof ZuulException ze) {
-            
+
             status = ze.getStatusCode();
             logger.error(
                     "Exception caught in ClientResponseWriter for channel {} ",

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/SocketAddressProperty.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/SocketAddressProperty.java
@@ -85,7 +85,8 @@ public final class SocketAddressProperty extends StringDerivedProperty<SocketAdd
         ;
 
         @SuppressWarnings("ImmutableEnumChecker") // Hopes and prayers that addressSupplier returns a constant.
-        @Nullable private final Supplier<? extends InetAddress> addressSupplier;
+        @Nullable
+        private final Supplier<? extends InetAddress> addressSupplier;
 
         BindType() {
             addressSupplier = null;

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ZuulDependencyKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ZuulDependencyKeys.java
@@ -51,7 +51,7 @@ public class ZuulDependencyKeys {
             new ChannelConfigKey<>("requestCompleteHandler");
     public static final ChannelConfigKey<Counter> httpRequestHeadersReadTimeoutCounter =
             new ChannelConfigKey<>("httpRequestHeadersReadTimeoutCounter");
-public static final ChannelConfigKey<PercentileTimer> httpRequestHeadersReadTimer =
+    public static final ChannelConfigKey<PercentileTimer> httpRequestHeadersReadTimer =
             new ChannelConfigKey<>("httpRequestHeadersReadTimer");
     public static final ChannelConfigKey<Counter> httpRequestReadTimeoutCounter =
             new ChannelConfigKey<>("httpRequestReadTimeoutCounter");

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2ContentLengthEnforcingHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2ContentLengthEnforcingHandler.java
@@ -53,7 +53,7 @@ public final class Http2ContentLengthEnforcingHandler extends ChannelInboundHand
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg instanceof HttpRequest req) {
-            
+
             List<String> lengthHeaders = req.headers().getAll(HttpHeaderNames.CONTENT_LENGTH);
             if (lengthHeaders.size() > 1) {
                 ctx.writeAndFlush(new DefaultHttp2ResetFrame(Http2Error.PROTOCOL_ERROR));

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2StreamErrorHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2StreamErrorHandler.java
@@ -33,7 +33,7 @@ public class Http2StreamErrorHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (cause instanceof Http2Exception.StreamException streamEx) {
-            
+
             ctx.writeAndFlush(new DefaultHttp2ResetFrame(streamEx.error()));
         } else if (cause instanceof DecoderException) {
             ctx.writeAndFlush(new DefaultHttp2ResetFrame(Http2Error.PROTOCOL_ERROR));

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2StreamHeaderCleaner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2StreamHeaderCleaner.java
@@ -34,7 +34,6 @@ public class Http2StreamHeaderCleaner extends ChannelInboundHandlerAdapter {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg instanceof HttpRequest req) {
-            
 
             for (String name : req.headers().names()) {
                 if (name.startsWith("x-http2-")) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushConnection.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushConnection.java
@@ -97,7 +97,6 @@ public class PushConnection {
     }
 
     public void closeConnection(WebSocketCloseStatus status, String message) {
-        ctx.writeAndFlush(new CloseWebSocketFrame(status, message))
-                .addListener(ChannelFutureListener.CLOSE);
+        ctx.writeAndFlush(new CloseWebSocketFrame(status, message)).addListener(ChannelFutureListener.CLOSE);
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushConnectionRegistry.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/push/PushConnectionRegistry.java
@@ -44,7 +44,8 @@ public class PushConnectionRegistry {
         secureTokenGenerator = new SecureRandom();
     }
 
-    @Nullable public PushConnection get(String clientId) {
+    @Nullable
+    public PushConnection get(String clientId) {
         return clientPushConnectionMap.get(clientId);
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/HttpHeadersTimeoutHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/HttpHeadersTimeoutHandler.java
@@ -21,7 +21,6 @@ import com.netflix.spectator.api.histogram.PercentileTimer;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpMessage;
-import io.netty.handler.timeout.ReadTimeoutException;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManager.java
@@ -96,7 +96,8 @@ public class OriginTimeoutManager {
     /**
      * This method makes the assumption that the timeout is a numeric value
      */
-    @Nullable private Long getRequestReadTimeout(IClientConfig clientConfig) {
+    @Nullable
+    private Long getRequestReadTimeout(IClientConfig clientConfig) {
         return Optional.ofNullable(clientConfig.get(CommonClientConfigKey.ReadTimeout))
                 .map(Long::valueOf)
                 .orElse(null);
@@ -105,7 +106,8 @@ public class OriginTimeoutManager {
     /**
      * This method makes the assumption that the timeout is a numeric value
      */
-    @Nullable private Long getOriginReadTimeout() {
+    @Nullable
+    private Long getOriginReadTimeout() {
         return Optional.ofNullable(origin.getClientConfig().get(CommonClientConfigKey.ReadTimeout))
                 .map(Long::valueOf)
                 .orElse(null);

--- a/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempts.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/niws/RequestAttempts.java
@@ -40,7 +40,8 @@ public class RequestAttempts extends ArrayList<RequestAttempt> {
         super();
     }
 
-    @Nullable public RequestAttempt getFinalAttempt() {
+    @Nullable
+    public RequestAttempt getFinalAttempt() {
         if (size() > 0) {
             return get(size() - 1);
         } else {

--- a/zuul-core/src/main/java/com/netflix/zuul/stats/status/StatusCategoryUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/stats/status/StatusCategoryUtils.java
@@ -33,11 +33,13 @@ public class StatusCategoryUtils {
         return getStatusCategory(msg.getContext());
     }
 
-    @Nullable public static StatusCategory getStatusCategory(SessionContext ctx) {
+    @Nullable
+    public static StatusCategory getStatusCategory(SessionContext ctx) {
         return ctx.get(CommonContextKeys.STATUS_CATEGORY);
     }
 
-    @Nullable public static String getStatusCategoryReason(SessionContext ctx) {
+    @Nullable
+    public static String getStatusCategoryReason(SessionContext ctx) {
         return ctx.get(CommonContextKeys.STATUS_CATEGORY_REASON);
     }
 
@@ -55,11 +57,13 @@ public class StatusCategoryUtils {
         ctx.remove(CommonContextKeys.STATUS_CATEGORY_REASON);
     }
 
-    @Nullable public static StatusCategory getOriginStatusCategory(SessionContext ctx) {
+    @Nullable
+    public static StatusCategory getOriginStatusCategory(SessionContext ctx) {
         return ctx.get(CommonContextKeys.ORIGIN_STATUS_CATEGORY);
     }
 
-    @Nullable public static String getOriginStatusCategoryReason(SessionContext ctx) {
+    @Nullable
+    public static String getOriginStatusCategoryReason(SessionContext ctx) {
         return ctx.get(CommonContextKeys.ORIGIN_STATUS_CATEGORY_REASON);
     }
 

--- a/zuul-core/src/test/java/com/netflix/netty/common/CloseOnIdleStateHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/CloseOnIdleStateHandlerTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.netty.common;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
@@ -50,6 +50,6 @@ class CloseOnIdleStateHandlerTest {
                 .fireUserEventTriggered(IdleStateEvent.ALL_IDLE_STATE_EVENT);
 
         Counter idleTimeouts = (Counter) registry.get(counterId);
-        assertEquals(1, idleTimeouts.count());
+        assertThat(idleTimeouts.count()).isEqualTo(1);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/netty/common/HttpServerLifecycleChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/HttpServerLifecycleChannelHandlerTest.java
@@ -16,7 +16,8 @@
 
 package com.netflix.netty.common;
 
-import com.google.common.truth.Truth;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
 import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
 import com.netflix.netty.common.HttpLifecycleChannelHandler.State;
@@ -42,7 +43,7 @@ class HttpServerLifecycleChannelHandlerTest {
 
         @Override
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
-            Truth.assertThat(evt).isInstanceOf(CompleteEvent.class);
+            assertThat(evt).isInstanceOf(CompleteEvent.class);
             this.completeEvent = (CompleteEvent) evt;
         }
 
@@ -64,7 +65,7 @@ class HttpServerLifecycleChannelHandlerTest {
         // Fire close
         channel.pipeline().close();
 
-        Truth.assertThat(reasonHandler.getCompleteEvent().getReason()).isEqualTo(CompleteReason.PIPELINE_REJECT);
+        assertThat(reasonHandler.getCompleteEvent().getReason()).isEqualTo(CompleteReason.PIPELINE_REJECT);
     }
 
     @Test
@@ -78,7 +79,7 @@ class HttpServerLifecycleChannelHandlerTest {
         // Fire close
         channel.pipeline().close();
 
-        Truth.assertThat(reasonHandler.getCompleteEvent().getReason()).isEqualTo(CompleteReason.CLOSE);
+        assertThat(reasonHandler.getCompleteEvent().getReason()).isEqualTo(CompleteReason.CLOSE);
     }
 
     @Test
@@ -88,16 +89,16 @@ class HttpServerLifecycleChannelHandlerTest {
 
         ByteBuf buffer = UnpooledByteBufAllocator.DEFAULT.buffer();
         try {
-            Truth.assertThat(buffer.refCnt()).isEqualTo(1);
+            assertThat(buffer.refCnt()).isEqualTo(1);
             FullHttpRequest httpRequest =
                     new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/whatever", buffer);
             channel.attr(HttpLifecycleChannelHandler.ATTR_STATE).set(State.STARTED);
             channel.writeInbound(httpRequest);
 
-            Truth.assertThat(channel.attr(HttpLifecycleChannelHandler.ATTR_HTTP_PIPELINE_REJECT)
+            assertThat(channel.attr(HttpLifecycleChannelHandler.ATTR_HTTP_PIPELINE_REJECT)
                             .get())
                     .isEqualTo(Boolean.TRUE);
-            Truth.assertThat(buffer.refCnt()).isEqualTo(0);
+            assertThat(buffer.refCnt()).isEqualTo(0);
         } finally {
             if (buffer.refCnt() != 0) {
                 ReferenceCountUtil.release(buffer);

--- a/zuul-core/src/test/java/com/netflix/netty/common/SourceAddressChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/SourceAddressChannelHandlerTest.java
@@ -16,9 +16,7 @@
 
 package com.netflix.netty.common;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.Inet4Address;
 import java.net.Inet6Address;
@@ -29,9 +27,9 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
 
 /**
  * Unit tests for {@link SourceAddressChannelHandler}.
@@ -42,11 +40,11 @@ class SourceAddressChannelHandlerTest {
     void ipv6AddressScopeIdRemoved() throws Exception {
         Inet6Address address =
                 Inet6Address.getByAddress("localhost", new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}, 2);
-        assertEquals(2, address.getScopeId());
+        assertThat(address.getScopeId()).isEqualTo(2);
 
         String addressString = SourceAddressChannelHandler.getHostAddress(new InetSocketAddress(address, 8080));
 
-        assertEquals("0:0:0:0:0:0:0:1", addressString);
+        assertThat(addressString).isEqualTo("0:0:0:0:0:0:0:1");
     }
 
     @Test
@@ -55,7 +53,7 @@ class SourceAddressChannelHandlerTest {
 
         String addressString = SourceAddressChannelHandler.getHostAddress(new InetSocketAddress(address, 8080));
 
-        assertEquals("127.0.0.1", addressString);
+        assertThat(addressString).isEqualTo("127.0.0.1");
     }
 
     @Test
@@ -64,7 +62,7 @@ class SourceAddressChannelHandlerTest {
 
         String addressString = SourceAddressChannelHandler.getHostAddress(address);
 
-        assertNull(null, addressString);
+        assertThat(addressString).isNull();
     }
 
     @Test
@@ -73,11 +71,11 @@ class SourceAddressChannelHandlerTest {
         // ::ffff:127.0.0.1
         Inet6Address address = Inet6Address.getByAddress(
                 "localhost", new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte) 0xFF, (byte) 0xFF, 127, 0, 0, 1}, -1);
-        assertEquals(0, address.getScopeId());
+        assertThat(address.getScopeId()).isEqualTo(0);
 
         String addressString = SourceAddressChannelHandler.getHostAddress(new InetSocketAddress(address, 8080));
 
-        assertEquals("127.0.0.1", addressString);
+        assertThat(addressString).isEqualTo("127.0.0.1");
     }
 
     @Test
@@ -97,15 +95,15 @@ class SourceAddressChannelHandlerTest {
                 continue;
             }
 
-            assertTrue(address.toString().contains("%"), address.toString());
+            assertThat(address.toString().contains("%")).as(address.toString()).isTrue();
 
             String addressString = SourceAddressChannelHandler.getHostAddress(new InetSocketAddress(address, 8080));
 
-            assertEquals("0:0:0:0:0:0:0:1", addressString);
+            assertThat(addressString).isEqualTo("0:0:0:0:0:0:0:1");
             return;
         }
 
-        AssumptionViolatedException failure = new AssumptionViolatedException("No Compatible Nics were found");
+        TestAbortedException failure = new TestAbortedException("No Compatible Nics were found");
         failures.forEach(failure::addSuppressed);
         throw failure;
     }

--- a/zuul-core/src/test/java/com/netflix/netty/common/metrics/InstrumentedResourceLeakDetectorTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/metrics/InstrumentedResourceLeakDetectorTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.netty.common.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.buffer.ByteBuf;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,12 +37,12 @@ class InstrumentedResourceLeakDetectorTest {
     @Test
     void test() {
         leakDetector.reportTracedLeak("test", "test");
-        assertEquals(1, leakDetector.leakCounter.get());
+        assertThat(leakDetector.leakCounter.get()).isEqualTo(1);
 
         leakDetector.reportTracedLeak("test", "test");
-        assertEquals(2, leakDetector.leakCounter.get());
+        assertThat(leakDetector.leakCounter.get()).isEqualTo(2);
 
         leakDetector.reportTracedLeak("test", "test");
-        assertEquals(3, leakDetector.leakCounter.get());
+        assertThat(leakDetector.leakCounter.get()).isEqualTo(3);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandlerTest.java
@@ -16,10 +16,7 @@
 
 package com.netflix.netty.common.proxyprotocol;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.net.InetAddresses;
 import com.netflix.netty.common.SourceAddressChannelHandler;
@@ -66,19 +63,26 @@ class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object dropped = channel.readInbound();
-        assertEquals(dropped, buf);
+        assertThat(buf).isEqualTo(dropped);
         buf.release();
 
-        assertNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
-        assertNull(channel.pipeline().context("HAProxyMessageChannelHandler"));
-        assertNull(
-                channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION).get());
-        assertNull(
-                channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE).get());
-        assertNull(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get());
-        assertNull(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get());
-        assertNull(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get());
-        assertNull(channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get());
+        assertThat(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME))
+                .isNull();
+        assertThat(channel.pipeline().context("HAProxyMessageChannelHandler")).isNull();
+        assertThat(channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION)
+                        .get())
+                .isNull();
+        assertThat(channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE)
+                        .get())
+                .isNull();
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get())
+                .isNull();
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get())
+                .isNull();
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get())
+                .isNull();
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get())
+                .isNull();
     }
 
     @Test
@@ -95,10 +99,12 @@ class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object msg = channel.readInbound();
-        assertNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
+        assertThat(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME))
+                .isNull();
 
         ByteBuf readBuf = (ByteBuf) msg;
-        assertEquals("POTATO", new String(ByteBufUtil.getBytes(readBuf), StandardCharsets.US_ASCII));
+        assertThat(new String(ByteBufUtil.getBytes(readBuf), StandardCharsets.US_ASCII))
+                .isEqualTo("POTATO");
         readBuf.release();
     }
 
@@ -117,19 +123,26 @@ class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object dropped = channel.readInbound();
-        assertEquals(dropped, buf);
+        assertThat(buf).isEqualTo(dropped);
         buf.release();
 
-        assertNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
-        assertNull(channel.pipeline().context("HAProxyMessageChannelHandler"));
-        assertNull(
-                channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION).get());
-        assertNull(
-                channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE).get());
-        assertNull(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get());
-        assertNull(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get());
-        assertNull(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get());
-        assertNull(channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get());
+        assertThat(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME))
+                .isNull();
+        assertThat(channel.pipeline().context("HAProxyMessageChannelHandler")).isNull();
+        assertThat(channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION)
+                        .get())
+                .isNull();
+        assertThat(channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE)
+                        .get())
+                .isNull();
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get())
+                .isNull();
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get())
+                .isNull();
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get())
+                .isNull();
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get())
+                .isNull();
     }
 
     @Test
@@ -147,12 +160,12 @@ class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object dropped = channel.readInbound();
-        assertEquals(dropped, buf);
+        assertThat(buf).isEqualTo(dropped);
         buf.release();
 
         Counter counter = registry.counter(
                 "zuul.hapm.decode", "success", "false", "port", String.valueOf(port), "needs_more_data", "false");
-        assertEquals(1, counter.count());
+        assertThat(counter.count()).isEqualTo(1);
     }
 
     @Disabled
@@ -172,13 +185,14 @@ class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf2);
 
         Object msg = channel.readInbound();
-        assertTrue(msg instanceof HAProxyMessage);
+        assertThat(msg instanceof HAProxyMessage).isTrue();
         buf1.release();
         buf2.release();
         ((HAProxyMessage) msg).release();
 
         // The handler should remove itself.
-        assertNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.class));
+        assertThat(channel.pipeline().context(ElbProxyProtocolChannelHandler.class))
+                .isNull();
     }
 
     @Test
@@ -195,15 +209,16 @@ class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf1);
 
         Object msg = channel.readInbound();
-        assertEquals(buf1, msg);
+        assertThat(msg).isEqualTo(buf1);
         buf1.release();
 
         // The handler should remove itself.
-        assertNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.class));
+        assertThat(channel.pipeline().context(ElbProxyProtocolChannelHandler.class))
+                .isNull();
 
         Counter counter = registry.counter(
                 "zuul.hapm.decode", "success", "false", "port", String.valueOf(port), "needs_more_data", "true");
-        assertEquals(1, counter.count());
+        assertThat(counter.count()).isEqualTo(1);
     }
 
     @Test
@@ -220,30 +235,29 @@ class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object dropped = channel.readInbound();
-        assertNull(dropped);
+        assertThat(dropped).isNull();
 
         // The handler should remove itself.
-        assertNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
-        assertNull(channel.pipeline().context(HAProxyMessageChannelHandler.class));
-        assertEquals(
-                HAProxyProtocolVersion.V1,
-                channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION).get());
+        assertThat(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME))
+                .isNull();
+        assertThat(channel.pipeline().context(HAProxyMessageChannelHandler.class))
+                .isNull();
+        assertThat(channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION)
+                        .get())
+                .isEqualTo(HAProxyProtocolVersion.V1);
         // TODO(carl-mastrangelo): this check is in place, but it should be removed.  The message is not properly GC'd
         // in later versions of netty.
-        assertNotNull(
-                channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE).get());
-        assertEquals(
-                "124.123.111.111",
-                channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get());
-        assertEquals(
-                new InetSocketAddress(InetAddresses.forString("124.123.111.111"), 443),
-                channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get());
-        assertEquals(
-                "192.168.0.1",
-                channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get());
-        assertEquals(
-                new InetSocketAddress(InetAddresses.forString("192.168.0.1"), 10008),
-                channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get());
+        assertThat(channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE)
+                        .get())
+                .isNotNull();
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get())
+                .isEqualTo("124.123.111.111");
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get())
+                .isEqualTo(new InetSocketAddress(InetAddresses.forString("124.123.111.111"), 443));
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get())
+                .isEqualTo("192.168.0.1");
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get())
+                .isEqualTo(new InetSocketAddress(InetAddresses.forString("192.168.0.1"), 10008));
     }
 
     @Test
@@ -259,29 +273,27 @@ class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object dropped = channel.readInbound();
-        assertNull(dropped);
+        assertThat(dropped).isNull();
 
         // The handler should remove itself.
-        assertNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
-        assertEquals(
-                HAProxyProtocolVersion.V1,
-                channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION).get());
+        assertThat(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME))
+                .isNull();
+        assertThat(channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION)
+                        .get())
+                .isEqualTo(HAProxyProtocolVersion.V1);
         // TODO(carl-mastrangelo): this check is in place, but it should be removed.  The message is not properly GC'd
         // in later versions of netty.
-        assertNotNull(
-                channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE).get());
-        assertEquals(
-                "::2",
-                channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get());
-        assertEquals(
-                new InetSocketAddress(InetAddresses.forString("::2"), 443),
-                channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get());
-        assertEquals(
-                "::1",
-                channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get());
-        assertEquals(
-                new InetSocketAddress(InetAddresses.forString("::1"), 10008),
-                channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get());
+        assertThat(channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE)
+                        .get())
+                .isNotNull();
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get())
+                .isEqualTo("::2");
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get())
+                .isEqualTo(new InetSocketAddress(InetAddresses.forString("::2"), 443));
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get())
+                .isEqualTo("::1");
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get())
+                .isEqualTo(new InetSocketAddress(InetAddresses.forString("::1"), 10008));
     }
 
     @Test
@@ -326,28 +338,26 @@ class ElbProxyProtocolChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object dropped = channel.readInbound();
-        assertNull(dropped);
+        assertThat(dropped).isNull();
 
         // The handler should remove itself.
-        assertNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
-        assertEquals(
-                HAProxyProtocolVersion.V2,
-                channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION).get());
+        assertThat(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME))
+                .isNull();
+        assertThat(channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_VERSION)
+                        .get())
+                .isEqualTo(HAProxyProtocolVersion.V2);
         // TODO(carl-mastrangelo): this check is in place, but it should be removed.  The message is not properly GC'd
         // in later versions of netty.
-        assertNotNull(
-                channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE).get());
-        assertEquals(
-                "124.123.111.111",
-                channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get());
-        assertEquals(
-                new InetSocketAddress(InetAddresses.forString("124.123.111.111"), 443),
-                channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get());
-        assertEquals(
-                "192.168.0.1",
-                channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get());
-        assertEquals(
-                new InetSocketAddress(InetAddresses.forString("192.168.0.1"), 10008),
-                channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get());
+        assertThat(channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE)
+                        .get())
+                .isNotNull();
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get())
+                .isEqualTo("124.123.111.111");
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get())
+                .isEqualTo(new InetSocketAddress(InetAddresses.forString("124.123.111.111"), 443));
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get())
+                .isEqualTo("192.168.0.1");
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get())
+                .isEqualTo(new InetSocketAddress(InetAddresses.forString("192.168.0.1"), 10008));
     }
 }

--- a/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/HAProxyMessageChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/HAProxyMessageChannelHandlerTest.java
@@ -16,9 +16,7 @@
 
 package com.netflix.netty.common.proxyprotocol;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.zuul.Attrs;
@@ -32,7 +30,6 @@ import io.netty.handler.codec.haproxy.HAProxyTLV;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 class HAProxyMessageChannelHandlerTest {
@@ -52,7 +49,7 @@ class HAProxyMessageChannelHandlerTest {
         channel.writeInbound(buf);
 
         Object result = channel.readInbound();
-        assertNull(result);
+        assertThat(result).isNull();
 
         InetSocketAddress destAddress = channel.attr(
                         SourceAddressChannelHandler.ATTR_PROXY_PROTOCOL_DESTINATION_ADDRESS)
@@ -61,19 +58,19 @@ class HAProxyMessageChannelHandlerTest {
         InetSocketAddress srcAddress = (InetSocketAddress)
                 channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get();
 
-        assertEquals("124.123.111.111", destAddress.getHostString());
-        assertEquals(443, destAddress.getPort());
+        assertThat(destAddress.getHostString()).isEqualTo("124.123.111.111");
+        assertThat(destAddress.getPort()).isEqualTo(443);
 
-        assertEquals("192.168.0.1", srcAddress.getHostString());
-        assertEquals(10008, srcAddress.getPort());
+        assertThat(srcAddress.getHostString()).isEqualTo("192.168.0.1");
+        assertThat(srcAddress.getPort()).isEqualTo(10008);
 
         Attrs attrs = channel.attr(Server.CONN_DIMENSIONS).get();
         Integer port = HAProxyMessageChannelHandler.HAPM_DEST_PORT.get(attrs);
-        assertEquals(443, port.intValue());
+        assertThat(port.intValue()).isEqualTo(443);
         String sourceIpVersion = HAProxyMessageChannelHandler.HAPM_SRC_IP_VERSION.get(attrs);
-        assertEquals("v4", sourceIpVersion);
+        assertThat(sourceIpVersion).isEqualTo("v4");
         String destIpVersion = HAProxyMessageChannelHandler.HAPM_DEST_IP_VERSION.get(attrs);
-        assertEquals("v4", destIpVersion);
+        assertThat(destIpVersion).isEqualTo("v4");
     }
 
     @Test
@@ -145,7 +142,7 @@ class HAProxyMessageChannelHandlerTest {
         channel.writeInbound(Unpooled.wrappedBuffer(header));
 
         Object result = channel.readInbound();
-        assertNull(result);
+        assertThat(result).isNull();
 
         HAProxyMessage hapm =
                 channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE).get();
@@ -157,7 +154,7 @@ class HAProxyMessageChannelHandlerTest {
 
         List<HAProxyTLV> nflxTLV = channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_CUSTOM_TLVS)
                 .get();
-        Assert.assertEquals(nflxTLV.size(), 1);
+        assertThat(nflxTLV.size()).isEqualTo(1);
         String payload = nflxTLV.get(0).content().toString(StandardCharsets.UTF_8);
         assertThat(payload).isEqualTo("nflx.custom.tlv");
     }
@@ -212,7 +209,7 @@ class HAProxyMessageChannelHandlerTest {
         channel.writeInbound(Unpooled.wrappedBuffer(header));
 
         Object result = channel.readInbound();
-        assertNull(result);
+        assertThat(result).isNull();
 
         HAProxyMessage hapm =
                 channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE).get();
@@ -300,7 +297,7 @@ class HAProxyMessageChannelHandlerTest {
         channel.writeInbound(Unpooled.wrappedBuffer(header));
 
         Object result = channel.readInbound();
-        assertNull(result);
+        assertThat(result).isNull();
 
         HAProxyMessage hapm =
                 channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE).get();

--- a/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.netty.common.proxyprotocol;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -154,7 +154,7 @@ class StripUntrustedProxyHeadersHandlerTest {
         headers.add("x-forwarded-for", "abcd");
         stripHandler.stripXFFHeaders(msg);
 
-        assertFalse(headers.contains("x-forwarded-for"));
+        assertThat(headers.contains("x-forwarded-for")).isFalse();
     }
 
     private StripUntrustedProxyHeadersHandler getHandler(AllowWhen allowWhen) {

--- a/zuul-core/src/test/java/com/netflix/netty/common/throttle/MaxInboundConnectionsHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/throttle/MaxInboundConnectionsHandlerTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.netty.common.throttle;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
@@ -54,10 +53,9 @@ class MaxInboundConnectionsHandlerTest {
 
         Counter throttledCount = (Counter) registry.get(counterId);
 
-        assertEquals(1, throttledCount.count());
-        assertEquals(
-                PassportState.SERVER_CH_THROTTLING,
-                CurrentPassport.fromChannel(channel).getState());
-        assertTrue(channel.attr(MaxInboundConnectionsHandler.ATTR_CH_THROTTLED).get());
+        assertThat(throttledCount.count()).isEqualTo(1);
+        assertThat(CurrentPassport.fromChannel(channel).getState()).isEqualTo(PassportState.SERVER_CH_THROTTLING);
+        assertThat(channel.attr(MaxInboundConnectionsHandler.ATTR_CH_THROTTLED).get())
+                .isTrue();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/AttrsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/AttrsTest.java
@@ -16,11 +16,9 @@
 
 package com.netflix.zuul;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.google.common.truth.Truth;
 import org.junit.jupiter.api.Test;
 
 class AttrsTest {
@@ -32,12 +30,12 @@ class AttrsTest {
         Attrs.Key<String> key2 = Attrs.newKey("foo");
         key2.put(attrs, "baz");
 
-        Truth.assertThat(attrs.keySet()).containsExactly(key1, key2);
+        assertThat(attrs.keySet()).containsExactlyInAnyOrder(key1, key2);
     }
 
     @Test
     void newKeyFailsOnNull() {
-        assertThrows(NullPointerException.class, () -> Attrs.newKey(null));
+        assertThatThrownBy(() -> Attrs.newKey(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -45,7 +43,7 @@ class AttrsTest {
         Attrs attrs = Attrs.newInstance();
         Attrs.Key<String> key = Attrs.newKey("foo");
 
-        assertThrows(NullPointerException.class, () -> key.put(attrs, null));
+        assertThatThrownBy(() -> key.put(attrs, null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -55,8 +53,8 @@ class AttrsTest {
         key.put(attrs, "bar");
         key.put(attrs, "baz");
 
-        assertEquals("baz", key.get(attrs));
-        Truth.assertThat(attrs.keySet()).containsExactly(key);
+        assertThat(key.get(attrs)).isEqualTo("baz");
+        assertThat(attrs.keySet()).containsExactly(key);
     }
 
     @Test
@@ -64,7 +62,7 @@ class AttrsTest {
         Attrs attrs = Attrs.newInstance();
         Attrs.Key<String> key = Attrs.newKey("foo");
 
-        assertNull(key.get(attrs));
+        assertThat(key.get(attrs)).isNull();
     }
 
     @Test
@@ -72,7 +70,7 @@ class AttrsTest {
         Attrs attrs = Attrs.newInstance();
         Attrs.Key<String> key = Attrs.newKey("foo");
 
-        assertEquals("bar", key.getOrDefault(attrs, "bar"));
+        assertThat(key.getOrDefault(attrs, "bar")).isEqualTo("bar");
     }
 
     @Test
@@ -81,6 +79,6 @@ class AttrsTest {
         Attrs.Key<String> key = Attrs.newKey("foo");
         key.put(attrs, "bar");
 
-        assertThrows(NullPointerException.class, () -> key.getOrDefault(attrs, null));
+        assertThatThrownBy(() -> key.getOrDefault(attrs, null)).isInstanceOf(NullPointerException.class);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/DynamicFilterLoaderTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/DynamicFilterLoaderTest.java
@@ -15,8 +15,7 @@
  */
 package com.netflix.zuul;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.zuul.filters.BaseSyncFilter;
 import com.netflix.zuul.filters.FilterRegistry;
@@ -49,7 +48,7 @@ class DynamicFilterLoaderTest {
         loader.putFiltersForClasses(new String[] {TestZuulFilter.class.getName()});
 
         Collection<ZuulFilter<?, ?>> filters = registry.getAllFilters();
-        assertEquals(1, filters.size());
+        assertThat(filters.size()).isEqualTo(1);
     }
 
     @Test
@@ -60,9 +59,9 @@ class DynamicFilterLoaderTest {
         } catch (ClassNotFoundException e) {
             caught = e;
         }
-        assertTrue(caught != null);
+        assertThat(caught != null).isTrue();
         Collection<ZuulFilter<?, ?>> filters = registry.getAllFilters();
-        assertEquals(0, filters.size());
+        assertThat(filters.size()).isEqualTo(0);
     }
 
     @Test
@@ -70,14 +69,14 @@ class DynamicFilterLoaderTest {
         loader.putFiltersForClasses(new String[] {TestZuulFilter.class.getName()});
 
         Collection<ZuulFilter<?, ?>> filters = registry.getAllFilters();
-        assertEquals(1, filters.size());
+        assertThat(filters.size()).isEqualTo(1);
 
         Collection<ZuulFilter<?, ?>> list = loader.getFiltersByType(FilterType.INBOUND);
-        assertTrue(list != null);
-        assertEquals(1, list.size());
+        assertThat(list != null).isTrue();
+        assertThat(list.size()).isEqualTo(1);
         ZuulFilter<?, ?> filter = list.iterator().next();
-        assertTrue(filter != null);
-        assertEquals(FilterType.INBOUND, filter.filterType());
+        assertThat(filter != null).isTrue();
+        assertThat(filter.filterType()).isEqualTo(FilterType.INBOUND);
     }
 
     private static final class TestZuulFilter extends BaseSyncFilter {

--- a/zuul-core/src/test/java/com/netflix/zuul/StaticFilterLoaderTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/StaticFilterLoaderTest.java
@@ -16,8 +16,9 @@
 
 package com.netflix.zuul;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.collect.ImmutableSet;
-import com.google.common.truth.Truth;
 import com.netflix.zuul.filters.FilterType;
 import com.netflix.zuul.filters.ZuulFilter;
 import com.netflix.zuul.filters.http.HttpInboundSyncFilter;
@@ -37,12 +38,12 @@ class StaticFilterLoaderTest {
                 factory, ImmutableSet.of(DummyFilter2.class, DummyFilter1.class, DummyFilter22.class));
 
         SortedSet<ZuulFilter<?, ?>> filters = filterLoader.getFiltersByType(FilterType.INBOUND);
-        Truth.assertThat(filters).hasSize(3);
+        assertThat(filters).hasSize(3);
         List<ZuulFilter<?, ?>> filterList = new ArrayList<>(filters);
 
-        Truth.assertThat(filterList.get(0)).isInstanceOf(DummyFilter1.class);
-        Truth.assertThat(filterList.get(1)).isInstanceOf(DummyFilter2.class);
-        Truth.assertThat(filterList.get(2)).isInstanceOf(DummyFilter22.class);
+        assertThat(filterList.get(0)).isInstanceOf(DummyFilter1.class);
+        assertThat(filterList.get(1)).isInstanceOf(DummyFilter2.class);
+        assertThat(filterList.get(2)).isInstanceOf(DummyFilter22.class);
     }
 
     @Test
@@ -52,7 +53,7 @@ class StaticFilterLoaderTest {
 
         ZuulFilter<?, ?> filter = filterLoader.getFilterByNameAndType("Robin", FilterType.INBOUND);
 
-        Truth.assertThat(filter).isInstanceOf(DummyFilter2.class);
+        assertThat(filter).isInstanceOf(DummyFilter2.class);
     }
 
     @Filter(order = 0, type = FilterType.INBOUND)

--- a/zuul-core/src/test/java/com/netflix/zuul/com/netflix/zuul/netty/server/push/PushConnectionTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/com/netflix/zuul/netty/server/push/PushConnectionTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.com.netflix.zuul.netty.server.push;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.zuul.netty.server.push.PushConnection;
 import com.netflix.zuul.netty.server.push.PushProtocol;
@@ -33,7 +32,7 @@ class PushConnectionTest {
     void testOneMessagePerSecond() throws InterruptedException {
         PushConnection conn = new PushConnection(PushProtocol.WEBSOCKET, null);
         for (int i = 0; i < 5; i++) {
-            assertFalse(conn.isRateLimited());
+            assertThat(conn.isRateLimited()).isFalse();
             Thread.sleep(1000);
         }
     }
@@ -41,18 +40,18 @@ class PushConnectionTest {
     @Test
     void testThreeMessagesInSuccession() {
         PushConnection conn = new PushConnection(PushProtocol.WEBSOCKET, null);
-        assertFalse(conn.isRateLimited());
-        assertFalse(conn.isRateLimited());
-        assertFalse(conn.isRateLimited());
+        assertThat(conn.isRateLimited()).isFalse();
+        assertThat(conn.isRateLimited()).isFalse();
+        assertThat(conn.isRateLimited()).isFalse();
     }
 
     @Test
     void testFourMessagesInSuccession() {
         PushConnection conn = new PushConnection(PushProtocol.WEBSOCKET, null);
-        assertFalse(conn.isRateLimited());
-        assertFalse(conn.isRateLimited());
-        assertFalse(conn.isRateLimited());
-        assertTrue(conn.isRateLimited());
+        assertThat(conn.isRateLimited()).isFalse();
+        assertThat(conn.isRateLimited()).isFalse();
+        assertThat(conn.isRateLimited()).isFalse();
+        assertThat(conn.isRateLimited()).isTrue();
     }
 
     @Test
@@ -60,9 +59,9 @@ class PushConnectionTest {
         PushConnection conn = new PushConnection(PushProtocol.WEBSOCKET, null);
         for (int i = 0; i < 10; i++) {
             if (i < 3) {
-                assertFalse(conn.isRateLimited());
+                assertThat(conn.isRateLimited()).isFalse();
             } else {
-                assertTrue(conn.isRateLimited());
+                assertThat(conn.isRateLimited()).isTrue();
             }
         }
     }
@@ -70,14 +69,14 @@ class PushConnectionTest {
     @Test
     void testMessagesInBatches() throws InterruptedException {
         PushConnection conn = new PushConnection(PushProtocol.WEBSOCKET, null);
-        assertFalse(conn.isRateLimited());
-        assertFalse(conn.isRateLimited());
-        assertFalse(conn.isRateLimited());
-        assertTrue(conn.isRateLimited());
+        assertThat(conn.isRateLimited()).isFalse();
+        assertThat(conn.isRateLimited()).isFalse();
+        assertThat(conn.isRateLimited()).isFalse();
+        assertThat(conn.isRateLimited()).isTrue();
         Thread.sleep(2000);
-        assertFalse(conn.isRateLimited());
-        assertFalse(conn.isRateLimited());
-        assertFalse(conn.isRateLimited());
-        assertTrue(conn.isRateLimited());
+        assertThat(conn.isRateLimited()).isFalse();
+        assertThat(conn.isRateLimited()).isFalse();
+        assertThat(conn.isRateLimited()).isFalse();
+        assertThat(conn.isRateLimited()).isTrue();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/DebugTest.java
@@ -23,10 +23,8 @@ import static com.netflix.zuul.context.Debug.getRequestDebug;
 import static com.netflix.zuul.context.Debug.getRoutingDebug;
 import static com.netflix.zuul.context.Debug.setDebugRequest;
 import static com.netflix.zuul.context.Debug.setDebugRouting;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.truth.Truth;
 import com.netflix.zuul.message.Headers;
 import com.netflix.zuul.message.http.HttpQueryParams;
 import com.netflix.zuul.message.http.HttpRequestMessage;
@@ -71,18 +69,18 @@ class DebugTest {
 
     @Test
     void testRequestDebug() {
-        assertFalse(debugRouting(ctx));
-        assertFalse(debugRequest(ctx));
+        assertThat(debugRouting(ctx)).isFalse();
+        assertThat(debugRequest(ctx)).isFalse();
         setDebugRouting(ctx, true);
         setDebugRequest(ctx, true);
-        assertTrue(debugRouting(ctx));
-        assertTrue(debugRequest(ctx));
+        assertThat(debugRouting(ctx)).isTrue();
+        assertThat(debugRequest(ctx)).isTrue();
 
         addRoutingDebug(ctx, "test1");
-        assertTrue(getRoutingDebug(ctx).contains("test1"));
+        assertThat(getRoutingDebug(ctx).contains("test1")).isTrue();
 
         addRequestDebug(ctx, "test2");
-        assertTrue(getRequestDebug(ctx).contains("test2"));
+        assertThat(getRequestDebug(ctx).contains("test2")).isTrue();
     }
 
     @Test
@@ -92,8 +90,8 @@ class DebugTest {
         Debug.writeDebugRequest(ctx, request, true).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        Truth.assertThat(debugLines)
-                .containsExactly(
+        assertThat(debugLines)
+                .containsExactlyInAnyOrder(
                         "REQUEST_INBOUND:: > LINE: POST /some/where?k1=v1 HTTP/1.1",
                         "REQUEST_INBOUND:: > HDR: Content-Length:13",
                         "REQUEST_INBOUND:: > HDR: lah:deda");
@@ -106,8 +104,8 @@ class DebugTest {
         Debug.writeDebugRequest(ctx, request, false).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        Truth.assertThat(debugLines)
-                .containsExactly(
+        assertThat(debugLines)
+                .containsExactlyInAnyOrder(
                         "REQUEST_OUTBOUND:: > LINE: POST /some/where?k1=v1 HTTP/1.1",
                         "REQUEST_OUTBOUND:: > HDR: Content-Length:13",
                         "REQUEST_OUTBOUND:: > HDR: lah:deda");
@@ -120,8 +118,8 @@ class DebugTest {
         Debug.writeDebugRequest(ctx, request, true).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        Truth.assertThat(debugLines)
-                .containsExactly(
+        assertThat(debugLines)
+                .containsExactlyInAnyOrder(
                         "REQUEST_INBOUND:: > LINE: POST /some/where?k1=v1 HTTP/1.1",
                         "REQUEST_INBOUND:: > HDR: Content-Length:13",
                         "REQUEST_INBOUND:: > HDR: lah:deda",
@@ -135,8 +133,8 @@ class DebugTest {
         Debug.writeDebugResponse(ctx, response, true).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        Truth.assertThat(debugLines)
-                .containsExactly(
+        assertThat(debugLines)
+                .containsExactlyInAnyOrder(
                         "RESPONSE_INBOUND:: < STATUS: 200",
                         "RESPONSE_INBOUND:: < HDR: Content-Length:13",
                         "RESPONSE_INBOUND:: < HDR: lah:deda");
@@ -149,8 +147,8 @@ class DebugTest {
         Debug.writeDebugResponse(ctx, response, false).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        Truth.assertThat(debugLines)
-                .containsExactly(
+        assertThat(debugLines)
+                .containsExactlyInAnyOrder(
                         "RESPONSE_OUTBOUND:: < STATUS: 200",
                         "RESPONSE_OUTBOUND:: < HDR: Content-Length:13",
                         "RESPONSE_OUTBOUND:: < HDR: lah:deda");
@@ -163,8 +161,8 @@ class DebugTest {
         Debug.writeDebugResponse(ctx, response, true).toBlocking().single();
 
         List<String> debugLines = getRequestDebug(ctx);
-        Truth.assertThat(debugLines)
-                .containsExactly(
+        assertThat(debugLines)
+                .containsExactlyInAnyOrder(
                         "RESPONSE_INBOUND:: < STATUS: 200",
                         "RESPONSE_INBOUND:: < HDR: Content-Length:13",
                         "RESPONSE_INBOUND:: < HDR: lah:deda",

--- a/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
@@ -15,11 +15,9 @@
  */
 package com.netflix.zuul.context;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.google.common.truth.Truth;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,8 +28,8 @@ class SessionContextTest {
     @Test
     void testBoolean() {
         SessionContext context = new SessionContext();
-        assertEquals(Boolean.FALSE, context.getBoolean("boolean_test"));
-        assertEquals(true, context.getBoolean("boolean_test", true));
+        assertThat(context.getBoolean("boolean_test")).isEqualTo(Boolean.FALSE);
+        assertThat(context.getBoolean("boolean_test", true)).isEqualTo(true);
     }
 
     @Test
@@ -42,12 +40,12 @@ class SessionContextTest {
         SessionContext.Key<String> key2 = SessionContext.newKey("foo");
         context.put(key2, "baz");
 
-        Truth.assertThat(context.keys()).containsExactly(key1, key2);
+        assertThat(context.keys()).containsExactlyInAnyOrder(key1, key2);
     }
 
     @Test
     void newKeyFailsOnNull() {
-        assertThrows(NullPointerException.class, () -> SessionContext.newKey(null));
+        assertThatThrownBy(() -> SessionContext.newKey(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -55,7 +53,7 @@ class SessionContextTest {
         SessionContext context = new SessionContext();
         SessionContext.Key<String> key = SessionContext.newKey("foo");
 
-        assertThrows(NullPointerException.class, () -> context.put(key, null));
+        assertThatThrownBy(() -> context.put(key, null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -65,8 +63,8 @@ class SessionContextTest {
         context.put(key, "bar");
         context.put(key, "baz");
 
-        assertEquals("baz", context.get(key));
-        Truth.assertThat(context.keys()).containsExactly(key);
+        assertThat(context.get(key)).isEqualTo("baz");
+        assertThat(context.keys()).containsExactly(key);
     }
 
     @Test
@@ -74,7 +72,7 @@ class SessionContextTest {
         SessionContext context = new SessionContext();
         SessionContext.Key<String> key = SessionContext.newKey("foo");
 
-        assertNull(context.get(key));
+        assertThat(context.get(key)).isNull();
     }
 
     @Test
@@ -82,7 +80,7 @@ class SessionContextTest {
         SessionContext context = new SessionContext();
         SessionContext.Key<String> key = SessionContext.newKey("foo");
 
-        assertEquals("bar", context.getOrDefault(key, "bar"));
+        assertThat(context.getOrDefault(key, "bar")).isEqualTo("bar");
     }
 
     @Test
@@ -91,28 +89,28 @@ class SessionContextTest {
         SessionContext.Key<String> key = SessionContext.newKey("foo");
         context.put(key, "bar");
 
-        assertThrows(NullPointerException.class, () -> context.getOrDefault(key, null));
+        assertThatThrownBy(() -> context.getOrDefault(key, null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void getUsesDefaultValueSupplier() {
         SessionContext context = new SessionContext();
         SessionContext.Key<String> key = SessionContext.newKey("foo", () -> "bar");
-        assertEquals("bar", context.get(key));
+        assertThat(context.get(key)).isEqualTo("bar");
     }
 
     @Test
     void getOrDefaultUsesDefaultValueSupplier() {
         SessionContext context = new SessionContext();
         SessionContext.Key<String> key = SessionContext.newKey("foo", () -> "bar");
-        assertEquals("bar", context.getOrDefault(key));
+        assertThat(context.getOrDefault(key)).isEqualTo("bar");
     }
 
     @Test
     void getOrDefaultUsesDefaultValueSupplierFailsWithout() {
         SessionContext context = new SessionContext();
         SessionContext.Key<String> key = SessionContext.newKey("foo");
-        assertThrows(NullPointerException.class, () -> context.getOrDefault(key));
+        assertThatThrownBy(() -> context.getOrDefault(key)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -121,11 +119,11 @@ class SessionContextTest {
         SessionContext.Key<String> key = SessionContext.newKey("foo");
         context.put(key, "bar");
 
-        Truth.assertThat(context.get(key)).isEqualTo("bar");
+        assertThat(context.get(key)).isEqualTo("bar");
 
         String val = context.remove(key);
-        Truth.assertThat(context.get(key)).isNull();
-        Truth.assertThat(val).isEqualTo("bar");
+        assertThat(context.get(key)).isNull();
+        assertThat(val).isEqualTo("bar");
     }
 
     @Test
@@ -134,11 +132,11 @@ class SessionContextTest {
         SessionContext.Key<String> key = SessionContext.newKey("foo");
         context.put(key, "bar");
 
-        Truth.assertThat(context.containsKey(key)).isTrue();
+        assertThat(context.containsKey(key)).isTrue();
 
         String val = context.remove(key);
-        Truth.assertThat(val).isEqualTo("bar");
+        assertThat(val).isEqualTo("bar");
 
-        Truth.assertThat(context.containsKey(key)).isFalse();
+        assertThat(context.containsKey(key)).isFalse();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/BaseFilterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/BaseFilterTest.java
@@ -15,7 +15,8 @@
  */
 package com.netflix.zuul.filters;
 
-import com.google.common.truth.Truth;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.netflix.config.ConfigurationManager;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.Headers;
@@ -24,14 +25,14 @@ import com.netflix.zuul.message.ZuulMessageImpl;
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import rx.Observable;
 
 /**
  * Tests for {@link BaseFilter}
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 class BaseFilterTest {
 
     private final AbstractConfiguration config = ConfigurationManager.getConfigInstance();
@@ -65,7 +66,7 @@ class BaseFilterTest {
                 .applyAsync(new ZuulMessageImpl(new SessionContext(), new Headers()))
                 .toBlocking()
                 .single();
-        Truth.assertThat(limit[0]).isEqualTo(4000);
+        assertThat(limit[0]).isEqualTo(4000);
     }
 
     @Test
@@ -95,7 +96,7 @@ class BaseFilterTest {
                 .applyAsync(new ZuulMessageImpl(new SessionContext(), new Headers()))
                 .toBlocking()
                 .single();
-        Truth.assertThat(limit[0]).isEqualTo(7000);
+        assertThat(limit[0]).isEqualTo(7000);
     }
 
     @Test
@@ -125,6 +126,6 @@ class BaseFilterTest {
                 .applyAsync(new ZuulMessageImpl(new SessionContext(), new Headers()))
                 .toBlocking()
                 .single();
-        Truth.assertThat(limit[0]).isEqualTo(4300);
+        assertThat(limit[0]).isEqualTo(4300);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/common/GZipResponseFilterTest.java
@@ -17,9 +17,7 @@
 package com.netflix.zuul.filters.common;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.netflix.zuul.context.SessionContext;
@@ -75,7 +73,7 @@ class GZipResponseFilterTest {
         response.getHeaders().set("Content-Length", Integer.toString(originBody.length));
         Mockito.when(filter.isRightSizeForGzip(response)).thenReturn(true); // Force GZip for small response
         response.setHasBody(true);
-        assertTrue(filter.shouldFilter(response));
+        assertThat(filter.shouldFilter(response)).isTrue();
 
         HttpResponseMessage result = filter.apply(response);
         HttpContent hc1 = filter.processContentChunk(
@@ -98,11 +96,11 @@ class GZipResponseFilterTest {
             }
             bodyStr = baos.toString("UTF-8");
         }
-        assertEquals("blah", bodyStr);
-        assertEquals("gzip", result.getHeaders().getFirst("Content-Encoding"));
+        assertThat(bodyStr).isEqualTo("blah");
+        assertThat(result.getHeaders().getFirst("Content-Encoding")).isEqualTo("gzip");
 
         // Check Content-Length header has been removed
-        assertEquals(0, result.getHeaders().getAll("Content-Length").size());
+        assertThat(result.getHeaders().getAll("Content-Length").size()).isEqualTo(0);
     }
 
     @Test
@@ -113,7 +111,7 @@ class GZipResponseFilterTest {
         response.getHeaders().set("Content-Length", Integer.toString(originBody.length));
         Mockito.when(filter.isRightSizeForGzip(response)).thenReturn(true); // Force GZip for small response
         response.setHasBody(true);
-        assertTrue(filter.shouldFilter(response));
+        assertThat(filter.shouldFilter(response)).isTrue();
 
         HttpResponseMessage result = filter.apply(response);
         HttpContent hc1 = filter.processContentChunk(
@@ -136,11 +134,11 @@ class GZipResponseFilterTest {
             }
             bodyStr = baos.toString("UTF-8");
         }
-        assertEquals("blah", bodyStr);
-        assertEquals("gzip", result.getHeaders().getFirst("Content-Encoding"));
+        assertThat(bodyStr).isEqualTo("blah");
+        assertThat(result.getHeaders().getFirst("Content-Encoding")).isEqualTo("gzip");
 
         // Check Content-Length header has been removed
-        assertEquals(0, result.getHeaders().getAll("Content-Length").size());
+        assertThat(result.getHeaders().getAll("Content-Length").size()).isEqualTo(0);
     }
 
     @Test
@@ -152,7 +150,7 @@ class GZipResponseFilterTest {
         response.getHeaders().set("Content-Type", "application/json");
         response.getHeaders().set("Content-Encoding", "gzip");
         response.setHasBody(true);
-        assertFalse(filter.shouldFilter(response));
+        assertThat(filter.shouldFilter(response)).isFalse();
     }
 
     @Test
@@ -164,7 +162,7 @@ class GZipResponseFilterTest {
         response.getHeaders().set("Content-Type", "application/json");
         response.getHeaders().set("Content-Encoding", "deflate");
         response.setHasBody(true);
-        assertFalse(filter.shouldFilter(response));
+        assertThat(filter.shouldFilter(response)).isFalse();
     }
 
     @Test
@@ -173,7 +171,7 @@ class GZipResponseFilterTest {
         byte[] originBody = "blah".getBytes(UTF_8);
         response.getHeaders().set("Content-Length", Integer.toString(originBody.length));
         response.setHasBody(true);
-        assertFalse(filter.shouldFilter(response));
+        assertThat(filter.shouldFilter(response)).isFalse();
     }
 
     @Test
@@ -181,6 +179,6 @@ class GZipResponseFilterTest {
         originalRequestHeaders.set("Accept-Encoding", "gzip");
         response.getHeaders().set("Transfer-Encoding", "chunked");
         response.setHasBody(true);
-        assertTrue(filter.shouldFilter(response));
+        assertThat(filter.shouldFilter(response)).isTrue();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
@@ -16,12 +16,10 @@
 
 package com.netflix.zuul.message;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 
-import com.google.common.truth.Truth;
 import com.netflix.zuul.exception.ZuulException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -45,9 +43,9 @@ class HeadersTest {
         Headers headers2 = Headers.copyOf(headers);
         headers2.add("Via", "duct");
 
-        Truth.assertThat(headers.getAll("Via")).isEmpty();
-        Truth.assertThat(headers2.size()).isEqualTo(2);
-        Truth.assertThat(headers2.getAll("Content-Length")).containsExactly("5");
+        assertThat(headers.getAll("Via")).isEmpty();
+        assertThat(headers2.size()).isEqualTo(2);
+        assertThat(headers2.getAll("Content-Length")).containsExactly("5");
     }
 
     @Test
@@ -57,7 +55,7 @@ class HeadersTest {
         headers.add("Cookie", "this=that");
         headers.add("Cookie", "frizzle=frazzle");
 
-        Truth.assertThat(headers.getFirst("cOOkIE")).isEqualTo("this=that");
+        assertThat(headers.getFirst("cOOkIE")).isEqualTo("this=that");
     }
 
     @Test
@@ -67,7 +65,7 @@ class HeadersTest {
         headers.add("Cookie", "this=that");
         headers.add("Cookie", "frizzle=frazzle");
 
-        Truth.assertThat(headers.getFirst(new HeaderName("cOOkIE"))).isEqualTo("this=that");
+        assertThat(headers.getFirst(new HeaderName("cOOkIE"))).isEqualTo("this=that");
     }
 
     @Test
@@ -77,7 +75,7 @@ class HeadersTest {
         headers.add("Cookie", "this=that");
         headers.add("Cookie", "frizzle=frazzle");
 
-        Truth.assertThat(headers.getFirst("Date")).isNull();
+        assertThat(headers.getFirst("Date")).isNull();
     }
 
     @Test
@@ -87,7 +85,7 @@ class HeadersTest {
         headers.add("Cookie", "this=that");
         headers.add("Cookie", "frizzle=frazzle");
 
-        Truth.assertThat(headers.getFirst(new HeaderName("Date"))).isNull();
+        assertThat(headers.getFirst(new HeaderName("Date"))).isNull();
     }
 
     @Test
@@ -97,7 +95,7 @@ class HeadersTest {
         headers.add("Cookie", "this=that");
         headers.add("Cookie", "frizzle=frazzle");
 
-        Truth.assertThat(headers.getFirst("Date", "tuesday")).isEqualTo("tuesday");
+        assertThat(headers.getFirst("Date", "tuesday")).isEqualTo("tuesday");
     }
 
     @Test
@@ -107,7 +105,7 @@ class HeadersTest {
         headers.add("Cookie", "this=that");
         headers.add("Cookie", "frizzle=frazzle");
 
-        Truth.assertThat(headers.getFirst(new HeaderName("Date"), "tuesday")).isEqualTo("tuesday");
+        assertThat(headers.getFirst(new HeaderName("Date"), "tuesday")).isEqualTo("tuesday");
     }
 
     @Test
@@ -121,11 +119,10 @@ class HeadersTest {
         headers.forEachNormalised((k, v) ->
                 result.computeIfAbsent(k, discard -> new ArrayList<>()).add(v));
 
-        Truth.assertThat(result)
+        assertThat(result)
                 .containsExactly(
-                        "via", Collections.singletonList("duct"),
-                        "cookie", Arrays.asList("this=that", "frizzle=Frazzle"))
-                .inOrder();
+                        entry("via", Collections.singletonList("duct")),
+                        entry("cookie", Arrays.asList("this=that", "frizzle=Frazzle")));
     }
 
     @Test
@@ -135,9 +132,7 @@ class HeadersTest {
         headers.add("Cookie", "this=that");
         headers.add("Cookie", "frizzle=frazzle");
 
-        Truth.assertThat(headers.getAll("CookiE"))
-                .containsExactly("this=that", "frizzle=frazzle")
-                .inOrder();
+        assertThat(headers.getAll("CookiE")).containsExactly("this=that", "frizzle=frazzle");
     }
 
     @Test
@@ -147,9 +142,7 @@ class HeadersTest {
         headers.add("Cookie", "this=that");
         headers.add("Cookie", "frizzle=frazzle");
 
-        Truth.assertThat(headers.getAll(new HeaderName("CookiE")))
-                .containsExactly("this=that", "frizzle=frazzle")
-                .inOrder();
+        assertThat(headers.getAll(new HeaderName("CookiE"))).containsExactly("this=that", "frizzle=frazzle");
     }
 
     @Test
@@ -161,8 +154,8 @@ class HeadersTest {
 
         headers.set("cookIe", "dilly=dally");
 
-        Truth.assertThat(headers.getAll("CookiE")).containsExactly("dilly=dally");
-        Truth.assertThat(headers.size()).isEqualTo(2);
+        assertThat(headers.getAll("CookiE")).containsExactly("dilly=dally");
+        assertThat(headers.size()).isEqualTo(2);
     }
 
     @Test
@@ -174,8 +167,8 @@ class HeadersTest {
 
         headers.set(new HeaderName("cookIe"), "dilly=dally");
 
-        Truth.assertThat(headers.getAll("CookiE")).containsExactly("dilly=dally");
-        Truth.assertThat(headers.size()).isEqualTo(2);
+        assertThat(headers.getAll("CookiE")).containsExactly("dilly=dally");
+        assertThat(headers.size()).isEqualTo(2);
     }
 
     @Test
@@ -187,8 +180,8 @@ class HeadersTest {
 
         headers.set("cookIe", null);
 
-        Truth.assertThat(headers.getAll("CookiE")).isEmpty();
-        Truth.assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.getAll("CookiE")).isEmpty();
+        assertThat(headers.size()).isEqualTo(1);
     }
 
     @Test
@@ -200,8 +193,8 @@ class HeadersTest {
 
         headers.set(new HeaderName("cookIe"), null);
 
-        Truth.assertThat(headers.getAll("CookiE")).isEmpty();
-        Truth.assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.getAll("CookiE")).isEmpty();
+        assertThat(headers.size()).isEqualTo(1);
     }
 
     @Test
@@ -213,8 +206,8 @@ class HeadersTest {
 
         headers.setIfValid("cookIe", null);
 
-        Truth.assertThat(headers.getAll("CookiE")).isEmpty();
-        Truth.assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.getAll("CookiE")).isEmpty();
+        assertThat(headers.size()).isEqualTo(1);
     }
 
     @Test
@@ -226,8 +219,8 @@ class HeadersTest {
 
         headers.setIfValid(new HeaderName("cookIe"), null);
 
-        Truth.assertThat(headers.getAll("CookiE")).isEmpty();
-        Truth.assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.getAll("CookiE")).isEmpty();
+        assertThat(headers.size()).isEqualTo(1);
     }
 
     @Test
@@ -241,10 +234,10 @@ class HeadersTest {
         headers.setIfValid("X-Valid-K2", "abc\r-xy\rz");
         headers.setIfValid("X-Valid-K3", "abc\n-xy\nz");
 
-        Truth.assertThat(headers.getAll("X-Valid-K1")).containsExactly("abc-xyz");
-        Truth.assertThat(headers.getAll("X-Valid-K2")).containsExactly("def-xyz");
-        Truth.assertThat(headers.getAll("X-Valid-K3")).containsExactly("xyz-xyz");
-        Truth.assertThat(headers.size()).isEqualTo(3);
+        assertThat(headers.getAll("X-Valid-K1")).containsExactly("abc-xyz");
+        assertThat(headers.getAll("X-Valid-K2")).containsExactly("def-xyz");
+        assertThat(headers.getAll("X-Valid-K3")).containsExactly("xyz-xyz");
+        assertThat(headers.size()).isEqualTo(3);
     }
 
     @Test
@@ -258,10 +251,10 @@ class HeadersTest {
         headers.setIfValid(new HeaderName("X-Valid-K2"), "abc\r-xy\rz");
         headers.setIfValid(new HeaderName("X-Valid-K3"), "abc\n-xy\nz");
 
-        Truth.assertThat(headers.getAll("X-Valid-K1")).containsExactly("abc-xyz");
-        Truth.assertThat(headers.getAll("X-Valid-K2")).containsExactly("def-xyz");
-        Truth.assertThat(headers.getAll("X-Valid-K3")).containsExactly("xyz-xyz");
-        Truth.assertThat(headers.size()).isEqualTo(3);
+        assertThat(headers.getAll("X-Valid-K1")).containsExactly("abc-xyz");
+        assertThat(headers.getAll("X-Valid-K2")).containsExactly("def-xyz");
+        assertThat(headers.getAll("X-Valid-K3")).containsExactly("xyz-xyz");
+        assertThat(headers.size()).isEqualTo(3);
     }
 
     @Test
@@ -273,11 +266,11 @@ class HeadersTest {
         headers.setIfValid("X-K\ney-2", "def-xyz");
         headers.setIfValid("X-K\rey-3", "xyz-xyz");
 
-        Truth.assertThat(headers.getAll("X-Valid-K1")).containsExactly("abc-xyz");
-        Truth.assertThat(headers.getAll("X-K\r\ney-1")).isEmpty();
-        Truth.assertThat(headers.getAll("X-K\ney-2")).isEmpty();
-        Truth.assertThat(headers.getAll("X-K\rey-3")).isEmpty();
-        Truth.assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.getAll("X-Valid-K1")).containsExactly("abc-xyz");
+        assertThat(headers.getAll("X-K\r\ney-1")).isEmpty();
+        assertThat(headers.getAll("X-K\ney-2")).isEmpty();
+        assertThat(headers.getAll("X-K\rey-3")).isEmpty();
+        assertThat(headers.size()).isEqualTo(1);
     }
 
     @Test
@@ -289,11 +282,11 @@ class HeadersTest {
         headers.setIfValid(new HeaderName("X-K\ney-2"), "def-xyz");
         headers.setIfValid(new HeaderName("X-K\rey-3"), "xyz-xyz");
 
-        Truth.assertThat(headers.getAll("X-Valid-K1")).containsExactly("abc-xyz");
-        Truth.assertThat(headers.getAll("X-K\r\ney-1")).isEmpty();
-        Truth.assertThat(headers.getAll("X-K\ney-2")).isEmpty();
-        Truth.assertThat(headers.getAll("X-K\rey-3")).isEmpty();
-        Truth.assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.getAll("X-Valid-K1")).containsExactly("abc-xyz");
+        assertThat(headers.getAll("X-K\r\ney-1")).isEmpty();
+        assertThat(headers.getAll("X-K\ney-2")).isEmpty();
+        assertThat(headers.getAll("X-K\rey-3")).isEmpty();
+        assertThat(headers.size()).isEqualTo(1);
     }
 
     @Test
@@ -305,9 +298,7 @@ class HeadersTest {
 
         headers.setIfAbsent("cookIe", "dilly=dally");
 
-        Truth.assertThat(headers.getAll("CookiE"))
-                .containsExactly("this=that", "frizzle=frazzle")
-                .inOrder();
+        assertThat(headers.getAll("CookiE")).containsExactly("this=that", "frizzle=frazzle");
     }
 
     @Test
@@ -319,9 +310,7 @@ class HeadersTest {
 
         headers.setIfAbsent(new HeaderName("cookIe"), "dilly=dally");
 
-        Truth.assertThat(headers.getAll("CookiE"))
-                .containsExactly("this=that", "frizzle=frazzle")
-                .inOrder();
+        assertThat(headers.getAll("CookiE")).containsExactly("this=that", "frizzle=frazzle");
     }
 
     @Test
@@ -331,7 +320,7 @@ class HeadersTest {
         headers.add("Cookie", "this=that");
         headers.add("Cookie", "frizzle=frazzle");
 
-        assertThrows(NullPointerException.class, () -> headers.setIfAbsent("cookIe", null));
+        assertThatThrownBy(() -> headers.setIfAbsent("cookIe", null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -341,7 +330,8 @@ class HeadersTest {
         headers.add("Cookie", "this=that");
         headers.add("Cookie", "frizzle=frazzle");
 
-        assertThrows(NullPointerException.class, () -> headers.setIfAbsent(new HeaderName("cookIe"), null));
+        assertThatThrownBy(() -> headers.setIfAbsent(new HeaderName("cookIe"), null))
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -353,7 +343,7 @@ class HeadersTest {
 
         headers.setIfAbsent("X-Netflix-Awesome", "true");
 
-        Truth.assertThat(headers.getAll("X-netflix-Awesome")).containsExactly("true");
+        assertThat(headers.getAll("X-netflix-Awesome")).containsExactly("true");
     }
 
     @Test
@@ -365,7 +355,7 @@ class HeadersTest {
 
         headers.setIfAbsent(new HeaderName("X-Netflix-Awesome"), "true");
 
-        Truth.assertThat(headers.getAll("X-netflix-Awesome")).containsExactly("true");
+        assertThat(headers.getAll("X-netflix-Awesome")).containsExactly("true");
     }
 
     @Test
@@ -378,8 +368,8 @@ class HeadersTest {
         headers.setIfAbsentAndValid("X-Netflix-Awesome", "true");
         headers.setIfAbsentAndValid("X-Netflix-Awesome", "True");
 
-        Truth.assertThat(headers.getAll("X-netflix-Awesome")).containsExactly("true");
-        Truth.assertThat(headers.size()).isEqualTo(4);
+        assertThat(headers.getAll("X-netflix-Awesome")).containsExactly("true");
+        assertThat(headers.size()).isEqualTo(4);
     }
 
     @Test
@@ -391,11 +381,11 @@ class HeadersTest {
         headers.setIfAbsentAndValid("X-Invalid-K2", "abc\rxy\rz");
         headers.setIfAbsentAndValid("X-Invalid-K3", "abc\nxy\nz");
 
-        Truth.assertThat(headers.getAll("Via")).containsExactly("duct");
-        Truth.assertThat(headers.getAll("X-Invalid-K1")).isEmpty();
-        Truth.assertThat(headers.getAll("X-Invalid-K2")).isEmpty();
-        Truth.assertThat(headers.getAll("X-Invalid-K3")).isEmpty();
-        Truth.assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.getAll("Via")).containsExactly("duct");
+        assertThat(headers.getAll("X-Invalid-K1")).isEmpty();
+        assertThat(headers.getAll("X-Invalid-K2")).isEmpty();
+        assertThat(headers.getAll("X-Invalid-K3")).isEmpty();
+        assertThat(headers.size()).isEqualTo(1);
     }
 
     @Test
@@ -407,9 +397,7 @@ class HeadersTest {
 
         headers.add("via", "con Dios");
 
-        Truth.assertThat(headers.getAll("Via"))
-                .containsExactly("duct", "con Dios")
-                .inOrder();
+        assertThat(headers.getAll("Via")).containsExactly("duct", "con Dios");
     }
 
     @Test
@@ -421,9 +409,7 @@ class HeadersTest {
 
         headers.add(new HeaderName("via"), "con Dios");
 
-        Truth.assertThat(headers.getAll("Via"))
-                .containsExactly("duct", "con Dios")
-                .inOrder();
+        assertThat(headers.getAll("Via")).containsExactly("duct", "con Dios");
     }
 
     @Test
@@ -433,11 +419,9 @@ class HeadersTest {
         headers.addIfValid("Cookie", "abc=def");
         headers.addIfValid("cookie", "uvw=xyz");
 
-        Truth.assertThat(headers.getAll("Via")).containsExactly("duct");
-        Truth.assertThat(headers.getAll("Cookie"))
-                .containsExactly("abc=def", "uvw=xyz")
-                .inOrder();
-        Truth.assertThat(headers.size()).isEqualTo(3);
+        assertThat(headers.getAll("Via")).containsExactly("duct");
+        assertThat(headers.getAll("Cookie")).containsExactly("abc=def", "uvw=xyz");
+        assertThat(headers.size()).isEqualTo(3);
     }
 
     @Test
@@ -447,11 +431,9 @@ class HeadersTest {
         headers.addIfValid("Cookie", "abc=def");
         headers.addIfValid(new HeaderName("cookie"), "uvw=xyz");
 
-        Truth.assertThat(headers.getAll("Via")).containsExactly("duct");
-        Truth.assertThat(headers.getAll("Cookie"))
-                .containsExactly("abc=def", "uvw=xyz")
-                .inOrder();
-        Truth.assertThat(headers.size()).isEqualTo(3);
+        assertThat(headers.getAll("Via")).containsExactly("duct");
+        assertThat(headers.getAll("Cookie")).containsExactly("abc=def", "uvw=xyz");
+        assertThat(headers.size()).isEqualTo(3);
     }
 
     @Test
@@ -463,12 +445,12 @@ class HeadersTest {
         headers.addIfValid("X-Invalid-K2", "abc\rxy\rz");
         headers.addIfValid("X-Invalid-K3", "abc\nxy\nz");
 
-        Truth.assertThat(headers.getAll("Via")).containsExactly("duct");
-        Truth.assertThat(headers.getAll("Cookie")).containsExactly("abc=def");
-        Truth.assertThat(headers.getAll("X-Invalid-K1")).isEmpty();
-        Truth.assertThat(headers.getAll("X-Invalid-K2")).isEmpty();
-        Truth.assertThat(headers.getAll("X-Invalid-K3")).isEmpty();
-        Truth.assertThat(headers.size()).isEqualTo(2);
+        assertThat(headers.getAll("Via")).containsExactly("duct");
+        assertThat(headers.getAll("Cookie")).containsExactly("abc=def");
+        assertThat(headers.getAll("X-Invalid-K1")).isEmpty();
+        assertThat(headers.getAll("X-Invalid-K2")).isEmpty();
+        assertThat(headers.getAll("X-Invalid-K3")).isEmpty();
+        assertThat(headers.size()).isEqualTo(2);
     }
 
     @Test
@@ -485,11 +467,9 @@ class HeadersTest {
         headers.putAll(other);
 
         // Only check the order per field, not for the entire set.
-        Truth.assertThat(headers.getAll("Via")).containsExactly("duct", "com").inOrder();
-        Truth.assertThat(headers.getAll("coOkiE"))
-                .containsExactly("this=that", "frizzle=frazzle", "a=b")
-                .inOrder();
-        Truth.assertThat(headers.size()).isEqualTo(5);
+        assertThat(headers.getAll("Via")).containsExactly("duct", "com");
+        assertThat(headers.getAll("coOkiE")).containsExactly("this=that", "frizzle=frazzle", "a=b");
+        assertThat(headers.size()).isEqualTo(5);
     }
 
     @Test
@@ -502,12 +482,10 @@ class HeadersTest {
 
         List<String> removed = headers.remove("Cookie");
 
-        Truth.assertThat(headers.getAll("Cookie")).isEmpty();
-        Truth.assertThat(headers.getAll("Soup")).containsExactly("salad");
-        Truth.assertThat(headers.size()).isEqualTo(2);
-        Truth.assertThat(removed)
-                .containsExactly("this=that", "frizzle=frazzle")
-                .inOrder();
+        assertThat(headers.getAll("Cookie")).isEmpty();
+        assertThat(headers.getAll("Soup")).containsExactly("salad");
+        assertThat(headers.size()).isEqualTo(2);
+        assertThat(removed).containsExactly("this=that", "frizzle=frazzle");
     }
 
     @Test
@@ -520,12 +498,10 @@ class HeadersTest {
 
         List<String> removed = headers.remove(new HeaderName("Cookie"));
 
-        Truth.assertThat(headers.getAll("Cookie")).isEmpty();
-        Truth.assertThat(headers.getAll("Soup")).containsExactly("salad");
-        Truth.assertThat(headers.size()).isEqualTo(2);
-        Truth.assertThat(removed)
-                .containsExactly("this=that", "frizzle=frazzle")
-                .inOrder();
+        assertThat(headers.getAll("Cookie")).isEmpty();
+        assertThat(headers.getAll("Soup")).containsExactly("salad");
+        assertThat(headers.size()).isEqualTo(2);
+        assertThat(removed).containsExactly("this=that", "frizzle=frazzle");
     }
 
     @Test
@@ -538,10 +514,10 @@ class HeadersTest {
 
         List<String> removed = headers.remove("Monkey");
 
-        Truth.assertThat(headers.getAll("Cookie")).isNotEmpty();
-        Truth.assertThat(headers.getAll("Soup")).containsExactly("salad");
-        Truth.assertThat(headers.size()).isEqualTo(4);
-        Truth.assertThat(removed).isEmpty();
+        assertThat(headers.getAll("Cookie")).isNotEmpty();
+        assertThat(headers.getAll("Soup")).containsExactly("salad");
+        assertThat(headers.size()).isEqualTo(4);
+        assertThat(removed).isEmpty();
     }
 
     @Test
@@ -554,10 +530,10 @@ class HeadersTest {
 
         List<String> removed = headers.remove(new HeaderName("Monkey"));
 
-        Truth.assertThat(headers.getAll("Cookie")).isNotEmpty();
-        Truth.assertThat(headers.getAll("Soup")).containsExactly("salad");
-        Truth.assertThat(headers.size()).isEqualTo(4);
-        Truth.assertThat(removed).isEmpty();
+        assertThat(headers.getAll("Cookie")).isNotEmpty();
+        assertThat(headers.getAll("Soup")).containsExactly("salad");
+        assertThat(headers.size()).isEqualTo(4);
+        assertThat(removed).isEmpty();
     }
 
     @Test
@@ -570,9 +546,9 @@ class HeadersTest {
 
         boolean removed = headers.removeIf(entry -> entry.getKey().getName().equals("Cookie"));
 
-        assertTrue(removed);
-        Truth.assertThat(headers.getAll("cOoKie")).containsExactly("frizzle=frazzle");
-        Truth.assertThat(headers.size()).isEqualTo(3);
+        assertThat(removed).isTrue();
+        assertThat(headers.getAll("cOoKie")).containsExactly("frizzle=frazzle");
+        assertThat(headers.size()).isEqualTo(3);
     }
 
     @Test
@@ -585,8 +561,8 @@ class HeadersTest {
 
         Set<HeaderName> keySet = headers.keySet();
 
-        Truth.assertThat(keySet)
-                .containsExactly(new HeaderName("COOKie"), new HeaderName("Soup"), new HeaderName("Via"));
+        assertThat(keySet)
+                .containsExactlyInAnyOrder(new HeaderName("COOKie"), new HeaderName("Soup"), new HeaderName("Via"));
         for (HeaderName headerName : keySet) {
             if (headerName.getName().equals("COOKie")) {
                 return;
@@ -603,20 +579,20 @@ class HeadersTest {
         headers.add("cookIE", "frizzle=frazzle");
         headers.add("Soup", "salad");
 
-        assertTrue(headers.contains("CoOkIe"));
-        assertTrue(headers.contains(new HeaderName("CoOkIe")));
-        assertTrue(headers.contains("cookie"));
-        assertTrue(headers.contains(new HeaderName("cookie")));
-        assertTrue(headers.contains("Cookie"));
-        assertTrue(headers.contains(new HeaderName("Cookie")));
-        assertTrue(headers.contains("COOKIE"));
-        assertTrue(headers.contains(new HeaderName("COOKIE")));
-        assertFalse(headers.contains("Monkey"));
-        assertFalse(headers.contains(new HeaderName("Monkey")));
+        assertThat(headers.contains("CoOkIe")).isTrue();
+        assertThat(headers.contains(new HeaderName("CoOkIe"))).isTrue();
+        assertThat(headers.contains("cookie")).isTrue();
+        assertThat(headers.contains(new HeaderName("cookie"))).isTrue();
+        assertThat(headers.contains("Cookie")).isTrue();
+        assertThat(headers.contains(new HeaderName("Cookie"))).isTrue();
+        assertThat(headers.contains("COOKIE")).isTrue();
+        assertThat(headers.contains(new HeaderName("COOKIE"))).isTrue();
+        assertThat(headers.contains("Monkey")).isFalse();
+        assertThat(headers.contains(new HeaderName("Monkey"))).isFalse();
 
         headers.remove("cookie");
-        assertFalse(headers.contains("cookie"));
-        assertFalse(headers.contains(new HeaderName("cookie")));
+        assertThat(headers.contains("cookie")).isFalse();
+        assertThat(headers.contains(new HeaderName("cookie"))).isFalse();
     }
 
     @Test
@@ -628,10 +604,11 @@ class HeadersTest {
         headers.add("Soup", "salad");
 
         // note the swapping of the two cookie casings.
-        assertTrue(headers.contains("CoOkIe", "frizzle=frazzle"));
-        assertTrue(headers.contains(new HeaderName("CoOkIe"), "frizzle=frazzle"));
-        assertFalse(headers.contains("Via", "lin"));
-        assertFalse(headers.contains(new HeaderName("Soup"), "of the day"));
+        assertThat(headers.contains("CoOkIe", "frizzle=frazzle")).isTrue();
+        assertThat(headers.contains(new HeaderName("CoOkIe"), "frizzle=frazzle"))
+                .isTrue();
+        assertThat(headers.contains("Via", "lin")).isFalse();
+        assertThat(headers.contains(new HeaderName("Soup"), "of the day")).isFalse();
     }
 
     @Test
@@ -640,9 +617,9 @@ class HeadersTest {
         headers.set("Content-Length", "5");
         headers.set("content-length", "10");
 
-        assertEquals("10", headers.getFirst("Content-Length"));
-        assertEquals("10", headers.getFirst("content-length"));
-        assertEquals(1, headers.getAll("content-length").size());
+        assertThat(headers.getFirst("Content-Length")).isEqualTo("10");
+        assertThat(headers.getFirst("content-length")).isEqualTo("10");
+        assertThat(headers.getAll("content-length").size()).isEqualTo(1);
     }
 
     @Test
@@ -652,9 +629,9 @@ class HeadersTest {
         headers.add("content-length", "10");
 
         List<String> values = headers.getAll("content-length");
-        assertTrue(values.contains("10"));
-        assertTrue(values.contains("5"));
-        assertEquals(2, values.size());
+        assertThat(values.contains("10")).isTrue();
+        assertThat(values.contains("5")).isTrue();
+        assertThat(values.size()).isEqualTo(2);
     }
 
     @Test
@@ -664,8 +641,8 @@ class HeadersTest {
         headers.setIfAbsent("content-length", "10");
 
         List<String> values = headers.getAll("content-length");
-        assertEquals(1, values.size());
-        assertEquals("5", values.get(0));
+        assertThat(values.size()).isEqualTo(1);
+        assertThat(values.get(0)).isEqualTo("5");
     }
 
     @Test
@@ -678,25 +655,29 @@ class HeadersTest {
         headers2.putAll(headers);
 
         List<String> values = headers2.getAll("content-length");
-        assertTrue(values.contains("10"));
-        assertTrue(values.contains("5"));
-        assertEquals(2, values.size());
+        assertThat(values.contains("10")).isTrue();
+        assertThat(values.contains("5")).isTrue();
+        assertThat(values.size()).isEqualTo(2);
     }
 
     @Test
     void testSanitizeValues_CRLF() {
         Headers headers = new Headers();
 
-        assertThrows(ZuulException.class, () -> headers.addAndValidate("x-test-break1", "a\r\nb\r\nc"));
-        assertThrows(ZuulException.class, () -> headers.setAndValidate("x-test-break1", "a\r\nb\r\nc"));
+        assertThatThrownBy(() -> headers.addAndValidate("x-test-break1", "a\r\nb\r\nc"))
+                .isInstanceOf(ZuulException.class);
+        assertThatThrownBy(() -> headers.setAndValidate("x-test-break1", "a\r\nb\r\nc"))
+                .isInstanceOf(ZuulException.class);
     }
 
     @Test
     void testSanitizeValues_LF() {
         Headers headers = new Headers();
 
-        assertThrows(ZuulException.class, () -> headers.addAndValidate("x-test-break1", "a\nb\nc"));
-        assertThrows(ZuulException.class, () -> headers.setAndValidate("x-test-break1", "a\nb\nc"));
+        assertThatThrownBy(() -> headers.addAndValidate("x-test-break1", "a\nb\nc"))
+                .isInstanceOf(ZuulException.class);
+        assertThatThrownBy(() -> headers.setAndValidate("x-test-break1", "a\nb\nc"))
+                .isInstanceOf(ZuulException.class);
     }
 
     @Test
@@ -704,12 +685,12 @@ class HeadersTest {
         Headers headers = new Headers();
 
         headers.addAndValidate("x-test-ISO-8859-1", "P Venkmän");
-        Truth.assertThat(headers.getAll("x-test-ISO-8859-1")).containsExactly("P Venkmän");
-        Truth.assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.getAll("x-test-ISO-8859-1")).containsExactly("P Venkmän");
+        assertThat(headers.size()).isEqualTo(1);
 
         headers.setAndValidate("x-test-ISO-8859-1", "Venkmän");
-        Truth.assertThat(headers.getAll("x-test-ISO-8859-1")).containsExactly("Venkmän");
-        Truth.assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.getAll("x-test-ISO-8859-1")).containsExactly("Venkmän");
+        assertThat(headers.size()).isEqualTo(1);
     }
 
     @Test
@@ -721,30 +702,34 @@ class HeadersTest {
         byte[] bytes = rawHeaderValue.getBytes(StandardCharsets.UTF_8);
         String utf8HeaderValue = new String(bytes, StandardCharsets.UTF_8);
         headers.addAndValidate("x-test-UTF8", utf8HeaderValue);
-        Truth.assertThat(headers.getAll("x-test-UTF8")).containsExactly(utf8HeaderValue);
-        Truth.assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.getAll("x-test-UTF8")).containsExactly(utf8HeaderValue);
+        assertThat(headers.size()).isEqualTo(1);
 
         rawHeaderValue = "\u017d" + "\u0172" + "uuu" + "\u016e" + "\u013F"; // ŽŲuuuŮĽ
         bytes = rawHeaderValue.getBytes(StandardCharsets.UTF_8);
         utf8HeaderValue = new String(bytes, StandardCharsets.UTF_8);
         headers.setAndValidate("x-test-UTF8", utf8HeaderValue);
-        Truth.assertThat(headers.getAll("x-test-UTF8")).containsExactly(utf8HeaderValue);
-        Truth.assertThat(headers.size()).isEqualTo(1);
+        assertThat(headers.getAll("x-test-UTF8")).containsExactly(utf8HeaderValue);
+        assertThat(headers.size()).isEqualTo(1);
     }
 
     @Test
     void testSanitizeValues_addSetHeaderName() {
         Headers headers = new Headers();
 
-        assertThrows(ZuulException.class, () -> headers.setAndValidate(new HeaderName("x-test-break1"), "a\nb\nc"));
-        assertThrows(ZuulException.class, () -> headers.addAndValidate(new HeaderName("x-test-break2"), "a\r\nb\r\nc"));
+        assertThatThrownBy(() -> headers.setAndValidate(new HeaderName("x-test-break1"), "a\nb\nc"))
+                .isInstanceOf(ZuulException.class);
+        assertThatThrownBy(() -> headers.addAndValidate(new HeaderName("x-test-break2"), "a\r\nb\r\nc"))
+                .isInstanceOf(ZuulException.class);
     }
 
     @Test
     void testSanitizeValues_nameCRLF() {
         Headers headers = new Headers();
 
-        assertThrows(ZuulException.class, () -> headers.addAndValidate("x-test-br\r\neak1", "a\r\nb\r\nc"));
-        assertThrows(ZuulException.class, () -> headers.setAndValidate("x-test-br\r\neak2", "a\r\nb\r\nc"));
+        assertThatThrownBy(() -> headers.addAndValidate("x-test-br\r\neak1", "a\r\nb\r\nc"))
+                .isInstanceOf(ZuulException.class);
+        assertThatThrownBy(() -> headers.setAndValidate("x-test-br\r\neak2", "a\r\nb\r\nc"))
+                .isInstanceOf(ZuulException.class);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/ZuulMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/ZuulMessageImplTest.java
@@ -17,10 +17,7 @@
 package com.netflix.zuul.message;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.zuul.context.SessionContext;
 import io.netty.buffer.Unpooled;
@@ -47,16 +44,16 @@ class ZuulMessageImplTest {
         ZuulMessage msg1 = new ZuulMessageImpl(ctx1, headers1);
         ZuulMessage msg2 = msg1.clone();
 
-        assertEquals(msg1.getBodyAsText(), msg2.getBodyAsText());
-        assertEquals(msg1.getHeaders(), msg2.getHeaders());
-        assertEquals(msg1.getContext(), msg2.getContext());
+        assertThat(msg2.getBodyAsText()).isEqualTo(msg1.getBodyAsText());
+        assertThat(msg2.getHeaders()).isEqualTo(msg1.getHeaders());
+        assertThat(msg2.getContext()).isEqualTo(msg1.getContext());
 
         // Verify that values of the 2 messages are decoupled.
         msg1.getHeaders().set("k1", "v_new");
         msg1.getContext().set("k1", "v_new");
 
-        assertEquals("v1", msg2.getHeaders().getFirst("k1"));
-        assertEquals("v1", msg2.getContext().get("k1"));
+        assertThat(msg2.getHeaders().getFirst("k1")).isEqualTo("v1");
+        assertThat(msg2.getContext().get("k1")).isEqualTo("v1");
     }
 
     @Test
@@ -65,10 +62,10 @@ class ZuulMessageImplTest {
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("Hello ".getBytes(UTF_8))));
         msg.bufferBodyContents(new DefaultLastHttpContent(Unpooled.copiedBuffer("World!".getBytes(UTF_8))));
         String body = new String(msg.getBody(), UTF_8);
-        assertTrue(msg.hasBody());
-        assertTrue(msg.hasCompleteBody());
-        assertEquals(TEXT1, body);
-        assertEquals(0, msg.getHeaders().getAll("Content-Length").size());
+        assertThat(msg.hasBody()).isTrue();
+        assertThat(msg.hasCompleteBody()).isTrue();
+        assertThat(body).isEqualTo(TEXT1);
+        assertThat(msg.getHeaders().getAll("Content-Length").size()).isEqualTo(0);
     }
 
     @Test
@@ -78,10 +75,10 @@ class ZuulMessageImplTest {
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("World!".getBytes(UTF_8))));
         msg.bufferBodyContents(new DefaultLastHttpContent());
         String body = new String(msg.getBody(), UTF_8);
-        assertTrue(msg.hasBody());
-        assertTrue(msg.hasCompleteBody());
-        assertEquals(TEXT1, body);
-        assertEquals(0, msg.getHeaders().getAll("Content-Length").size());
+        assertThat(msg.hasBody()).isTrue();
+        assertThat(msg.hasCompleteBody()).isTrue();
+        assertThat(body).isEqualTo(TEXT1);
+        assertThat(msg.getHeaders().getAll("Content-Length").size()).isEqualTo(0);
     }
 
     @Test
@@ -91,10 +88,10 @@ class ZuulMessageImplTest {
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("World!".getBytes(UTF_8))));
         msg.bufferBodyContents(new DefaultLastHttpContent());
         String body = msg.getBodyAsText();
-        assertTrue(msg.hasBody());
-        assertTrue(msg.hasCompleteBody());
-        assertEquals(TEXT1, body);
-        assertEquals(0, msg.getHeaders().getAll("Content-Length").size());
+        assertThat(msg.hasBody()).isTrue();
+        assertThat(msg.hasCompleteBody()).isTrue();
+        assertThat(body).isEqualTo(TEXT1);
+        assertThat(msg.getHeaders().getAll("Content-Length").size()).isEqualTo(0);
     }
 
     @Test
@@ -102,9 +99,9 @@ class ZuulMessageImplTest {
         ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.setBody(TEXT1.getBytes(UTF_8));
         String body = new String(msg.getBody(), UTF_8);
-        assertEquals(TEXT1, body);
-        assertEquals(1, msg.getHeaders().getAll("Content-Length").size());
-        assertEquals(String.valueOf(TEXT1.length()), msg.getHeaders().getFirst("Content-Length"));
+        assertThat(body).isEqualTo(TEXT1);
+        assertThat(msg.getHeaders().getAll("Content-Length").size()).isEqualTo(1);
+        assertThat(msg.getHeaders().getFirst("Content-Length")).isEqualTo(String.valueOf(TEXT1.length()));
     }
 
     @Test
@@ -112,11 +109,11 @@ class ZuulMessageImplTest {
         ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.setBodyAsText(TEXT1);
         String body = new String(msg.getBody(), UTF_8);
-        assertTrue(msg.hasBody());
-        assertTrue(msg.hasCompleteBody());
-        assertEquals(TEXT1, body);
-        assertEquals(1, msg.getHeaders().getAll("Content-Length").size());
-        assertEquals(String.valueOf(TEXT1.length()), msg.getHeaders().getFirst("Content-Length"));
+        assertThat(msg.hasBody()).isTrue();
+        assertThat(msg.hasCompleteBody()).isTrue();
+        assertThat(body).isEqualTo(TEXT1);
+        assertThat(msg.getHeaders().getAll("Content-Length").size()).isEqualTo(1);
+        assertThat(msg.getHeaders().getFirst("Content-Length")).isEqualTo(String.valueOf(TEXT1.length()));
     }
 
     @Test
@@ -124,11 +121,11 @@ class ZuulMessageImplTest {
         ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.setBodyAsText(TEXT1);
         String body = msg.getBodyAsText();
-        assertTrue(msg.hasBody());
-        assertTrue(msg.hasCompleteBody());
-        assertEquals(TEXT1, body);
-        assertEquals(1, msg.getHeaders().getAll("Content-Length").size());
-        assertEquals(String.valueOf(TEXT1.length()), msg.getHeaders().getFirst("Content-Length"));
+        assertThat(msg.hasBody()).isTrue();
+        assertThat(msg.hasCompleteBody()).isTrue();
+        assertThat(body).isEqualTo(TEXT1);
+        assertThat(msg.getHeaders().getAll("Content-Length").size()).isEqualTo(1);
+        assertThat(msg.getHeaders().getFirst("Content-Length")).isEqualTo(String.valueOf(TEXT1.length()));
     }
 
     @Test
@@ -136,19 +133,19 @@ class ZuulMessageImplTest {
         ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.setBodyAsText(TEXT1);
         String body = new String(msg.getBody(), UTF_8);
-        assertTrue(msg.hasBody());
-        assertTrue(msg.hasCompleteBody());
-        assertEquals(TEXT1, body);
-        assertEquals(1, msg.getHeaders().getAll("Content-Length").size());
-        assertEquals(String.valueOf(TEXT1.length()), msg.getHeaders().getFirst("Content-Length"));
+        assertThat(msg.hasBody()).isTrue();
+        assertThat(msg.hasCompleteBody()).isTrue();
+        assertThat(body).isEqualTo(TEXT1);
+        assertThat(msg.getHeaders().getAll("Content-Length").size()).isEqualTo(1);
+        assertThat(msg.getHeaders().getFirst("Content-Length")).isEqualTo(String.valueOf(TEXT1.length()));
 
         msg.setBodyAsText(TEXT2);
         body = new String(msg.getBody(), UTF_8);
-        assertTrue(msg.hasBody());
-        assertTrue(msg.hasCompleteBody());
-        assertEquals(TEXT2, body);
-        assertEquals(1, msg.getHeaders().getAll("Content-Length").size());
-        assertEquals(String.valueOf(TEXT2.length()), msg.getHeaders().getFirst("Content-Length"));
+        assertThat(msg.hasBody()).isTrue();
+        assertThat(msg.hasCompleteBody()).isTrue();
+        assertThat(body).isEqualTo(TEXT2);
+        assertThat(msg.getHeaders().getAll("Content-Length").size()).isEqualTo(1);
+        assertThat(msg.getHeaders().getFirst("Content-Length")).isEqualTo(String.valueOf(TEXT2.length()));
     }
 
     @Test
@@ -156,19 +153,19 @@ class ZuulMessageImplTest {
         ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
         msg.setBody(TEXT1.getBytes(UTF_8));
         String body = new String(msg.getBody(), UTF_8);
-        assertTrue(msg.hasBody());
-        assertTrue(msg.hasCompleteBody());
-        assertEquals(TEXT1, body);
-        assertEquals(1, msg.getHeaders().getAll("Content-Length").size());
-        assertEquals(String.valueOf(TEXT1.length()), msg.getHeaders().getFirst("Content-Length"));
+        assertThat(msg.hasBody()).isTrue();
+        assertThat(msg.hasCompleteBody()).isTrue();
+        assertThat(body).isEqualTo(TEXT1);
+        assertThat(msg.getHeaders().getAll("Content-Length").size()).isEqualTo(1);
+        assertThat(msg.getHeaders().getFirst("Content-Length")).isEqualTo(String.valueOf(TEXT1.length()));
 
         msg.setBody(TEXT2.getBytes(UTF_8));
         body = new String(msg.getBody(), UTF_8);
-        assertTrue(msg.hasBody());
-        assertTrue(msg.hasCompleteBody());
-        assertEquals(TEXT2, body);
-        assertEquals(1, msg.getHeaders().getAll("Content-Length").size());
-        assertEquals(String.valueOf(TEXT2.length()), msg.getHeaders().getFirst("Content-Length"));
+        assertThat(msg.hasBody()).isTrue();
+        assertThat(msg.hasCompleteBody()).isTrue();
+        assertThat(body).isEqualTo(TEXT2);
+        assertThat(msg.getHeaders().getAll("Content-Length").size()).isEqualTo(1);
+        assertThat(msg.getHeaders().getFirst("Content-Length")).isEqualTo(String.valueOf(TEXT2.length()));
     }
 
     @Test
@@ -183,15 +180,15 @@ class ZuulMessageImplTest {
         }
 
         for (HttpContent c : msg.getBodyContents()) {
-            assertFalse(c.content().isReadable());
-            assertEquals(0, c.content().readableBytes());
+            assertThat(c.content().isReadable()).isFalse();
+            assertThat(c.content().readableBytes()).isEqualTo(0);
         }
 
         msg.resetBodyReader();
 
         for (HttpContent c : msg.getBodyContents()) {
-            assertTrue(c.content().isReadable());
-            assertTrue(c.content().readableBytes() > 0);
+            assertThat(c.content().isReadable()).isTrue();
+            assertThat(c.content().readableBytes() > 0).isTrue();
         }
     }
 
@@ -207,24 +204,24 @@ class ZuulMessageImplTest {
         }
 
         // ensure body returns entire chunk content irregardless of reader index movement above
-        assertEquals(12, msg.getBodyLength());
-        assertEquals(TEXT1, new String(msg.getBody(), StandardCharsets.UTF_8));
+        assertThat(msg.getBodyLength()).isEqualTo(12);
+        assertThat(new String(msg.getBody(), StandardCharsets.UTF_8)).isEqualTo(TEXT1);
 
         // buffer more content and ensure body returns entire chunk content
         msg.bufferBodyContents(new DefaultLastHttpContent(Unpooled.copiedBuffer(" Bye".getBytes(UTF_8))));
 
-        assertEquals(16, msg.getBodyLength());
-        assertEquals("Hello World! Bye", new String(msg.getBody(), StandardCharsets.UTF_8));
+        assertThat(msg.getBodyLength()).isEqualTo(16);
+        assertThat(new String(msg.getBody(), StandardCharsets.UTF_8)).isEqualTo("Hello World! Bye");
     }
 
     @Test
     void testFetchingEmptyBody() {
         ZuulMessage msg = new ZuulMessageImpl(new SessionContext(), new Headers());
-        assertEquals(0, msg.getBodyLength());
-        assertNull(msg.getBody());
+        assertThat(msg.getBodyLength()).isEqualTo(0);
+        assertThat(msg.getBody()).isNull();
 
         msg.bufferBodyContents(new DefaultHttpContent(Unpooled.copiedBuffer("".getBytes(UTF_8))));
-        assertEquals(0, msg.getBodyLength());
-        assertEquals(0, msg.getBody().length);
+        assertThat(msg.getBodyLength()).isEqualTo(0);
+        assertThat(msg.getBody().length).isEqualTo(0);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpQueryParamsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpQueryParamsTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.message.http;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Locale;
@@ -37,7 +36,7 @@ class HttpQueryParamsTest {
         qp.add("k1", "v2");
         qp.add("k2", "v3");
 
-        assertEquals("k1=v1&k1=v2&k2=v3", qp.toEncodedString());
+        assertThat(qp.toEncodedString()).isEqualTo("k1=v1&k1=v2&k2=v3");
     }
 
     @Test
@@ -47,30 +46,30 @@ class HttpQueryParamsTest {
         qp.add("k1", "v1");
         qp.add("k1", "v1");
 
-        assertEquals("k1=v1&k1=v1&k1=v1", qp.toEncodedString());
-        assertEquals(List.of("v1", "v1", "v1"), qp.get("k1"));
+        assertThat(qp.toEncodedString()).isEqualTo("k1=v1&k1=v1&k1=v1");
+        assertThat(qp.get("k1")).isEqualTo(List.of("v1", "v1", "v1"));
     }
 
     @Test
     void testToEncodedString() {
         HttpQueryParams qp = new HttpQueryParams();
         qp.add("k'1", "v1&");
-        assertEquals("k%271=v1%26", qp.toEncodedString());
+        assertThat(qp.toEncodedString()).isEqualTo("k%271=v1%26");
 
         qp = new HttpQueryParams();
         qp.add("k+", "\n");
-        assertEquals("k%2B=%0A", qp.toEncodedString());
+        assertThat(qp.toEncodedString()).isEqualTo("k%2B=%0A");
     }
 
     @Test
     void testToString() {
         HttpQueryParams qp = new HttpQueryParams();
         qp.add("k'1", "v1&");
-        assertEquals("k'1=v1&", qp.toString());
+        assertThat(qp.toString()).isEqualTo("k'1=v1&");
 
         qp = new HttpQueryParams();
         qp.add("k+", "\n");
-        assertEquals("k+=\n", qp.toString());
+        assertThat(qp.toString()).isEqualTo("k+=\n");
     }
 
     @Test
@@ -82,7 +81,7 @@ class HttpQueryParamsTest {
         qp2.add("k1", "v1");
         qp2.add("k2", "v2");
 
-        assertEquals(qp1, qp2);
+        assertThat(qp2).isEqualTo(qp1);
     }
 
     @Test
@@ -94,9 +93,9 @@ class HttpQueryParamsTest {
 
         HttpQueryParams actual = HttpQueryParams.parse("k1=&k2=v2&k3=");
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
-        assertEquals("k1=&k2=v2&k3=", actual.toEncodedString());
+        assertThat(actual.toEncodedString()).isEqualTo("k1=&k2=v2&k3=");
     }
 
     @Test
@@ -106,9 +105,9 @@ class HttpQueryParamsTest {
 
         HttpQueryParams actual = HttpQueryParams.parse("k1=");
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
-        assertEquals("k1=", actual.toEncodedString());
+        assertThat(actual.toEncodedString()).isEqualTo("k1=");
     }
 
     @Test
@@ -118,9 +117,9 @@ class HttpQueryParamsTest {
 
         HttpQueryParams actual = HttpQueryParams.parse("k1");
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
-        assertEquals("k1", actual.toEncodedString());
+        assertThat(actual.toEncodedString()).isEqualTo("k1");
     }
 
     @Test
@@ -130,9 +129,9 @@ class HttpQueryParamsTest {
 
         HttpQueryParams actual = HttpQueryParams.parse("=");
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
-        assertEquals("%3D", actual.toEncodedString());
+        assertThat(actual.toEncodedString()).isEqualTo("%3D");
     }
 
     @Test
@@ -145,9 +144,9 @@ class HttpQueryParamsTest {
 
         HttpQueryParams actual = HttpQueryParams.parse("k1=&k2=v2&k3&k4=v4");
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
 
-        assertEquals("k1=&k2=v2&k3&k4=v4", actual.toEncodedString());
+        assertThat(actual.toEncodedString()).isEqualTo("k1=&k2=v2&k3&k4=v4");
     }
 
     @Test
@@ -157,7 +156,7 @@ class HttpQueryParamsTest {
         queryParams.add("foo", "bar");
         queryParams.add(camelCaseKey.toLowerCase(Locale.ROOT), "value");
 
-        assertTrue(queryParams.containsIgnoreCase(camelCaseKey));
+        assertThat(queryParams.containsIgnoreCase(camelCaseKey)).isTrue();
     }
 
     @Test
@@ -165,8 +164,8 @@ class HttpQueryParamsTest {
         String queryString =
                 IntStream.range(0, 100).mapToObj(i -> "k%d=v%d".formatted(i, i)).collect(Collectors.joining("&"));
         HttpQueryParams queryParams = HttpQueryParams.parse(queryString);
-        assertEquals(queryString, queryParams.toEncodedString());
-        assertEquals(queryString, queryParams.toString());
-        assertEquals(queryString, queryParams.immutableCopy().toString());
+        assertThat(queryParams.toEncodedString()).isEqualTo(queryString);
+        assertThat(queryParams.toString()).isEqualTo(queryString);
+        assertThat(queryParams.immutableCopy().toString()).isEqualTo(queryString);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpRequestMessageImplTest.java
@@ -16,9 +16,8 @@
 
 package com.netflix.zuul.message.http;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -78,24 +77,22 @@ class HttpRequestMessageImplTest {
         request.storeInboundRequest();
         HttpRequestInfo originalRequest = request.getInboundRequest();
 
-        assertEquals(request.getPort(), originalRequest.getPort());
-        assertEquals(request.getPath(), originalRequest.getPath());
-        assertEquals(
-                request.getQueryParams().getFirst("flag"),
-                originalRequest.getQueryParams().getFirst("flag"));
-        assertEquals(
-                request.getHeaders().getFirst("Host"),
-                originalRequest.getHeaders().getFirst("Host"));
+        assertThat(originalRequest.getPort()).isEqualTo(request.getPort());
+        assertThat(originalRequest.getPath()).isEqualTo(request.getPath());
+        assertThat(originalRequest.getQueryParams().getFirst("flag"))
+                .isEqualTo(request.getQueryParams().getFirst("flag"));
+        assertThat(originalRequest.getHeaders().getFirst("Host"))
+                .isEqualTo(request.getHeaders().getFirst("Host"));
 
         request.setPort(8080);
         request.setPath("/another/place");
         request.getQueryParams().set("flag", "20");
         request.getHeaders().set("Host", "wah.netflix.com");
 
-        assertEquals(7002, originalRequest.getPort());
-        assertEquals("/some/where", originalRequest.getPath());
-        assertEquals("5", originalRequest.getQueryParams().getFirst("flag"));
-        assertEquals("blah.netflix.com", originalRequest.getHeaders().getFirst("Host"));
+        assertThat(originalRequest.getPort()).isEqualTo(7002);
+        assertThat(originalRequest.getPath()).isEqualTo("/some/where");
+        assertThat(originalRequest.getQueryParams().getFirst("flag")).isEqualTo("5");
+        assertThat(originalRequest.getHeaders().getFirst("Host")).isEqualTo("blah.netflix.com");
     }
 
     @Test
@@ -115,7 +112,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("https://blah.netflix.com:7002/some/where?flag=5", request.reconstructURI());
+        assertThat(request.reconstructURI()).isEqualTo("https://blah.netflix.com:7002/some/where?flag=5");
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -132,7 +129,7 @@ class HttpRequestMessageImplTest {
                 "http",
                 7002,
                 "localhost");
-        assertEquals("http://place.netflix.com/some/where", request.reconstructURI());
+        assertThat(request.reconstructURI()).isEqualTo("http://place.netflix.com/some/where");
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -150,7 +147,7 @@ class HttpRequestMessageImplTest {
                 "http",
                 7002,
                 "localhost");
-        assertEquals("https://place.netflix.com/some/where", request.reconstructURI());
+        assertThat(request.reconstructURI()).isEqualTo("https://place.netflix.com/some/where");
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -165,7 +162,7 @@ class HttpRequestMessageImplTest {
                 "http",
                 7002,
                 "localhost");
-        assertEquals("http://localhost:7002/some/where", request.reconstructURI());
+        assertThat(request.reconstructURI()).isEqualTo("http://localhost:7002/some/where");
 
         queryParams = new HttpQueryParams();
         queryParams.add("flag", "5");
@@ -182,7 +179,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("https://localhost:7002/some%20where?flag=5&flag+B=9", request.reconstructURI());
+        assertThat(request.reconstructURI()).isEqualTo("https://localhost:7002/some%20where?flag=5&flag+B=9");
     }
 
     @Test
@@ -206,8 +203,8 @@ class HttpRequestMessageImplTest {
                 true);
 
         // Check it's the same value 2nd time.
-        assertEquals("https://blah.netflix.com:7002/some/where?flag=5", request.reconstructURI());
-        assertEquals("https://blah.netflix.com:7002/some/where?flag=5", request.reconstructURI());
+        assertThat(request.reconstructURI()).isEqualTo("https://blah.netflix.com:7002/some/where?flag=5");
+        assertThat(request.reconstructURI()).isEqualTo("https://blah.netflix.com:7002/some/where?flag=5");
 
         // Check that cached on 1st usage.
         request = new HttpRequestMessageImpl(
@@ -226,15 +223,15 @@ class HttpRequestMessageImplTest {
         request = spy(request);
         when(request._reconstructURI()).thenReturn("http://testhost/blah");
         verify(request, times(1))._reconstructURI();
-        assertEquals("http://testhost/blah", request.reconstructURI());
-        assertEquals("http://testhost/blah", request.reconstructURI());
+        assertThat(request.reconstructURI()).isEqualTo("http://testhost/blah");
+        assertThat(request.reconstructURI()).isEqualTo("http://testhost/blah");
 
         // Check that throws exception if we try to mutate it.
         try {
             request.setPath("/new-path");
             fail();
         } catch (IllegalStateException e) {
-            assertTrue(true);
+            assertThat(true).isTrue();
         }
     }
 
@@ -255,11 +252,11 @@ class HttpRequestMessageImplTest {
                 "localhost");
 
         // Check that value changes.
-        assertEquals("/some/where?flag=5", request.getPathAndQuery());
+        assertThat(request.getPathAndQuery()).isEqualTo("/some/where?flag=5");
         request.getQueryParams().add("k", "v");
-        assertEquals("/some/where?flag=5&k=v", request.getPathAndQuery());
+        assertThat(request.getPathAndQuery()).isEqualTo("/some/where?flag=5&k=v");
         request.setPath("/other");
-        assertEquals("/other?flag=5&k=v", request.getPathAndQuery());
+        assertThat(request.getPathAndQuery()).isEqualTo("/other?flag=5&k=v");
     }
 
     @Test
@@ -281,8 +278,8 @@ class HttpRequestMessageImplTest {
                 true);
 
         // Check it's the same value 2nd time.
-        assertEquals("/some/where?flag=5", request.getPathAndQuery());
-        assertEquals("/some/where?flag=5", request.getPathAndQuery());
+        assertThat(request.getPathAndQuery()).isEqualTo("/some/where?flag=5");
+        assertThat(request.getPathAndQuery()).isEqualTo("/some/where?flag=5");
 
         // Check that cached on 1st usage.
         request = new HttpRequestMessageImpl(
@@ -301,8 +298,8 @@ class HttpRequestMessageImplTest {
         request = spy(request);
         when(request.generatePathAndQuery()).thenReturn("/blah");
         verify(request, times(1)).generatePathAndQuery();
-        assertEquals("/blah", request.getPathAndQuery());
-        assertEquals("/blah", request.getPathAndQuery());
+        assertThat(request.getPathAndQuery()).isEqualTo("/blah");
+        assertThat(request.getPathAndQuery()).isEqualTo("/blah");
     }
 
     @Test
@@ -325,12 +322,12 @@ class HttpRequestMessageImplTest {
                 true);
 
         // Check it's the same value 2nd time.
-        assertEquals("blah.netflix.com", request.getOriginalHost());
-        assertEquals("blah.netflix.com", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("blah.netflix.com");
+        assertThat(request.getOriginalHost()).isEqualTo("blah.netflix.com");
 
         // Update the Host header value and ensure the result didn't change.
         headers.set("Host", "testOriginalHost2");
-        assertEquals("blah.netflix.com", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("blah.netflix.com");
     }
 
     @Test
@@ -349,7 +346,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("blah.netflix.com", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("blah.netflix.com");
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -365,7 +362,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("0.0.0.1", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("0.0.0.1");
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -381,7 +378,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("0.0.0.1", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("0.0.0.1");
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -397,7 +394,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("[::2]", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("[::2]");
 
         queryParams = new HttpQueryParams();
         headers = new Headers();
@@ -413,7 +410,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("[::2]", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("[::2]");
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com");
@@ -429,7 +426,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("foo.netflix.com", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("foo.netflix.com");
 
         headers = new Headers();
         headers.add("X-Forwarded-Host", "foo.netflix.com");
@@ -444,7 +441,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("foo.netflix.com", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("foo.netflix.com");
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com:8080");
@@ -459,7 +456,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("blah.netflix.com", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("blah.netflix.com");
     }
 
     @Test
@@ -480,7 +477,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("my_underscore_endpoint.netflix.com", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("my_underscore_endpoint.netflix.com");
 
         headers = new Headers();
         headers.add("Host", "my_underscore_endpoint.netflix.com:8080");
@@ -495,7 +492,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("my_underscore_endpoint.netflix.com", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("my_underscore_endpoint.netflix.com");
 
         headers = new Headers();
         headers.add("Host", "my_underscore_endpoint^including~more-chars.netflix.com");
@@ -510,7 +507,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("my_underscore_endpoint^including~more-chars.netflix.com", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("my_underscore_endpoint^including~more-chars.netflix.com");
 
         headers = new Headers();
         headers.add("Host", "hostname%5Ewith-url-encoded.netflix.com");
@@ -525,7 +522,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals("hostname%5Ewith-url-encoded.netflix.com", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("hostname%5Ewith-url-encoded.netflix.com");
     }
 
     @Test
@@ -545,7 +542,8 @@ class HttpRequestMessageImplTest {
                 7002,
                 "localhost");
 
-        assertThrows(URISyntaxException.class, () -> HttpRequestMessageImpl.getOriginalHost(headers, "server"));
+        assertThatThrownBy(() -> HttpRequestMessageImpl.getOriginalHost(headers, "server"))
+                .isInstanceOf(URISyntaxException.class);
     }
 
     @Test
@@ -567,7 +565,7 @@ class HttpRequestMessageImplTest {
                 7002,
                 "server");
 
-        assertEquals("server", request.getOriginalHost());
+        assertThat(request.getOriginalHost()).isEqualTo("server");
     }
 
     @Test
@@ -585,7 +583,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(7002, request.getOriginalPort());
+        assertThat(request.getOriginalPort()).isEqualTo(7002);
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com");
@@ -601,7 +599,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(443, request.getOriginalPort());
+        assertThat(request.getOriginalPort()).isEqualTo(443);
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com:443");
@@ -616,7 +614,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(443, request.getOriginalPort());
+        assertThat(request.getOriginalPort()).isEqualTo(443);
 
         headers = new Headers();
         headers.add("Host", "127.0.0.2:443");
@@ -631,7 +629,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(443, request.getOriginalPort());
+        assertThat(request.getOriginalPort()).isEqualTo(443);
 
         headers = new Headers();
         headers.add("Host", "127.0.0.2");
@@ -646,7 +644,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(7002, request.getOriginalPort());
+        assertThat(request.getOriginalPort()).isEqualTo(7002);
 
         headers = new Headers();
         headers.add("Host", "[::2]:443");
@@ -661,7 +659,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(443, request.getOriginalPort());
+        assertThat(request.getOriginalPort()).isEqualTo(443);
 
         headers = new Headers();
         headers.add("Host", "[::2]");
@@ -676,7 +674,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(7002, request.getOriginalPort());
+        assertThat(request.getOriginalPort()).isEqualTo(7002);
 
         headers = new Headers();
         headers.add("Host", "blah.netflix.com:443");
@@ -692,7 +690,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(7005, request.getOriginalPort());
+        assertThat(request.getOriginalPort()).isEqualTo(7005);
 
         headers = new Headers();
         headers.add("Host", "host_with_underscores.netflix.com:8080");
@@ -707,7 +705,9 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(7002, request.getOriginalPort(), "should fallback to server port");
+        assertThat(request.getOriginalPort())
+                .as("should fallback to server port")
+                .isEqualTo(7002);
     }
 
     @Test
@@ -728,7 +728,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(8080, request.getOriginalPort());
+        assertThat(request.getOriginalPort()).isEqualTo(8080);
 
         headers = new Headers();
         headers.add("Host", "host-with-carrots^1.0.0.netflix.com:8080");
@@ -743,7 +743,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(8080, request.getOriginalPort());
+        assertThat(request.getOriginalPort()).isEqualTo(8080);
 
         headers = new Headers();
         headers.add("Host", "host-with-carrots-no-port^1.0.0.netflix.com");
@@ -758,7 +758,7 @@ class HttpRequestMessageImplTest {
                 "https",
                 7002,
                 "localhost");
-        assertEquals(7002, request.getOriginalPort());
+        assertThat(request.getOriginalPort()).isEqualTo(7002);
     }
 
     @Test
@@ -766,7 +766,8 @@ class HttpRequestMessageImplTest {
         Headers headers = new Headers();
         headers.add("Host", "ba::33");
 
-        assertEquals(9999, HttpRequestMessageImpl.getOriginalPort(new SessionContext(), headers, 9999));
+        assertThat(HttpRequestMessageImpl.getOriginalPort(new SessionContext(), headers, 9999))
+                .isEqualTo(9999);
     }
 
     @Test
@@ -775,7 +776,8 @@ class HttpRequestMessageImplTest {
         headers.add(HttpHeaderNames.X_FORWARDED_PORT, "");
 
         // Default to using server port
-        assertEquals(9999, HttpRequestMessageImpl.getOriginalPort(new SessionContext(), headers, 9999));
+        assertThat(HttpRequestMessageImpl.getOriginalPort(new SessionContext(), headers, 9999))
+                .isEqualTo(9999);
     }
 
     @Test
@@ -786,21 +788,19 @@ class HttpRequestMessageImplTest {
                 new InetSocketAddress(InetAddresses.forString("1.1.1.1"), 443));
         Headers headers = new Headers();
         headers.add("X-Forwarded-Port", "6000");
-        assertEquals(443, HttpRequestMessageImpl.getOriginalPort(context, headers, 9999));
+        assertThat(HttpRequestMessageImpl.getOriginalPort(context, headers, 9999))
+                .isEqualTo(443);
     }
 
     @Test
     void testCleanCookieHeaders() {
-        assertEquals(
-                "BlahId=12345; something=67890;",
-                HttpRequestMessageImpl.cleanCookieHeader("BlahId=12345; Secure, something=67890;"));
-        assertEquals(
-                "BlahId=12345; something=67890;",
-                HttpRequestMessageImpl.cleanCookieHeader("BlahId=12345; something=67890;"));
-        assertEquals(
-                " BlahId=12345; something=67890;",
-                HttpRequestMessageImpl.cleanCookieHeader(" Secure, BlahId=12345; Secure, something=67890;"));
-        assertEquals("", HttpRequestMessageImpl.cleanCookieHeader(""));
+        assertThat(HttpRequestMessageImpl.cleanCookieHeader("BlahId=12345; Secure, something=67890;"))
+                .isEqualTo("BlahId=12345; something=67890;");
+        assertThat(HttpRequestMessageImpl.cleanCookieHeader("BlahId=12345; something=67890;"))
+                .isEqualTo("BlahId=12345; something=67890;");
+        assertThat(HttpRequestMessageImpl.cleanCookieHeader(" Secure, BlahId=12345; Secure, something=67890;"))
+                .isEqualTo(" BlahId=12345; something=67890;");
+        assertThat(HttpRequestMessageImpl.cleanCookieHeader("")).isEqualTo("");
     }
 
     @Test
@@ -819,7 +819,7 @@ class HttpRequestMessageImplTest {
                 new InetSocketAddress("api.netflix.com", 443),
                 true);
 
-        assertEquals(message.getClientDestinationPort(), Optional.of(443));
+        assertThat(Optional.of(443)).isEqualTo(message.getClientDestinationPort());
     }
 
     @Test
@@ -840,10 +840,10 @@ class HttpRequestMessageImplTest {
                 new InetSocketAddress("api.netflix.com", 443),
                 true);
         Cookies cookies = message.parseCookies();
-        assertEquals(2, cookies.getAll().size());
+        assertThat(cookies.getAll().size()).isEqualTo(2);
         List<Cookie> kCookies = cookies.get("k");
-        assertEquals(2, kCookies.size());
-        assertEquals("v1", kCookies.get(0).value());
-        assertEquals("v2", kCookies.get(1).value());
+        assertThat(kCookies.size()).isEqualTo(2);
+        assertThat(kCookies.get(0).value()).isEqualTo("v1");
+        assertThat(kCookies.get(1).value()).isEqualTo("v2");
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpResponseMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpResponseMessageImplTest.java
@@ -16,9 +16,7 @@
 
 package com.netflix.zuul.message.http;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.Headers;
@@ -58,9 +56,9 @@ class HttpResponseMessageImplTest {
                         "Set-Cookie",
                         "c2=4567; Max-Age=-1; Expires=Tue, 01 Sep 2015 22:49:57 GMT; Path=/; Domain=.netflix.com");
 
-        assertTrue(response.hasSetCookieWithName("c1"));
-        assertTrue(response.hasSetCookieWithName("c2"));
-        assertFalse(response.hasSetCookieWithName("XX"));
+        assertThat(response.hasSetCookieWithName("c1")).isTrue();
+        assertThat(response.hasSetCookieWithName("c2")).isTrue();
+        assertThat(response.hasSetCookieWithName("XX")).isFalse();
     }
 
     @Test
@@ -76,19 +74,19 @@ class HttpResponseMessageImplTest {
 
         response.removeExistingSetCookie("c1");
 
-        assertEquals(1, response.getHeaders().size());
-        assertFalse(response.hasSetCookieWithName("c1"));
-        assertTrue(response.hasSetCookieWithName("c2"));
+        assertThat(response.getHeaders().size()).isEqualTo(1);
+        assertThat(response.hasSetCookieWithName("c1")).isFalse();
+        assertThat(response.hasSetCookieWithName("c2")).isTrue();
     }
 
     @Test
     void testContentLengthHeaderHasCorrectValue() {
-        assertEquals(0, response.getHeaders().getAll("Content-Length").size());
+        assertThat(response.getHeaders().getAll("Content-Length").size()).isEqualTo(0);
 
         response.setBodyAsText(TEXT1);
-        assertEquals(String.valueOf(TEXT1.length()), response.getHeaders().getFirst("Content-Length"));
+        assertThat(response.getHeaders().getFirst("Content-Length")).isEqualTo(String.valueOf(TEXT1.length()));
 
         response.setBody(TEXT2.getBytes(StandardCharsets.UTF_8));
-        assertEquals(String.valueOf(TEXT2.length()), response.getHeaders().getFirst("Content-Length"));
+        assertThat(response.getHeaders().getFirst("Content-Length")).isEqualTo(String.valueOf(TEXT2.length()));
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.monitoring;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Gauge;
@@ -42,16 +41,16 @@ class ConnCounterTest {
         counter.increment("end");
 
         Gauge meter1 = registry.gauge(registry.createId("foo.start", "from", "nascent"));
-        assertNotNull(meter1);
-        assertEquals(1, meter1.value(), 0);
+        assertThat(meter1).isNotNull();
+        assertThat(meter1.value()).isCloseTo(1.0, org.assertj.core.data.Offset.offset(0.0));
 
         Gauge meter2 = registry.gauge(registry.createId("foo.middle", "from", "start"));
-        assertNotNull(meter2);
-        assertEquals(1, meter2.value(), 0);
+        assertThat(meter2).isNotNull();
+        assertThat(meter2.value()).isCloseTo(1.0, org.assertj.core.data.Offset.offset(0.0));
 
         Gauge meter3 = registry.gauge(registry.createId("foo.end", "from", "middle", "bar", "baz"));
-        assertNotNull(meter3);
-        assertEquals(1, meter3.value(), 0);
+        assertThat(meter3).isNotNull();
+        assertThat(meter3.value()).isCloseTo(1.0, org.assertj.core.data.Offset.offset(0.0));
     }
 
     @Test
@@ -67,6 +66,7 @@ class ConnCounterTest {
         ConnCounter.from(channel).increment("active");
         ConnCounter.from(channel).increment("active");
 
-        assertEquals(1, ConnCounter.from(channel).getCurrentActiveConns(), 0);
+        assertThat(ConnCounter.from(channel).getCurrentActiveConns())
+                .isCloseTo(1.0, org.assertj.core.data.Offset.offset(0.0));
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnTimerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnTimerTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.monitoring;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.spectator.api.Registry;
@@ -42,15 +41,15 @@ class ConnTimerTest {
         timer.record(4000L, "end");
 
         PercentileTimer meter1 = PercentileTimer.get(registry, registry.createId("foo.start-middle"));
-        assertNotNull(meter1);
-        assertEquals(1000L, meter1.totalTime());
+        assertThat(meter1).isNotNull();
+        assertThat(meter1.totalTime()).isEqualTo(1000L);
 
         PercentileTimer meter2 = PercentileTimer.get(registry, registry.createId("foo.middle-end", "bar", "baz"));
-        assertNotNull(meter2);
-        assertEquals(2000L, meter2.totalTime());
+        assertThat(meter2).isNotNull();
+        assertThat(meter2.totalTime()).isEqualTo(2000L);
 
         PercentileTimer meter3 = PercentileTimer.get(registry, registry.createId("foo.start-end", "bar", "baz"));
-        assertNotNull(meter3);
-        assertEquals(3000L, meter3.totalTime());
+        assertThat(meter3).isNotNull();
+        assertThat(meter3.totalTime()).isEqualTo(3000L);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/NettyRequestAttemptFactoryTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/NettyRequestAttemptFactoryTest.java
@@ -16,8 +16,8 @@
 
 package com.netflix.zuul.netty;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.exception.OutboundErrorType;
 import com.netflix.zuul.exception.OutboundException;
@@ -42,68 +42,72 @@ public class NettyRequestAttemptFactoryTest {
 
     @Test
     public void mapNettyToOutboundExceptionMapsToOutboundException() {
-        Exception e = new OutboundException(OutboundErrorType.OTHER,
-                new RequestAttempts());
+        Exception e = new OutboundException(OutboundErrorType.OTHER, new RequestAttempts());
         OutboundException mapException = factory.mapNettyToOutboundException(e, new SessionContext());
 
-        assertEquals(e, mapException);
+        assertThat(mapException).isEqualTo(e);
         // check that the type is OutboundException
-        assertNotNull(mapException);
+        assertThat(mapException).isNotNull();
     }
 
     @Test
     public void mapNettyToOutboundExceptionMapsToReadTimeoutException() {
-        OutboundException mapException = factory.mapNettyToOutboundException(new ReadTimeoutException(), new SessionContext());
+        OutboundException mapException =
+                factory.mapNettyToOutboundException(new ReadTimeoutException(), new SessionContext());
 
         // check that the type is OutboundException
-        assertNotNull(mapException);
-        assertEquals(OutboundErrorType.READ_TIMEOUT, mapException.getOutboundErrorType());
+        assertThat(mapException).isNotNull();
+        assertThat(mapException.getOutboundErrorType()).isEqualTo(OutboundErrorType.READ_TIMEOUT);
     }
 
     @Test
     public void mapNettyToOutboundExceptionMapsToOriginConcurrencyExceededException() {
-        OutboundException mapException = factory.mapNettyToOutboundException(new OriginConcurrencyExceededException(OriginName.fromVipAndApp("vip", "app")), new SessionContext());
+        OutboundException mapException = factory.mapNettyToOutboundException(
+                new OriginConcurrencyExceededException(OriginName.fromVipAndApp("vip", "app")), new SessionContext());
 
         // check that the type is OutboundException
-        assertNotNull(mapException);
-        assertEquals(OutboundErrorType.ORIGIN_CONCURRENCY_EXCEEDED, mapException.getOutboundErrorType());
+        assertThat(mapException).isNotNull();
+        assertThat(mapException.getOutboundErrorType()).isEqualTo(OutboundErrorType.ORIGIN_CONCURRENCY_EXCEEDED);
     }
 
     @Test
     public void mapNettyToOutboundExceptionMapsToOriginConnectException() {
-        OutboundException mapException = factory.mapNettyToOutboundException(new OriginConnectException("error",
-                OutboundErrorType.OTHER), new SessionContext());
+        OutboundException mapException = factory.mapNettyToOutboundException(
+                new OriginConnectException("error", OutboundErrorType.OTHER), new SessionContext());
 
         // check that the type is OutboundException
-        assertNotNull(mapException);
-        assertEquals(OutboundErrorType.OTHER, mapException.getOutboundErrorType());
+        assertThat(mapException).isNotNull();
+        assertThat(mapException.getOutboundErrorType()).isEqualTo(OutboundErrorType.OTHER);
     }
 
     @Test
     public void mapNettyToOutboundExceptionMapsToClosedChannelException() {
-        OutboundException mapException = factory.mapNettyToOutboundException(new ClosedChannelException(), new SessionContext());
+        OutboundException mapException =
+                factory.mapNettyToOutboundException(new ClosedChannelException(), new SessionContext());
 
         // check that the type is OutboundException
-        assertNotNull(mapException);
-        assertEquals(OutboundErrorType.RESET_CONNECTION, mapException.getOutboundErrorType());
+        assertThat(mapException).isNotNull();
+        assertThat(mapException.getOutboundErrorType()).isEqualTo(OutboundErrorType.RESET_CONNECTION);
     }
 
     @Test
     public void mapNettyToOutboundExceptionMapsToHeaderListSizeException() {
-        OutboundException mapException = factory.mapNettyToOutboundException(Http2Exception.headerListSizeError(1, Http2Error.CONNECT_ERROR, false, ""), new SessionContext());
+        OutboundException mapException = factory.mapNettyToOutboundException(
+                Http2Exception.headerListSizeError(1, Http2Error.CONNECT_ERROR, false, ""), new SessionContext());
 
         // check that the type is OutboundException
-        assertNotNull(mapException);
-        assertEquals(OutboundErrorType.HEADER_FIELDS_TOO_LARGE, mapException.getOutboundErrorType());
+        assertThat(mapException).isNotNull();
+        assertThat(mapException.getOutboundErrorType()).isEqualTo(OutboundErrorType.HEADER_FIELDS_TOO_LARGE);
     }
 
     @Test
     public void mapNettyToOutboundExceptionMapsToIllegalStateException() {
-        OutboundException mapException = factory.mapNettyToOutboundException(new Exception(new IllegalStateException(new Throwable("No available server"))), new SessionContext());
+        OutboundException mapException = factory.mapNettyToOutboundException(
+                new Exception(new IllegalStateException(new Throwable("No available server"))), new SessionContext());
 
         // check that the type is OutboundException
-        assertNotNull(mapException);
-        assertEquals(OutboundErrorType.NO_AVAILABLE_SERVERS, mapException.getOutboundErrorType());
+        assertThat(mapException).isNotNull();
+        assertThat(mapException.getOutboundErrorType()).isEqualTo(OutboundErrorType.NO_AVAILABLE_SERVERS);
     }
 
     @Test
@@ -111,7 +115,7 @@ public class NettyRequestAttemptFactoryTest {
         OutboundException mapException = factory.mapNettyToOutboundException(new Exception(), new SessionContext());
 
         // check that the type is OutboundException
-        assertNotNull(mapException);
-        assertEquals(OutboundErrorType.OTHER, mapException.getOutboundErrorType());
+        assertThat(mapException).isNotNull();
+        assertThat(mapException.getOutboundErrorType()).isEqualTo(OutboundErrorType.OTHER);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ClientTimeoutHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ClientTimeoutHandlerTest.java
@@ -17,6 +17,7 @@
 package com.netflix.zuul.netty.connectionpool;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -32,7 +33,6 @@ import io.netty.util.ReferenceCountUtil;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -116,7 +116,7 @@ class ClientTimeoutHandlerTest {
     }
 
     private void verifyWrite() {
-        Assertions.assertTrue(verifier.seenWrite);
+        assertThat(verifier.seenWrite).isTrue();
     }
 
     private static class WriteVerifyingHandler extends ChannelDuplexHandler {

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolConfigImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolConfigImplTest.java
@@ -19,9 +19,7 @@ package com.netflix.zuul.netty.connectionpool;
 import static com.netflix.zuul.netty.connectionpool.ConnectionPoolConfigImpl.MAX_REQUESTS_PER_CONNECTION;
 import static com.netflix.zuul.netty.connectionpool.ConnectionPoolConfigImpl.PER_SERVER_WATERLINE;
 import static com.netflix.zuul.netty.connectionpool.ConnectionPoolConfigImpl.TCP_KEEP_ALIVE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfigKey;
@@ -47,172 +45,173 @@ class ConnectionPoolConfigImplTest {
 
     @Test
     void testGetConnectTimeout() {
-        assertEquals(ConnectionPoolConfigImpl.DEFAULT_CONNECT_TIMEOUT, connectionPoolConfig.getConnectTimeout());
+        assertThat(connectionPoolConfig.getConnectTimeout())
+                .isEqualTo(ConnectionPoolConfigImpl.DEFAULT_CONNECT_TIMEOUT);
     }
 
     @Test
     void testGetConnectTimeoutOverride() {
         clientConfig.set(IClientConfigKey.Keys.ConnectTimeout, 1000);
-        assertEquals(1000, connectionPoolConfig.getConnectTimeout());
+        assertThat(connectionPoolConfig.getConnectTimeout()).isEqualTo(1000);
     }
 
     @Test
     void testGetMaxRequestsPerConnection() {
-        assertEquals(
-                ConnectionPoolConfigImpl.DEFAULT_MAX_REQUESTS_PER_CONNECTION,
-                connectionPoolConfig.getMaxRequestsPerConnection());
+        assertThat(connectionPoolConfig.getMaxRequestsPerConnection())
+                .isEqualTo(ConnectionPoolConfigImpl.DEFAULT_MAX_REQUESTS_PER_CONNECTION);
     }
 
     @Test
     void testGetMaxRequestsPerConnectionOverride() {
         clientConfig.set(MAX_REQUESTS_PER_CONNECTION, 2000);
-        assertEquals(2000, connectionPoolConfig.getMaxRequestsPerConnection());
+        assertThat(connectionPoolConfig.getMaxRequestsPerConnection()).isEqualTo(2000);
     }
 
     @Test
     void testMaxConnectionsPerHost() {
-        assertEquals(ConnectionPoolConfigImpl.DEFAULT_MAX_CONNS_PER_HOST, connectionPoolConfig.maxConnectionsPerHost());
+        assertThat(connectionPoolConfig.maxConnectionsPerHost())
+                .isEqualTo(ConnectionPoolConfigImpl.DEFAULT_MAX_CONNS_PER_HOST);
     }
 
     @Test
     void testMaxConnectionsPerHostOverride() {
         clientConfig.set(IClientConfigKey.Keys.MaxConnectionsPerHost, 60);
-        assertEquals(60, connectionPoolConfig.maxConnectionsPerHost());
+        assertThat(connectionPoolConfig.maxConnectionsPerHost()).isEqualTo(60);
     }
 
     @Test
     void testPerServerWaterline() {
-        assertEquals(ConnectionPoolConfigImpl.DEFAULT_PER_SERVER_WATERLINE, connectionPoolConfig.perServerWaterline());
+        assertThat(connectionPoolConfig.perServerWaterline())
+                .isEqualTo(ConnectionPoolConfigImpl.DEFAULT_PER_SERVER_WATERLINE);
     }
 
     @Test
     void testPerServerWaterlineOverride() {
         clientConfig.set(PER_SERVER_WATERLINE, 5);
-        assertEquals(5, connectionPoolConfig.perServerWaterline());
+        assertThat(connectionPoolConfig.perServerWaterline()).isEqualTo(5);
     }
 
     @Test
     void testGetIdleTimeout() {
-        assertEquals(ConnectionPoolConfigImpl.DEFAULT_IDLE_TIMEOUT, connectionPoolConfig.getIdleTimeout());
+        assertThat(connectionPoolConfig.getIdleTimeout()).isEqualTo(ConnectionPoolConfigImpl.DEFAULT_IDLE_TIMEOUT);
     }
 
     @Test
     void testGetIdleTimeoutOverride() {
         clientConfig.set(IClientConfigKey.Keys.ConnIdleEvictTimeMilliSeconds, 70000);
-        assertEquals(70000, connectionPoolConfig.getIdleTimeout());
+        assertThat(connectionPoolConfig.getIdleTimeout()).isEqualTo(70000);
     }
 
     @Test
     void testGetTcpKeepAlive() {
-        assertFalse(connectionPoolConfig.getTcpKeepAlive());
+        assertThat(connectionPoolConfig.getTcpKeepAlive()).isFalse();
     }
 
     @Test
     void testGetTcpKeepAliveOverride() {
         clientConfig.set(TCP_KEEP_ALIVE, true);
-        assertTrue(connectionPoolConfig.getTcpKeepAlive());
+        assertThat(connectionPoolConfig.getTcpKeepAlive()).isTrue();
     }
 
     @Test
     void testGetTcpNoDelay() {
-        assertFalse(connectionPoolConfig.getTcpNoDelay());
+        assertThat(connectionPoolConfig.getTcpNoDelay()).isFalse();
     }
 
     @Test
     void testGetTcpNoDelayOverride() {
         clientConfig.set(ConnectionPoolConfigImpl.TCP_NO_DELAY, true);
-        assertTrue(connectionPoolConfig.getTcpNoDelay());
+        assertThat(connectionPoolConfig.getTcpNoDelay()).isTrue();
     }
 
     @Test
     void testGetTcpReceiveBufferSize() {
-        assertEquals(ConnectionPoolConfigImpl.DEFAULT_BUFFER_SIZE, connectionPoolConfig.getTcpReceiveBufferSize());
+        assertThat(connectionPoolConfig.getTcpReceiveBufferSize())
+                .isEqualTo(ConnectionPoolConfigImpl.DEFAULT_BUFFER_SIZE);
     }
 
     @Test
     void testGetTcpReceiveBufferSizeOverride() {
         clientConfig.set(IClientConfigKey.Keys.ReceiveBufferSize, 40000);
-        assertEquals(40000, connectionPoolConfig.getTcpReceiveBufferSize());
+        assertThat(connectionPoolConfig.getTcpReceiveBufferSize()).isEqualTo(40000);
     }
 
     @Test
     void testGetTcpSendBufferSize() {
-        assertEquals(ConnectionPoolConfigImpl.DEFAULT_BUFFER_SIZE, connectionPoolConfig.getTcpSendBufferSize());
+        assertThat(connectionPoolConfig.getTcpSendBufferSize()).isEqualTo(ConnectionPoolConfigImpl.DEFAULT_BUFFER_SIZE);
     }
 
     @Test
     void testGetTcpSendBufferSizeOverride() {
         clientConfig.set(IClientConfigKey.Keys.SendBufferSize, 40000);
-        assertEquals(40000, connectionPoolConfig.getTcpSendBufferSize());
+        assertThat(connectionPoolConfig.getTcpSendBufferSize()).isEqualTo(40000);
     }
 
     @Test
     void testGetNettyWriteBufferHighWaterMark() {
-        assertEquals(
-                ConnectionPoolConfigImpl.DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK,
-                connectionPoolConfig.getNettyWriteBufferHighWaterMark());
+        assertThat(connectionPoolConfig.getNettyWriteBufferHighWaterMark())
+                .isEqualTo(ConnectionPoolConfigImpl.DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK);
     }
 
     @Test
     void testGetNettyWriteBufferHighWaterMarkOverride() {
         clientConfig.set(ConnectionPoolConfigImpl.WRITE_BUFFER_HIGH_WATER_MARK, 40000);
-        assertEquals(40000, connectionPoolConfig.getNettyWriteBufferHighWaterMark());
+        assertThat(connectionPoolConfig.getNettyWriteBufferHighWaterMark()).isEqualTo(40000);
     }
 
     @Test
     void testGetNettyWriteBufferLowWaterMark() {
-        assertEquals(
-                ConnectionPoolConfigImpl.DEFAULT_WRITE_BUFFER_LOW_WATER_MARK,
-                connectionPoolConfig.getNettyWriteBufferLowWaterMark());
+        assertThat(connectionPoolConfig.getNettyWriteBufferLowWaterMark())
+                .isEqualTo(ConnectionPoolConfigImpl.DEFAULT_WRITE_BUFFER_LOW_WATER_MARK);
     }
 
     @Test
     void testGetNettyWriteBufferLowWaterMarkOverride() {
         clientConfig.set(ConnectionPoolConfigImpl.WRITE_BUFFER_LOW_WATER_MARK, 10000);
-        assertEquals(10000, connectionPoolConfig.getNettyWriteBufferLowWaterMark());
+        assertThat(connectionPoolConfig.getNettyWriteBufferLowWaterMark()).isEqualTo(10000);
     }
 
     @Test
     void testGetNettyAutoRead() {
-        assertFalse(connectionPoolConfig.getNettyAutoRead());
+        assertThat(connectionPoolConfig.getNettyAutoRead()).isFalse();
     }
 
     @Test
     void testGetNettyAutoReadOverride() {
         clientConfig.set(ConnectionPoolConfigImpl.AUTO_READ, true);
-        assertTrue(connectionPoolConfig.getNettyAutoRead());
+        assertThat(connectionPoolConfig.getNettyAutoRead()).isTrue();
     }
 
     @Test
     void testIsSecure() {
-        assertFalse(connectionPoolConfig.isSecure());
+        assertThat(connectionPoolConfig.isSecure()).isFalse();
     }
 
     @Test
     void testIsSecureOverride() {
         clientConfig.set(IClientConfigKey.Keys.IsSecure, true);
-        assertTrue(connectionPoolConfig.isSecure());
+        assertThat(connectionPoolConfig.isSecure()).isTrue();
     }
 
     @Test
     void testUseIPAddrForServer() {
-        assertTrue(connectionPoolConfig.useIPAddrForServer());
+        assertThat(connectionPoolConfig.useIPAddrForServer()).isTrue();
     }
 
     @Test
     void testUseIPAddrForServerOverride() {
         clientConfig.set(IClientConfigKey.Keys.UseIPAddrForServer, false);
-        assertFalse(connectionPoolConfig.useIPAddrForServer());
+        assertThat(connectionPoolConfig.useIPAddrForServer()).isFalse();
     }
 
     @Test
     void testIsCloseOnCircuitBreakerEnabled() {
-        assertTrue(connectionPoolConfig.isCloseOnCircuitBreakerEnabled());
+        assertThat(connectionPoolConfig.isCloseOnCircuitBreakerEnabled()).isTrue();
     }
 
     @Test
     void testIsCloseOnCircuitBreakerEnabledOverride() {
         clientConfig.set(ConnectionPoolConfigImpl.CLOSE_ON_CIRCUIT_BREAKER, false);
-        assertFalse(connectionPoolConfig.isCloseOnCircuitBreakerEnabled());
+        assertThat(connectionPoolConfig.isCloseOnCircuitBreakerEnabled()).isFalse();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetricsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetricsTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.netty.connectionpool;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
 import com.netflix.spectator.api.Counter;
@@ -63,9 +63,9 @@ class ConnectionPoolMetricsTest {
     }
 
     private void validateCounter(String name, Counter counter) {
-        assertEquals(name, counter.id().name());
+        assertThat(counter.id().name()).isEqualTo(name);
         Map<String, String> tags = Lists.newArrayList(counter.id().tags().iterator()).stream()
                 .collect(Collectors.toMap(Tag::key, Tag::value));
-        assertEquals("whatever", tags.get("id"));
+        assertThat(tags.get("id")).isEqualTo("whatever");
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunnerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/filter/BaseZuulFilterRunnerTest.java
@@ -16,10 +16,7 @@
 
 package com.netflix.zuul.netty.filter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 
@@ -101,17 +98,16 @@ public class BaseZuulFilterRunnerTest {
         asyncFilter.output.set(message.clone());
 
         resumer.validator = m -> {
-            assertEquals(
-                    0,
-                    asyncFilter.getConcurrency(),
-                    "concurrency should have been decremented before the filter chain was resumed");
+            assertThat(asyncFilter.getConcurrency())
+                    .as("concurrency should have been decremented before the filter chain was resumed")
+                    .isEqualTo(0);
             return m;
         };
 
         runner.filter(asyncFilter, message);
         ZuulMessage filteredMessage = resumer.future.get(5, TimeUnit.SECONDS);
         // sanity check to verify the message was transformed by AsyncFilter
-        assertNotSame(message, filteredMessage);
+        assertThat(filteredMessage).isNotSameAs(message);
     }
 
     @Test
@@ -120,18 +116,17 @@ public class BaseZuulFilterRunnerTest {
         asyncFilter.output.set(null);
 
         resumer.validator = m -> {
-            assertEquals(
-                    0,
-                    asyncFilter.getConcurrency(),
-                    "concurrency should have been decremented before the filter chain was resumed");
-            assertNotNull(m);
+            assertThat(asyncFilter.getConcurrency())
+                    .as("concurrency should have been decremented before the filter chain was resumed")
+                    .isEqualTo(0);
+            assertThat(m).isNotNull();
             return m;
         };
 
         runner.filter(asyncFilter, message);
         ZuulMessage filteredMessage = resumer.future.get(5, TimeUnit.SECONDS);
         // sanity check to verify the message was transformed by AsyncFilter
-        assertSame(message, filteredMessage);
+        assertThat(filteredMessage).isSameAs(message);
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/filter/EventExecutorSchedulerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/filter/EventExecutorSchedulerTest.java
@@ -16,9 +16,8 @@
 
 package com.netflix.zuul.netty.filter;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -60,7 +59,7 @@ class EventExecutorSchedulerTest {
 
     @Test
     void nullExecutor() {
-        assertThrows(NullPointerException.class, () -> new EventExecutorScheduler(null));
+        assertThatThrownBy(() -> new EventExecutorScheduler(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -74,8 +73,8 @@ class EventExecutorSchedulerTest {
                 executed.set(true);
             };
             Subscription schedule = worker.schedule(action);
-            assertTrue(executed.get());
-            assertTrue(schedule.isUnsubscribed());
+            assertThat(executed.get()).isTrue();
+            assertThat(schedule.isUnsubscribed()).isTrue();
             latch.countDown();
         });
 
@@ -97,20 +96,20 @@ class EventExecutorSchedulerTest {
 
         Worker worker = scheduler.createWorker();
         Subscription schedule = worker.schedule(action);
-        assertFalse(schedule.isUnsubscribed());
+        assertThat(schedule.isUnsubscribed()).isFalse();
 
         latch.countDown();
         // ensure the original action finished
         eventLoop.submit(() -> {}).get(5, TimeUnit.SECONDS);
-        assertTrue(inEventLoop.get());
-        assertTrue(schedule.isUnsubscribed());
+        assertThat(inEventLoop.get()).isTrue();
+        assertThat(schedule.isUnsubscribed()).isTrue();
     }
 
     @Test
     void workerUnsubscribe() {
         Worker worker = scheduler.createWorker();
-        assertFalse(worker.isUnsubscribed());
+        assertThat(worker.isUnsubscribed()).isFalse();
         worker.unsubscribe();
-        assertTrue(worker.isUnsubscribed());
+        assertThat(worker.isUnsubscribed()).isTrue();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulEndPointRunnerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulEndPointRunnerTest.java
@@ -16,10 +16,7 @@
 
 package com.netflix.zuul.netty.filter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -96,34 +93,34 @@ class ZuulEndPointRunnerTest {
     void nonErrorEndpoint() {
         request.getContext().setShouldSendErrorResponse(false);
         request.getContext().setEndpoint(BASIC_ENDPOINT);
-        assertNull(request.getContext().get(CommonContextKeys.ZUUL_ENDPOINT));
+        assertThat(request.getContext().get(CommonContextKeys.ZUUL_ENDPOINT)).isNull();
         endpointRunner.filter(request);
         ZuulFilter<HttpRequestMessage, HttpResponseMessage> filter =
                 request.getContext().get(CommonContextKeys.ZUUL_ENDPOINT);
-        assertTrue(filter instanceof BasicEndpoint);
+        assertThat(filter instanceof BasicEndpoint).isTrue();
 
         ArgumentCaptor<HttpResponseMessage> captor = ArgumentCaptor.forClass(HttpResponseMessage.class);
         verify(filterRunner, times(1)).filter(captor.capture());
         HttpResponseMessage capturedResponseMessage = captor.getValue();
-        assertEquals(capturedResponseMessage.getInboundRequest(), request.getInboundRequest());
-        assertEquals("basicEndpoint", capturedResponseMessage.getContext().getEndpoint());
-        assertFalse(capturedResponseMessage.getContext().errorResponseSent());
+        assertThat(request.getInboundRequest()).isEqualTo(capturedResponseMessage.getInboundRequest());
+        assertThat(capturedResponseMessage.getContext().getEndpoint()).isEqualTo("basicEndpoint");
+        assertThat(capturedResponseMessage.getContext().errorResponseSent()).isFalse();
     }
 
     @Test
     void errorEndpoint() {
         request.getContext().setShouldSendErrorResponse(true);
-        assertNull(request.getContext().get(CommonContextKeys.ZUUL_ENDPOINT));
+        assertThat(request.getContext().get(CommonContextKeys.ZUUL_ENDPOINT)).isNull();
         endpointRunner.filter(request);
         ZuulFilter filter = request.getContext().get(CommonContextKeys.ZUUL_ENDPOINT);
-        assertTrue(filter instanceof ErrorEndpoint);
+        assertThat(filter instanceof ErrorEndpoint).isTrue();
 
         ArgumentCaptor<HttpResponseMessage> captor = ArgumentCaptor.forClass(HttpResponseMessage.class);
         verify(filterRunner, times(1)).filter(captor.capture());
         HttpResponseMessage capturedResponseMessage = captor.getValue();
-        assertEquals(capturedResponseMessage.getInboundRequest(), request.getInboundRequest());
-        assertNull(capturedResponseMessage.getContext().getEndpoint());
-        assertTrue(capturedResponseMessage.getContext().errorResponseSent());
+        assertThat(request.getInboundRequest()).isEqualTo(capturedResponseMessage.getInboundRequest());
+        assertThat(capturedResponseMessage.getContext().getEndpoint()).isNull();
+        assertThat(capturedResponseMessage.getContext().errorResponseSent()).isTrue();
     }
 
     @Filter(order = 10, type = FilterType.ENDPOINT)

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/insights/ServerStateHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/insights/ServerStateHandlerTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.netty.insights;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
@@ -65,14 +65,14 @@ class ServerStateHandlerTest {
         channel.pipeline().context(DummyChannelHandler.class).fireChannelActive();
         channel.pipeline().context(DummyChannelHandler.class).fireChannelActive();
 
-        assertEquals(3, connects.count());
+        assertThat(connects.count()).isEqualTo(3);
 
         // Closes X 1
         channel.pipeline().context(DummyChannelHandler.class).fireChannelInactive();
 
-        assertEquals(3, connects.count());
-        assertEquals(1, closes.count());
-        assertEquals(0, errors.count());
+        assertThat(connects.count()).isEqualTo(3);
+        assertThat(closes.count()).isEqualTo(1);
+        assertThat(errors.count()).isEqualTo(0);
     }
 
     @Test
@@ -84,9 +84,7 @@ class ServerStateHandlerTest {
 
         channel.pipeline().context(DummyChannelHandler.class).fireChannelActive();
 
-        assertEquals(
-                PassportState.SERVER_CH_ACTIVE,
-                CurrentPassport.fromChannel(channel).getState());
+        assertThat(CurrentPassport.fromChannel(channel).getState()).isEqualTo(PassportState.SERVER_CH_ACTIVE);
     }
 
     @Test
@@ -97,8 +95,6 @@ class ServerStateHandlerTest {
 
         channel.pipeline().context(DummyChannelHandler.class).fireChannelInactive();
 
-        assertEquals(
-                PassportState.SERVER_CH_INACTIVE,
-                CurrentPassport.fromChannel(channel).getState());
+        assertThat(CurrentPassport.fromChannel(channel).getState()).isEqualTo(PassportState.SERVER_CH_INACTIVE);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializerTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.netty.server;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.netty.common.channel.config.ChannelConfig;
@@ -59,10 +59,14 @@ class BaseZuulChannelInitializerTest {
 
         init.addTcpRelatedHandlers(channel.pipeline());
 
-        assertNotNull(channel.pipeline().context(SourceAddressChannelHandler.class));
-        assertNotNull(channel.pipeline().context(PerEventLoopMetricsChannelHandler.Connections.class));
-        assertNotNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
-        assertNotNull(channel.pipeline().context(MaxInboundConnectionsHandler.class));
+        assertThat(channel.pipeline().context(SourceAddressChannelHandler.class))
+                .isNotNull();
+        assertThat(channel.pipeline().context(PerEventLoopMetricsChannelHandler.Connections.class))
+                .isNotNull();
+        assertThat(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME))
+                .isNotNull();
+        assertThat(channel.pipeline().context(MaxInboundConnectionsHandler.class))
+                .isNotNull();
     }
 
     @Test
@@ -86,10 +90,14 @@ class BaseZuulChannelInitializerTest {
 
         init.addTcpRelatedHandlers(channel.pipeline());
 
-        assertNotNull(channel.pipeline().context(SourceAddressChannelHandler.class));
-        assertNotNull(channel.pipeline().context(PerEventLoopMetricsChannelHandler.Connections.class));
-        assertNotNull(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME));
-        assertNotNull(channel.pipeline().context(MaxInboundConnectionsHandler.class));
+        assertThat(channel.pipeline().context(SourceAddressChannelHandler.class))
+                .isNotNull();
+        assertThat(channel.pipeline().context(PerEventLoopMetricsChannelHandler.Connections.class))
+                .isNotNull();
+        assertThat(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME))
+                .isNotNull();
+        assertThat(channel.pipeline().context(MaxInboundConnectionsHandler.class))
+                .isNotNull();
     }
 
     @Test
@@ -113,7 +121,9 @@ class BaseZuulChannelInitializerTest {
 
         init.addPassportHandler(channel.pipeline());
 
-        assertNotNull(channel.pipeline().context(ServerStateHandler.InboundHandler.class));
-        assertNotNull(channel.pipeline().context(ServerStateHandler.OutboundHandler.class));
+        assertThat(channel.pipeline().context(ServerStateHandler.InboundHandler.class))
+                .isNotNull();
+        assertThat(channel.pipeline().context(ServerStateHandler.OutboundHandler.class))
+                .isNotNull();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientConnectionsShutdownTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientConnectionsShutdownTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.netty.server;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -163,7 +162,7 @@ class ClientConnectionsShutdownTest {
 
         channels.forEach(Channel::close);
         testPromise.await(10, TimeUnit.SECONDS);
-        assertTrue(channels.isEmpty());
+        assertThat(channels.isEmpty()).isTrue();
     }
 
     @Test
@@ -176,9 +175,9 @@ class ClientConnectionsShutdownTest {
             createChannels(10);
             shutdown.gracefullyShutdownClientChannels().await(10, TimeUnit.SECONDS);
 
-            assertTrue(
-                    channels.isEmpty(),
-                    "All channels in group should have been force closed after the timeout was triggered");
+            assertThat(channels.isEmpty())
+                    .as("All channels in group should have been force closed after the timeout was triggered")
+                    .isTrue();
         } finally {
             configuration.setProperty(configName, "30");
         }
@@ -212,8 +211,12 @@ class ClientConnectionsShutdownTest {
             channels.add(connect.channel());
 
             boolean await = shutdown.gracefullyShutdownClientChannels().await(10, TimeUnit.SECONDS);
-            assertTrue(await, "the promise should finish even if a channel failed to close");
-            assertEquals(1, channels.size(), "all other channels should have been closed");
+            assertThat(await)
+                    .as("the promise should finish even if a channel failed to close")
+                    .isTrue();
+            assertThat(channels.size())
+                    .as("all other channels should have been closed")
+                    .isEqualTo(1);
         } finally {
             configuration.setProperty(configName, "30");
         }
@@ -235,7 +238,9 @@ class ClientConnectionsShutdownTest {
             channels.forEach(Channel::close);
 
             promise.await(10, TimeUnit.SECONDS);
-            assertTrue(channels.isEmpty(), "All channels in group should have been closed");
+            assertThat(channels.isEmpty())
+                    .as("All channels in group should have been closed")
+                    .isTrue();
         } finally {
             configuration.setProperty(configName, "30");
         }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
@@ -16,11 +16,8 @@
 
 package com.netflix.zuul.netty.server;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.net.InetAddresses;
 import com.netflix.netty.common.HttpLifecycleChannelHandler;
 import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
@@ -74,12 +71,13 @@ class ClientRequestReceiverTest {
             result = channel.readInbound();
             result.disposeBufferedBody();
         }
-        assertEquals((int) result.getClientDestinationPort().get(), hapmDestinationAddress.getPort());
+        assertThat(hapmDestinationAddress.getPort())
+                .isEqualTo((int) result.getClientDestinationPort().get());
         int destinationPort = ((InetSocketAddress)
                         result.getContext().get(CommonContextKeys.PROXY_PROTOCOL_DESTINATION_ADDRESS))
                 .getPort();
-        assertEquals(444, destinationPort);
-        assertEquals(444, result.getOriginalPort());
+        assertThat(destinationPort).isEqualTo(444);
+        assertThat(result.getOriginalPort()).isEqualTo(444);
         channel.close();
     }
 
@@ -99,7 +97,7 @@ class ClientRequestReceiverTest {
             result.disposeBufferedBody();
         }
 
-        assertEquals("/foo/bar/somePath/%5E1.0.0", result.getPath());
+        assertThat(result.getPath()).isEqualTo("/foo/bar/somePath/%5E1.0.0");
 
         channel.close();
     }
@@ -120,7 +118,7 @@ class ClientRequestReceiverTest {
             result.disposeBufferedBody();
         }
 
-        assertEquals("/foo/bar/somePath/%5E1.0.0", result.getPath());
+        assertThat(result.getPath()).isEqualTo("/foo/bar/somePath/%5E1.0.0");
 
         channel.close();
     }
@@ -138,7 +136,7 @@ class ClientRequestReceiverTest {
             result.disposeBufferedBody();
         }
 
-        assertEquals("asdf", result.getPath());
+        assertThat(result.getPath()).isEqualTo("asdf");
 
         channel.close();
     }
@@ -159,9 +157,9 @@ class ClientRequestReceiverTest {
             result.disposeBufferedBody();
         }
 
-        assertEquals("foo", result.getQueryParams().getFirst("param1"));
-        assertEquals("bar", result.getQueryParams().getFirst("param2"));
-        assertEquals("baz", result.getQueryParams().getFirst("param3"));
+        assertThat(result.getQueryParams().getFirst("param1")).isEqualTo("foo");
+        assertThat(result.getQueryParams().getFirst("param2")).isEqualTo("bar");
+        assertThat(result.getQueryParams().getFirst("param3")).isEqualTo("baz");
 
         channel.close();
     }
@@ -192,8 +190,8 @@ class ClientRequestReceiverTest {
             result.disposeBufferedBody();
         }
 
-        assertNull(result.getContext().getError());
-        assertFalse(result.getContext().shouldSendErrorResponse());
+        assertThat(result.getContext().getError()).isNull();
+        assertThat(result.getContext().shouldSendErrorResponse()).isFalse();
         channel.close();
     }
 
@@ -223,12 +221,14 @@ class ClientRequestReceiverTest {
             result.disposeBufferedBody();
         }
 
-        assertNotNull(result.getContext().getError());
-        assertTrue(result.getContext().getError().getMessage().contains("too large"));
-        assertTrue(result.getContext().shouldSendErrorResponse());
-        assertEquals(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST, StatusCategoryUtils.getStatusCategory(result));
-        assertTrue(StatusCategoryUtils.getStatusCategoryReason(result.getContext())
-                .startsWith("Invalid request provided: Request body size "));
+        assertThat(result.getContext().getError()).isNotNull();
+        assertThat(result.getContext().getError().getMessage().contains("too large"))
+                .isTrue();
+        assertThat(result.getContext().shouldSendErrorResponse()).isTrue();
+        assertThat(StatusCategoryUtils.getStatusCategory(result))
+                .isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
+        assertThat(StatusCategoryUtils.getStatusCategoryReason(result.getContext()))
+                .startsWith("Invalid request provided: Request body size ");
         channel.close();
     }
 
@@ -262,12 +262,10 @@ class ClientRequestReceiverTest {
         channel.close();
 
         HttpRequestMessage request = ClientRequestReceiver.getRequestFromChannel(channel);
-        assertEquals(
-                ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST,
-                StatusCategoryUtils.getStatusCategory(request.getContext()));
-        assertEquals(
-                "Invalid request provided: Decode failure",
-                StatusCategoryUtils.getStatusCategoryReason(request.getContext()));
+        assertThat(StatusCategoryUtils.getStatusCategory(request.getContext()))
+                .isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
+        assertThat(StatusCategoryUtils.getStatusCategoryReason(request.getContext()))
+                .isEqualTo("Invalid request provided: Decode failure");
     }
 
     @Test
@@ -294,11 +292,11 @@ class ClientRequestReceiverTest {
 
         HttpRequestMessage request = ClientRequestReceiver.getRequestFromChannel(channel);
         SessionContext context = request.getContext();
-        assertEquals(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST, StatusCategoryUtils.getStatusCategory(context));
-        assertEquals("Multiple Host headers", context.getError().getMessage());
-        assertEquals(
-                "Invalid request provided: Multiple Host headers",
-                StatusCategoryUtils.getStatusCategoryReason(context));
+        assertThat(StatusCategoryUtils.getStatusCategory(context))
+                .isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
+        assertThat(context.getError().getMessage()).isEqualTo("Multiple Host headers");
+        assertThat(StatusCategoryUtils.getStatusCategoryReason(context))
+                .isEqualTo("Invalid request provided: Multiple Host headers");
     }
 
     @Test
@@ -325,9 +323,8 @@ class ClientRequestReceiverTest {
                         new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST)));
         channel.close();
 
-        assertEquals(
-                ZuulStatusCategory.FAILURE_CLIENT_PIPELINE_REJECT,
-                StatusCategoryUtils.getStatusCategory(inboundRequest.getContext()));
+        assertThat(StatusCategoryUtils.getStatusCategory(inboundRequest.getContext()))
+                .isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_PIPELINE_REJECT);
     }
 
     @Test
@@ -356,12 +353,12 @@ class ClientRequestReceiverTest {
 
         HttpRequestMessage request = ClientRequestReceiver.getRequestFromChannel(channel);
         Headers headers = request.getHeaders();
-        assertEquals(4, headers.size());
-        assertEquals("Value1", headers.getFirst("Header1"));
-        assertEquals("Value2", headers.getFirst("Header2"));
+        assertThat(headers.size()).isEqualTo(4);
+        assertThat(headers.getFirst("Header1")).isEqualTo("Value1");
+        assertThat(headers.getFirst("Header2")).isEqualTo("Value2");
 
         List<String> duplicates = headers.getAll("Duplicate");
-        assertEquals(Arrays.asList("Duplicate1", "Duplicate2"), duplicates);
+        assertThat(duplicates).isEqualTo(Arrays.asList("Duplicate1", "Duplicate2"));
     }
 
     @Test
@@ -385,6 +382,6 @@ class ClientRequestReceiverTest {
         channel.close();
 
         HttpRequestMessage request = ClientRequestReceiver.getRequestFromChannel(channel);
-        assertEquals(clientIp, request.getClientIp());
+        assertThat(request.getClientIp()).isEqualTo(clientIp);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientResponseWriterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientResponseWriterTest.java
@@ -16,9 +16,7 @@
 
 package com.netflix.zuul.netty.server;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.netty.common.HttpLifecycleChannelHandler;
 import com.netflix.zuul.BasicRequestCompleteHandler;
@@ -128,12 +126,12 @@ class ClientResponseWriterTest {
         channel.writeInbound(response);
 
         HttpResponseMessage zuulResponse = responseWriter.getZuulResponse();
-        assertNotNull(zuulResponse);
-        assertNotNull(nettyResp.get());
+        assertThat(zuulResponse).isNotNull();
+        assertThat(nettyResp.get()).isNotNull();
 
         channel.pipeline()
                 .fireUserEventTriggered(new HttpLifecycleChannelHandler.CompleteEvent(
                         HttpLifecycleChannelHandler.CompleteReason.SESSION_COMPLETE, null, nettyResp.get()));
-        assertNull(responseWriter.getZuulResponse());
+        assertThat(responseWriter.getZuulResponse()).isNull();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/IoUringTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/IoUringTest.java
@@ -16,10 +16,8 @@
 
 package com.netflix.zuul.netty.server;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
@@ -127,12 +125,12 @@ class IoUringTest {
         s.start();
 
         List<NamedSocketAddress> addresses = s.getListeningAddresses();
-        assertEquals(2, addresses.size());
+        assertThat(addresses.size()).isEqualTo(2);
 
         addresses.forEach(address -> {
-            assertTrue(address.unwrap() instanceof InetSocketAddress);
+            assertThat(address.unwrap() instanceof InetSocketAddress).isTrue();
             InetSocketAddress inetAddress = ((InetSocketAddress) address.unwrap());
-            assertNotEquals(0, inetAddress.getPort());
+            assertThat(inetAddress.getPort()).isNotEqualTo(0);
             checkConnection(inetAddress.getPort());
         });
 
@@ -140,10 +138,10 @@ class IoUringTest {
 
         s.stop();
 
-        assertEquals(2, ioUringChannels.size());
+        assertThat(ioUringChannels.size()).isEqualTo(2);
 
         for (IoUringServerSocketChannel ch : ioUringChannels) {
-            assertTrue(ch.eventLoop().isShutdown(), "isShutdown");
+            assertThat(ch.eventLoop().isShutdown()).as("isShutdown").isTrue();
         }
     }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ServerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ServerTest.java
@@ -16,10 +16,8 @@
 
 package com.netflix.zuul.netty.server;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
@@ -100,11 +98,11 @@ class ServerTest {
         s.start();
 
         List<NamedSocketAddress> addrs = s.getListeningAddresses();
-        assertEquals(2, addrs.size());
+        assertThat(addrs.size()).isEqualTo(2);
         for (NamedSocketAddress address : addrs) {
-            assertTrue(address.unwrap() instanceof InetSocketAddress);
+            assertThat(address.unwrap() instanceof InetSocketAddress).isTrue();
             int port = ((InetSocketAddress) address.unwrap()).getPort();
-            assertNotEquals(0, port);
+            assertThat(port).isNotEqualTo(0);
             checkConnection(port);
         }
 
@@ -112,10 +110,10 @@ class ServerTest {
 
         s.stop();
 
-        assertEquals(2, nioChannels.size());
+        assertThat(nioChannels.size()).isEqualTo(2);
 
         for (NioSocketChannel ch : nioChannels) {
-            assertTrue(ch.isShutdown(), "isShutdown");
+            assertThat(ch.isShutdown()).as("isShutdown").isTrue();
         }
     }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/SocketAddressPropertyTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/SocketAddressPropertyTest.java
@@ -16,10 +16,8 @@
 
 package com.netflix.zuul.netty.server;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.netflix.zuul.netty.server.SocketAddressProperty.BindType;
 import io.netty.channel.unix.DomainSocketAddress;
@@ -37,114 +35,115 @@ class SocketAddressPropertyTest {
         SocketAddressProperty prop = new SocketAddressProperty("com.netflix.zuul.netty.server.testprop", "=7001");
 
         SocketAddress address = prop.getValue();
-        assertEquals(InetSocketAddress.class, address.getClass());
+        assertThat(address.getClass()).isEqualTo(InetSocketAddress.class);
         InetSocketAddress inetSocketAddress = (InetSocketAddress) address;
-        assertEquals(7001, inetSocketAddress.getPort());
-        assertFalse(inetSocketAddress.isUnresolved());
+        assertThat(inetSocketAddress.getPort()).isEqualTo(7001);
+        assertThat(inetSocketAddress.isUnresolved()).isFalse();
     }
 
     @Test
     void bindTypeWorks_any() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("ANY=7001");
 
-        assertEquals(InetSocketAddress.class, address.getClass());
+        assertThat(address.getClass()).isEqualTo(InetSocketAddress.class);
         InetSocketAddress inetSocketAddress = (InetSocketAddress) address;
-        assertEquals(7001, inetSocketAddress.getPort());
-        assertFalse(inetSocketAddress.isUnresolved());
+        assertThat(inetSocketAddress.getPort()).isEqualTo(7001);
+        assertThat(inetSocketAddress.isUnresolved()).isFalse();
     }
 
     @Test
     void bindTypeWorks_blank() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("=7001");
 
-        assertEquals(InetSocketAddress.class, address.getClass());
+        assertThat(address.getClass()).isEqualTo(InetSocketAddress.class);
         InetSocketAddress inetSocketAddress = (InetSocketAddress) address;
-        assertEquals(7001, inetSocketAddress.getPort());
-        assertFalse(inetSocketAddress.isUnresolved());
+        assertThat(inetSocketAddress.getPort()).isEqualTo(7001);
+        assertThat(inetSocketAddress.isUnresolved()).isFalse();
     }
 
     @Test
     void bindTypeWorks_ipv4Any() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("IPV4_ANY=7001");
 
-        assertEquals(InetSocketAddress.class, address.getClass());
+        assertThat(address.getClass()).isEqualTo(InetSocketAddress.class);
         InetSocketAddress inetSocketAddress = (InetSocketAddress) address;
-        assertEquals(7001, inetSocketAddress.getPort());
-        assertFalse(inetSocketAddress.isUnresolved());
-        assertTrue(inetSocketAddress.getAddress() instanceof Inet4Address);
-        assertTrue(inetSocketAddress.getAddress().isAnyLocalAddress());
+        assertThat(inetSocketAddress.getPort()).isEqualTo(7001);
+        assertThat(inetSocketAddress.isUnresolved()).isFalse();
+        assertThat(inetSocketAddress.getAddress() instanceof Inet4Address).isTrue();
+        assertThat(inetSocketAddress.getAddress().isAnyLocalAddress()).isTrue();
     }
 
     @Test
     void bindTypeWorks_ipv6Any() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("IPV6_ANY=7001");
 
-        assertEquals(InetSocketAddress.class, address.getClass());
+        assertThat(address.getClass()).isEqualTo(InetSocketAddress.class);
         InetSocketAddress inetSocketAddress = (InetSocketAddress) address;
-        assertEquals(7001, inetSocketAddress.getPort());
-        assertFalse(inetSocketAddress.isUnresolved());
-        assertTrue(inetSocketAddress.getAddress() instanceof Inet6Address);
-        assertTrue(inetSocketAddress.getAddress().isAnyLocalAddress());
+        assertThat(inetSocketAddress.getPort()).isEqualTo(7001);
+        assertThat(inetSocketAddress.isUnresolved()).isFalse();
+        assertThat(inetSocketAddress.getAddress() instanceof Inet6Address).isTrue();
+        assertThat(inetSocketAddress.getAddress().isAnyLocalAddress()).isTrue();
     }
 
     @Test
     void bindTypeWorks_anyLocal() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("ANY_LOCAL=7001");
 
-        assertEquals(InetSocketAddress.class, address.getClass());
+        assertThat(address.getClass()).isEqualTo(InetSocketAddress.class);
         InetSocketAddress inetSocketAddress = (InetSocketAddress) address;
-        assertEquals(7001, inetSocketAddress.getPort());
-        assertFalse(inetSocketAddress.isUnresolved());
-        assertTrue(inetSocketAddress.getAddress().isLoopbackAddress());
+        assertThat(inetSocketAddress.getPort()).isEqualTo(7001);
+        assertThat(inetSocketAddress.isUnresolved()).isFalse();
+        assertThat(inetSocketAddress.getAddress().isLoopbackAddress()).isTrue();
     }
 
     @Test
     void bindTypeWorks_ipv4Local() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("IPV4_LOCAL=7001");
 
-        assertEquals(InetSocketAddress.class, address.getClass());
+        assertThat(address.getClass()).isEqualTo(InetSocketAddress.class);
         InetSocketAddress inetSocketAddress = (InetSocketAddress) address;
-        assertEquals(7001, inetSocketAddress.getPort());
-        assertFalse(inetSocketAddress.isUnresolved());
-        assertTrue(inetSocketAddress.getAddress() instanceof Inet4Address);
-        assertTrue(inetSocketAddress.getAddress().isLoopbackAddress());
+        assertThat(inetSocketAddress.getPort()).isEqualTo(7001);
+        assertThat(inetSocketAddress.isUnresolved()).isFalse();
+        assertThat(inetSocketAddress.getAddress() instanceof Inet4Address).isTrue();
+        assertThat(inetSocketAddress.getAddress().isLoopbackAddress()).isTrue();
     }
 
     @Test
     void bindTypeWorks_ipv6Local() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("IPV6_LOCAL=7001");
 
-        assertEquals(InetSocketAddress.class, address.getClass());
+        assertThat(address.getClass()).isEqualTo(InetSocketAddress.class);
         InetSocketAddress inetSocketAddress = (InetSocketAddress) address;
-        assertEquals(7001, inetSocketAddress.getPort());
-        assertFalse(inetSocketAddress.isUnresolved());
-        assertTrue(inetSocketAddress.getAddress() instanceof Inet6Address);
-        assertTrue(inetSocketAddress.getAddress().isLoopbackAddress());
+        assertThat(inetSocketAddress.getPort()).isEqualTo(7001);
+        assertThat(inetSocketAddress.isUnresolved()).isFalse();
+        assertThat(inetSocketAddress.getAddress() instanceof Inet6Address).isTrue();
+        assertThat(inetSocketAddress.getAddress().isLoopbackAddress()).isTrue();
     }
 
     @Test
     void bindTypeWorks_uds() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("UDS=/var/run/zuul.sock");
 
-        assertEquals(DomainSocketAddress.class, address.getClass());
+        assertThat(address.getClass()).isEqualTo(DomainSocketAddress.class);
         DomainSocketAddress domainSocketAddress = (DomainSocketAddress) address;
-        assertEquals("/var/run/zuul.sock", domainSocketAddress.path());
+        assertThat(domainSocketAddress.path()).isEqualTo("/var/run/zuul.sock");
     }
 
     @Test
     void bindTypeWorks_udsWithEquals() {
         SocketAddress address = SocketAddressProperty.Decoder.INSTANCE.apply("UDS=/var/run/zuul=.sock");
 
-        assertEquals(DomainSocketAddress.class, address.getClass());
+        assertThat(address.getClass()).isEqualTo(DomainSocketAddress.class);
         DomainSocketAddress domainSocketAddress = (DomainSocketAddress) address;
-        assertEquals("/var/run/zuul=.sock", domainSocketAddress.path());
+        assertThat(domainSocketAddress.path()).isEqualTo("/var/run/zuul=.sock");
     }
 
     @Test
     void failsOnMissingEqual() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            SocketAddressProperty.Decoder.INSTANCE.apply("ANY");
-        });
+        assertThatThrownBy(() -> {
+                    SocketAddressProperty.Decoder.INSTANCE.apply("ANY");
+                })
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -156,18 +155,20 @@ class SocketAddressPropertyTest {
                 BindType.ANY_LOCAL,
                 BindType.IPV4_LOCAL,
                 BindType.IPV6_LOCAL)) {
-            IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-                SocketAddressProperty.Decoder.INSTANCE.apply(type.name() + "=bogus");
-            });
-            assertTrue(exception.getMessage().contains("Port"));
+            assertThatThrownBy(() -> {
+                        SocketAddressProperty.Decoder.INSTANCE.apply(type.name() + "=bogus");
+                    })
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Port");
         }
     }
 
     @Test
     public void failsOnBadAddress() throws Exception {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            SocketAddressProperty.Decoder.INSTANCE.apply("");
-        });
-        assertEquals("Invalid address", exception.getMessage());
+        assertThatThrownBy(() -> {
+                    SocketAddressProperty.Decoder.INSTANCE.apply("");
+                })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid address");
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2ConnectionErrorHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2ConnectionErrorHandlerTest.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.zuul.netty.server.http2;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -42,7 +42,7 @@ class Http2ConnectionErrorHandlerTest {
     public void nonHttp2ExceptionsPassedUpPipeline() {
         RuntimeException exception = new RuntimeException();
         channel.pipeline().fireExceptionCaught(exception);
-        assertEquals(exception, exceptionCapturingHandler.caught);
+        assertThat(exceptionCapturingHandler.caught).isEqualTo(exception);
     }
 
     private static class ExceptionCapturingHandler extends ChannelInboundHandlerAdapter {

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2ContentLengthEnforcingHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2ContentLengthEnforcingHandlerTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.netty.server.http2;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.UnpooledByteBufAllocator;

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2OrHttpHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2OrHttpHandlerTest.java
@@ -16,10 +16,7 @@
 
 package com.netflix.zuul.netty.server.http2;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.netty.common.Http2ConnectionCloseHandler;
 import com.netflix.netty.common.Http2ConnectionExpiryHandler;
@@ -72,7 +69,7 @@ class Http2OrHttpHandlerTest {
         assertThat(channel.pipeline().get(Http2FrameCodec.class)).isInstanceOf(Http2FrameCodec.class);
         assertThat(channel.pipeline().get(BaseZuulChannelInitializer.HTTP_CODEC_HANDLER_NAME))
                 .isInstanceOf(Http2MultiplexHandler.class);
-        assertEquals("HTTP/2", channel.attr(Http2OrHttpHandler.PROTOCOL_NAME).get());
+        assertThat(channel.attr(Http2OrHttpHandler.PROTOCOL_NAME).get()).isEqualTo("HTTP/2");
     }
 
     @Test
@@ -88,7 +85,8 @@ class Http2OrHttpHandlerTest {
         channel.pipeline().addLast(Http2OrHttpHandler.class.getSimpleName(), http2OrHttpHandler);
 
         http2OrHttpHandler.configurePipeline(channel.pipeline().lastContext(), ApplicationProtocolNames.HTTP_2);
-        assertNotNull(channel.pipeline().context(Http2ConnectionErrorHandler.class));
+        assertThat(channel.pipeline().context(Http2ConnectionErrorHandler.class))
+                .isNotNull();
     }
 
     @Test
@@ -105,6 +103,7 @@ class Http2OrHttpHandlerTest {
         channel.pipeline().addLast(Http2OrHttpHandler.class.getSimpleName(), http2OrHttpHandler);
 
         http2OrHttpHandler.configurePipeline(channel.pipeline().lastContext(), ApplicationProtocolNames.HTTP_2);
-        assertNull(channel.pipeline().context(Http2ConnectionErrorHandler.class));
+        assertThat(channel.pipeline().context(Http2ConnectionErrorHandler.class))
+                .isNull();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushAuthHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushAuthHandlerTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.netty.server.push;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -37,14 +36,14 @@ class PushAuthHandlerTest {
                 new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/ws", Unpooled.buffer());
 
         // Invalid input
-        assertTrue(authHandler.isInvalidOrigin(request));
+        assertThat(authHandler.isInvalidOrigin(request)).isTrue();
         request.headers().add(HttpHeaderNames.ORIGIN, "zuul-push.foo.com");
-        assertTrue(authHandler.isInvalidOrigin(request));
+        assertThat(authHandler.isInvalidOrigin(request)).isTrue();
 
         // Valid input
         request.headers().remove(HttpHeaderNames.ORIGIN);
         request.headers().add(HttpHeaderNames.ORIGIN, "zuul-push.netflix.com");
-        assertFalse(authHandler.isInvalidOrigin(request));
+        assertThat(authHandler.isInvalidOrigin(request)).isFalse();
     }
 
     class ZuulPushAuthHandlerTest extends PushAuthHandler {

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushConnectionRegistryTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushConnectionRegistryTest.java
@@ -16,9 +16,7 @@
 
 package com.netflix.zuul.netty.server.push;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -40,11 +38,11 @@ class PushConnectionRegistryTest {
 
     @Test
     void testPutAndGet() {
-        assertNull(pushConnectionRegistry.get("clientId1"));
+        assertThat(pushConnectionRegistry.get("clientId1")).isNull();
 
         pushConnectionRegistry.put("clientId1", pushConnection);
 
-        assertEquals(pushConnection, pushConnectionRegistry.get("clientId1"));
+        assertThat(pushConnectionRegistry.get("clientId1")).isEqualTo(pushConnection);
     }
 
     @Test
@@ -54,15 +52,15 @@ class PushConnectionRegistryTest {
 
         List<PushConnection> connections = pushConnectionRegistry.getAll();
 
-        assertEquals(2, connections.size());
+        assertThat(connections.size()).isEqualTo(2);
     }
 
     @Test
     void testMintNewSecureToken() {
         String token = pushConnectionRegistry.mintNewSecureToken();
 
-        assertNotNull(token);
-        assertEquals(20, token.length()); // 15 bytes become 20 characters when Base64-encoded
+        assertThat(token).isNotNull();
+        assertThat(token.length()).isEqualTo(20); // 15 bytes become 20 characters when Base64-encoded
     }
 
     @Test
@@ -76,16 +74,16 @@ class PushConnectionRegistryTest {
     void testRemove() {
         pushConnectionRegistry.put("clientId1", pushConnection);
 
-        assertEquals(pushConnection, pushConnectionRegistry.remove("clientId1"));
-        assertNull(pushConnectionRegistry.get("clientId1"));
+        assertThat(pushConnectionRegistry.remove("clientId1")).isEqualTo(pushConnection);
+        assertThat(pushConnectionRegistry.get("clientId1")).isNull();
     }
 
     @Test
     void testSize() {
-        assertEquals(0, pushConnectionRegistry.size());
+        assertThat(pushConnectionRegistry.size()).isEqualTo(0);
 
         pushConnectionRegistry.put("clientId1", pushConnection);
 
-        assertEquals(1, pushConnectionRegistry.size());
+        assertThat(pushConnectionRegistry.size()).isEqualTo(1);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushMessageSenderInitializerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushMessageSenderInitializerTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.netty.server.push;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.netty.channel.Channel;
@@ -54,8 +54,8 @@ class PushMessageSenderInitializerTest {
     void testInitChannel() throws Exception {
         initializer.initChannel(channel);
 
-        assertNotNull(channel.pipeline().context(HttpServerCodec.class));
-        assertNotNull(channel.pipeline().context(HttpObjectAggregator.class));
-        assertNotNull(channel.pipeline().get("mockHandler"));
+        assertThat(channel.pipeline().context(HttpServerCodec.class)).isNotNull();
+        assertThat(channel.pipeline().context(HttpObjectAggregator.class)).isNotNull();
+        assertThat(channel.pipeline().get("mockHandler")).isNotNull();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushRegistrationHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/push/PushRegistrationHandlerTest.java
@@ -15,10 +15,7 @@
  */
 package com.netflix.zuul.netty.server.push;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -151,11 +148,11 @@ class PushRegistrationHandlerTest {
         int taskListSize = handler.getScheduledFutures().size();
         doReturn(true).when(channel).isActive();
         requestClientToClose.run();
-        assertEquals(taskListSize + 1, handler.getScheduledFutures().size());
+        assertThat(handler.getScheduledFutures().size()).isEqualTo(taskListSize + 1);
         Object capture = writeCaptor.getValue();
-        assertTrue(capture instanceof TextWebSocketFrame);
+        assertThat(capture instanceof TextWebSocketFrame).isTrue();
         TextWebSocketFrame frame = (TextWebSocketFrame) capture;
-        assertEquals("_CLOSE_", frame.text());
+        assertThat(frame.text()).isEqualTo("_CLOSE_");
     }
 
     @Test
@@ -167,31 +164,31 @@ class PushRegistrationHandlerTest {
         List<ScheduledFuture<?>> copyOfFutures = new ArrayList<>(handler.getScheduledFutures());
 
         handler.channelInactive(context);
-        assertNull(registry.get(testAuth.getClientIdentity()));
-        assertTrue(handler.getScheduledFutures().isEmpty());
-        copyOfFutures.forEach(f -> assertTrue(f.isCancelled()));
+        assertThat(registry.get(testAuth.getClientIdentity())).isNull();
+        assertThat(handler.getScheduledFutures().isEmpty()).isTrue();
+        copyOfFutures.forEach(f -> assertThat(f.isCancelled()).isTrue());
         verify(context).close();
     }
 
     private void doHandshakeComplete() throws Exception {
         handler.userEventTriggered(context, PushProtocol.WEBSOCKET.getHandshakeCompleteEvent());
-        assertNotNull(handler.getPushConnection());
+        assertThat(handler.getPushConnection()).isNotNull();
         verify(eventLoopSpy).schedule(scheduledCaptor.capture(), anyLong(), eq(TimeUnit.SECONDS));
     }
 
     private void authenticateChannel() throws Exception {
         handler.userEventTriggered(context, successfulAuth);
-        assertNotNull(registry.get(successfulAuth.getClientIdentity()));
-        assertEquals(2, handler.getScheduledFutures().size());
+        assertThat(registry.get(successfulAuth.getClientIdentity())).isNotNull();
+        assertThat(handler.getScheduledFutures().size()).isEqualTo(2);
         verify(pipelineMock).remove(PushAuthHandler.NAME);
     }
 
     private void validateConnectionClosed(int expected, String messaged) {
         Object capture = writeCaptor.getValue();
-        assertTrue(capture instanceof CloseWebSocketFrame);
+        assertThat(capture instanceof CloseWebSocketFrame).isTrue();
         CloseWebSocketFrame closeFrame = (CloseWebSocketFrame) capture;
-        assertEquals(expected, closeFrame.statusCode());
-        assertEquals(messaged, closeFrame.reasonText());
+        assertThat(closeFrame.statusCode()).isEqualTo(expected);
+        assertThat(closeFrame.reasonText()).isEqualTo(messaged);
         verify(channelFuture).addListener(ChannelFutureListener.CLOSE);
     }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ssl/SslHandshakeInfoHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ssl/SslHandshakeInfoHandlerTest.java
@@ -16,9 +16,7 @@
 
 package com.netflix.zuul.netty.server.ssl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -60,13 +58,14 @@ class SslHandshakeInfoHandlerTest {
         serverChannel.pipeline().addLast(new SslHandshakeInfoHandler());
 
         Object clientHello = clientChannel.readOutbound();
-        assertNotNull(clientHello);
+        assertThat(clientHello).isNotNull();
         ReferenceCountUtil.retain(clientHello);
 
         serverChannel.writeInbound(clientHello);
 
         // Assert that the handler removes itself from the pipeline, since it was torn down.
-        assertNull(serverChannel.pipeline().context(SslHandshakeInfoHandler.class));
+        assertThat(serverChannel.pipeline().context(SslHandshakeInfoHandler.class))
+                .isNull();
     }
 
     @Test
@@ -74,14 +73,14 @@ class SslHandshakeInfoHandlerTest {
         SslHandshakeInfoHandler handler = new SslHandshakeInfoHandler();
 
         RuntimeException noMessage = new RuntimeException();
-        assertEquals(noMessage.toString(), handler.getFailureCause(noMessage));
+        assertThat(handler.getFailureCause(noMessage)).isEqualTo(noMessage.toString());
 
         RuntimeException withMessage = new RuntimeException("some unexpected message");
-        assertEquals("some unexpected message", handler.getFailureCause(withMessage));
+        assertThat(handler.getFailureCause(withMessage)).isEqualTo("some unexpected message");
 
         RuntimeException openSslMessage = new RuntimeException("javax.net.ssl.SSLHandshakeException: error:1000008e:SSL"
                 + " routines:OPENSSL_internal:DIGEST_CHECK_FAILED");
 
-        assertEquals("DIGEST_CHECK_FAILED", handler.getFailureCause(openSslMessage));
+        assertThat(handler.getFailureCause(openSslMessage)).isEqualTo("DIGEST_CHECK_FAILED");
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/ssl/BaseSslContextFactoryTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/ssl/BaseSslContextFactoryTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.netty.ssl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.handler.ssl.SslProvider;
 import org.junit.jupiter.api.Test;
@@ -27,6 +27,6 @@ import org.junit.jupiter.api.Test;
 class BaseSslContextFactoryTest {
     @Test
     void testDefaultSslProviderIsOpenSsl() {
-        assertEquals(SslProvider.OPENSSL, BaseSslContextFactory.chooseSslProvider());
+        assertThat(BaseSslContextFactory.chooseSslProvider()).isEqualTo(SslProvider.OPENSSL);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/ssl/ClientSslContextFactoryTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/ssl/ClientSslContextFactoryTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.netty.ssl;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.spectator.api.DefaultRegistry;
 import io.netty.handler.ssl.OpenSslClientContext;
@@ -36,14 +35,14 @@ class ClientSslContextFactoryTest {
     void enableTls13() {
         String[] protos = ClientSslContextFactory.maybeAddTls13(true, "TLSv1.2");
 
-        assertEquals(Arrays.asList("TLSv1.3", "TLSv1.2"), Arrays.asList(protos));
+        assertThat(Arrays.asList(protos)).isEqualTo(Arrays.asList("TLSv1.3", "TLSv1.2"));
     }
 
     @Test
     void disableTls13() {
         String[] protos = ClientSslContextFactory.maybeAddTls13(false, "TLSv1.2");
 
-        assertEquals(Arrays.asList("TLSv1.2"), Arrays.asList(protos));
+        assertThat(Arrays.asList(protos)).isEqualTo(Arrays.asList("TLSv1.2"));
     }
 
     @Test
@@ -69,6 +68,6 @@ class ClientSslContextFactoryTest {
         ClientSslContextFactory factory = new ClientSslContextFactory(new DefaultRegistry());
         List<String> ciphers = factory.getCiphers();
         assertThat(ciphers).isNotEmpty();
-        assertThat(ciphers).containsNoDuplicates();
+        assertThat(ciphers).doesNotHaveDuplicates();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/ssl/OpenSslTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/ssl/OpenSslTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.netty.ssl;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslProvider;
@@ -28,13 +27,13 @@ class OpenSslTest {
     @BeforeEach
     void beforeEach() {
         OpenSsl.ensureAvailability();
-        assertTrue(OpenSsl.isAvailable());
+        assertThat(OpenSsl.isAvailable()).isTrue();
     }
 
     @Test
     void testBoringSsl() {
         assertThat(OpenSsl.versionString()).isEqualTo("BoringSSL");
-        assertTrue(SslProvider.isAlpnSupported(SslProvider.OPENSSL));
-        assertTrue(SslProvider.isTlsv13Supported(SslProvider.OPENSSL));
+        assertThat(SslProvider.isAlpnSupported(SslProvider.OPENSSL)).isTrue();
+        assertThat(SslProvider.isTlsv13Supported(SslProvider.OPENSSL)).isTrue();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/timeouts/OriginTimeoutManagerTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.netty.timeouts;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.netflix.client.config.CommonClientConfigKey;
@@ -72,7 +72,7 @@ class OriginTimeoutManagerTest {
     void computeReadTimeout_default() {
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
 
-        assertEquals(OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS.get(), timeout.toMillis());
+        assertThat(timeout.toMillis()).isEqualTo(OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS.get());
     }
 
     @Test
@@ -81,7 +81,7 @@ class OriginTimeoutManagerTest {
 
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
 
-        assertEquals(1000, timeout.toMillis());
+        assertThat(timeout.toMillis()).isEqualTo(1000);
     }
 
     @Test
@@ -90,7 +90,7 @@ class OriginTimeoutManagerTest {
 
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
 
-        assertEquals(1000, timeout.toMillis());
+        assertThat(timeout.toMillis()).isEqualTo(1000);
     }
 
     @Test
@@ -100,7 +100,7 @@ class OriginTimeoutManagerTest {
 
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
 
-        assertEquals(1000, timeout.toMillis());
+        assertThat(timeout.toMillis()).isEqualTo(1000);
     }
 
     @Test
@@ -110,7 +110,7 @@ class OriginTimeoutManagerTest {
 
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
 
-        assertEquals(100, timeout.toMillis());
+        assertThat(timeout.toMillis()).isEqualTo(100);
     }
 
     @Test
@@ -120,7 +120,7 @@ class OriginTimeoutManagerTest {
 
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
 
-        assertEquals(100, timeout.toMillis());
+        assertThat(timeout.toMillis()).isEqualTo(100);
     }
 
     @Test
@@ -134,6 +134,6 @@ class OriginTimeoutManagerTest {
 
         Duration timeout = originTimeoutManager.computeReadTimeout(request, 1);
 
-        assertEquals(OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS.get(), timeout.toMillis());
+        assertThat(timeout.toMillis()).isEqualTo(OriginTimeoutManager.MAX_OUTBOUND_READ_TIMEOUT_MS.get());
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/niws/RequestAttemptTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/niws/RequestAttemptTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.niws;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -39,7 +39,7 @@ public class RequestAttemptTest {
         RequestAttempt attempt = new RequestAttempt(1, null, null, "target", "chosen", 200, null, null, 0, 0, 0);
         attempt.setException(new RuntimeException("runtime failure"));
 
-        assertEquals("runtime failure", attempt.getError());
+        assertThat(attempt.getError()).isEqualTo("runtime failure");
     }
 
     @Test
@@ -51,8 +51,8 @@ public class RequestAttemptTest {
                 new SSLHandshakeException("Invalid tls cert"),
                 OutboundErrorType.CONNECT_ERROR));
 
-        assertEquals("ORIGIN_CONNECT_ERROR", attempt.getError());
-        assertEquals("Invalid tls cert", attempt.getCause());
+        assertThat(attempt.getError()).isEqualTo("ORIGIN_CONNECT_ERROR");
+        assertThat(attempt.getCause()).isEqualTo("Invalid tls cert");
     }
 
     @Test
@@ -65,8 +65,8 @@ public class RequestAttemptTest {
         attempt.setException(new OriginConnectException(
                 "origin connect failure", handshakeException, OutboundErrorType.CONNECT_ERROR));
 
-        assertEquals("ORIGIN_CONNECT_ERROR", attempt.getError());
-        assertEquals("Cert doesn't match expected", attempt.getCause());
+        assertThat(attempt.getError()).isEqualTo("ORIGIN_CONNECT_ERROR");
+        assertThat(attempt.getCause()).isEqualTo("Cert doesn't match expected");
     }
 
     @Test
@@ -77,8 +77,8 @@ public class RequestAttemptTest {
                 new IOException(new RuntimeException("socket failure")),
                 OutboundErrorType.CONNECT_ERROR));
 
-        assertEquals("ORIGIN_CONNECT_ERROR", attempt.getError());
-        assertEquals("java.lang.RuntimeException: socket failure", attempt.getCause());
+        assertThat(attempt.getError()).isEqualTo("ORIGIN_CONNECT_ERROR");
+        assertThat(attempt.getCause()).isEqualTo("java.lang.RuntimeException: socket failure");
     }
 
     @Test
@@ -107,11 +107,12 @@ public class RequestAttemptTest {
         RequestAttempt attempt = new RequestAttempt(1, null, null, "target", "chosen", 200, null, null, 0, 0, 0);
         attempt.setException(h2Exception);
 
-        assertEquals("Cannot create stream 100 greater than Last-Stream-ID 99 from GOAWAY.", attempt.getError());
-        assertEquals("StreamException", attempt.getExceptionType());
+        assertThat(attempt.getError())
+                .isEqualTo("Cannot create stream 100 greater than Last-Stream-ID 99 from GOAWAY.");
+        assertThat(attempt.getExceptionType()).isEqualTo("StreamException");
 
-        assertEquals(
-                "io.netty.handler.codec.http2.DefaultHttp2Connection.createStream(DefaultHttp2Connection.java:772)",
-                attempt.getCause());
+        assertThat(attempt.getCause())
+                .isEqualTo(
+                        "io.netty.handler.codec.http2.DefaultHttp2Connection.createStream(DefaultHttp2Connection.java:772)");
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/origins/OriginNameTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/origins/OriginNameTest.java
@@ -16,8 +16,8 @@
 
 package com.netflix.zuul.origins;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,15 +26,15 @@ class OriginNameTest {
     void getAuthority() {
         OriginName trusted = OriginName.fromVipAndApp("woodly-doodly", "westerndigital");
 
-        assertEquals("westerndigital", trusted.getAuthority());
+        assertThat(trusted.getAuthority()).isEqualTo("westerndigital");
     }
 
     @Test
     void getMetrics() {
         OriginName trusted = OriginName.fromVipAndApp("WOODLY-doodly", "westerndigital");
 
-        assertEquals("woodly-doodly", trusted.getMetricId());
-        assertEquals("WOODLY-doodly", trusted.getNiwsClientName());
+        assertThat(trusted.getMetricId()).isEqualTo("woodly-doodly");
+        assertThat(trusted.getNiwsClientName()).isEqualTo("WOODLY-doodly");
     }
 
     @Test
@@ -42,8 +42,8 @@ class OriginNameTest {
         OriginName name1 = OriginName.fromVipAndApp("woodly-doodly", "westerndigital");
         OriginName name2 = OriginName.fromVipAndApp("woodly-doodly", "westerndigital", "woodly-doodly");
 
-        assertEquals(name1, name2);
-        assertEquals(name1.hashCode(), name2.hashCode());
+        assertThat(name2).isEqualTo(name1);
+        assertThat(name2.hashCode()).isEqualTo(name1.hashCode());
     }
 
     @Test
@@ -52,8 +52,8 @@ class OriginNameTest {
         OriginName name1 = OriginName.fromVip("woodly-doodly", "westerndigital");
         OriginName name2 = OriginName.fromVipAndApp("woodly-doodly", "woodly", "westerndigital");
 
-        assertEquals(name1, name2);
-        assertEquals(name1.hashCode(), name2.hashCode());
+        assertThat(name2).isEqualTo(name1);
+        assertThat(name2.hashCode()).isEqualTo(name1.hashCode());
     }
 
     @Test
@@ -61,16 +61,18 @@ class OriginNameTest {
         OriginName name1 = OriginName.fromVip("woodly-doodly");
         OriginName name2 = OriginName.fromVipAndApp("woodly-doodly", "woodly", "woodly-doodly");
 
-        assertEquals(name1, name2);
-        assertEquals(name1.hashCode(), name2.hashCode());
+        assertThat(name2).isEqualTo(name1);
+        assertThat(name2.hashCode()).isEqualTo(name1.hashCode());
     }
 
     @Test
     void noNull() {
-        assertThrows(NullPointerException.class, () -> OriginName.fromVipAndApp(null, "app"));
-        assertThrows(NullPointerException.class, () -> OriginName.fromVipAndApp("vip", null));
-        assertThrows(NullPointerException.class, () -> OriginName.fromVipAndApp(null, "app", "niws"));
-        assertThrows(NullPointerException.class, () -> OriginName.fromVipAndApp("vip", null, "niws"));
-        assertThrows(NullPointerException.class, () -> OriginName.fromVipAndApp("vip", "app", null));
+        assertThatThrownBy(() -> OriginName.fromVipAndApp(null, "app")).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> OriginName.fromVipAndApp("vip", null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> OriginName.fromVipAndApp(null, "app", "niws"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> OriginName.fromVipAndApp("vip", null, "niws"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> OriginName.fromVipAndApp("vip", "app", null)).isInstanceOf(NullPointerException.class);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/passport/CurrentPassportTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/passport/CurrentPassportTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.passport;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -32,9 +31,9 @@ class CurrentPassportTest {
 
         List<StartAndEnd> pairs = passport.findEachPairOf(
                 PassportState.IN_REQ_HEADERS_RECEIVED, PassportState.IN_REQ_LAST_CONTENT_RECEIVED);
-        assertEquals(1, pairs.size());
-        assertEquals(0, pairs.get(0).startTime);
-        assertEquals(50, pairs.get(0).endTime);
+        assertThat(pairs.size()).isEqualTo(1);
+        assertThat(pairs.get(0).startTime).isEqualTo(0);
+        assertThat(pairs.get(0).endTime).isEqualTo(50);
     }
 
     @Test
@@ -45,11 +44,11 @@ class CurrentPassportTest {
                         + " +350=FILTERS_INBOUND_END, +400=MISC_IO_STOP, +1117794707=NOW]}");
 
         List<StartAndEnd> pairs = passport.findEachPairOf(PassportState.MISC_IO_START, PassportState.MISC_IO_STOP);
-        assertEquals(2, pairs.size());
-        assertEquals(200, pairs.get(0).startTime);
-        assertEquals(250, pairs.get(0).endTime);
-        assertEquals(300, pairs.get(1).startTime);
-        assertEquals(400, pairs.get(1).endTime);
+        assertThat(pairs.size()).isEqualTo(2);
+        assertThat(pairs.get(0).startTime).isEqualTo(200);
+        assertThat(pairs.get(0).endTime).isEqualTo(250);
+        assertThat(pairs.get(1).startTime).isEqualTo(300);
+        assertThat(pairs.get(1).endTime).isEqualTo(400);
     }
 
     @Test
@@ -59,7 +58,7 @@ class CurrentPassportTest {
 
         List<StartAndEnd> pairs = passport.findEachPairOf(
                 PassportState.IN_REQ_HEADERS_RECEIVED, PassportState.IN_REQ_LAST_CONTENT_RECEIVED);
-        assertEquals(0, pairs.size());
+        assertThat(pairs.size()).isEqualTo(0);
     }
 
     @Test
@@ -70,7 +69,7 @@ class CurrentPassportTest {
 
         List<StartAndEnd> pairs = passport.findEachPairOf(
                 PassportState.IN_REQ_HEADERS_RECEIVED, PassportState.IN_REQ_LAST_CONTENT_RECEIVED);
-        assertEquals(0, pairs.size());
+        assertThat(pairs.size()).isEqualTo(0);
     }
 
     @Test
@@ -81,7 +80,7 @@ class CurrentPassportTest {
 
         List<StartAndEnd> pairs = passport.findEachPairOf(
                 PassportState.IN_REQ_HEADERS_RECEIVED, PassportState.IN_REQ_LAST_CONTENT_RECEIVED);
-        assertEquals(0, pairs.size());
+        assertThat(pairs.size()).isEqualTo(0);
     }
 
     @Test
@@ -90,12 +89,12 @@ class CurrentPassportTest {
                 "CurrentPassport {start_ms=0, [+0=FILTERS_INBOUND_START, +50=IN_REQ_LAST_CONTENT_RECEIVED,"
                         + " +200=MISC_IO_START, +250=IN_REQ_HEADERS_RECEIVED, +1117794707=NOW]}");
 
-        assertEquals(
-                200, passport.findStateBackwards(PassportState.MISC_IO_START).getTime());
+        assertThat(passport.findStateBackwards(PassportState.MISC_IO_START).getTime())
+                .isEqualTo(200);
     }
 
     @Test
     void testGetStateWithNoHistory() {
-        assertNull(CurrentPassport.create().getState());
+        assertThat(CurrentPassport.create().getState()).isNull();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/stats/ErrorStatsDataTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/stats/ErrorStatsDataTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.stats;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,9 +32,9 @@ class ErrorStatsDataTest {
     void testUpdateStats() {
         ErrorStatsData sd = new ErrorStatsData("route", "test");
         sd.update();
-        assertEquals(1, sd.getCount());
+        assertThat(sd.getCount()).isEqualTo(1);
         sd.update();
-        assertEquals(2, sd.getCount());
+        assertThat(sd.getCount()).isEqualTo(2);
     }
 
     @Test
@@ -45,10 +44,9 @@ class ErrorStatsDataTest {
         ErrorStatsData sd2 = new ErrorStatsData("route", "test1");
         ErrorStatsData sd3 = new ErrorStatsData("route", "test");
 
-        assertEquals(sd, sd1);
-        assertEquals(sd1, sd);
-        assertEquals(sd, sd);
-        assertNotEquals(sd, sd2);
-        assertNotEquals(sd2, sd3);
+        assertThat(sd1).isEqualTo(sd);
+        assertThat(sd).isEqualTo(sd1);
+        assertThat(sd).isNotEqualTo(sd2);
+        assertThat(sd2).isNotEqualTo(sd3);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/stats/ErrorStatsManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/stats/ErrorStatsManagerTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.stats;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.Test;
@@ -33,21 +32,21 @@ class ErrorStatsManagerTest {
     @Test
     void testPutStats() {
         ErrorStatsManager sm = new ErrorStatsManager();
-        assertNotNull(sm);
+        assertThat(sm).isNotNull();
         sm.putStats("test", "cause");
-        assertNotNull(sm.routeMap.get("test"));
+        assertThat(sm.routeMap.get("test")).isNotNull();
         ConcurrentHashMap<String, ErrorStatsData> map = sm.routeMap.get("test");
         ErrorStatsData sd = map.get("cause");
-        assertEquals(1, sd.getCount());
+        assertThat(sd.getCount()).isEqualTo(1);
         sm.putStats("test", "cause");
-        assertEquals(2, sd.getCount());
+        assertThat(sd.getCount()).isEqualTo(2);
     }
 
     @Test
     void testGetStats() {
         ErrorStatsManager sm = new ErrorStatsManager();
-        assertNotNull(sm);
+        assertThat(sm).isNotNull();
         sm.putStats("test", "cause");
-        assertNotNull(sm.getStats("test", "cause"));
+        assertThat(sm.getStats("test", "cause")).isNotNull();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/stats/RouteStatusCodeMonitorTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/stats/RouteStatusCodeMonitorTest.java
@@ -16,8 +16,7 @@
 
 package com.netflix.zuul.stats;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,11 +27,11 @@ class RouteStatusCodeMonitorTest {
     @Test
     void testUpdateStats() {
         RouteStatusCodeMonitor sd = new RouteStatusCodeMonitor("test", 200);
-        assertEquals("test", sd.route);
+        assertThat(sd.route).isEqualTo("test");
         sd.update();
-        assertEquals(1, sd.getCount());
+        assertThat(sd.getCount()).isEqualTo(1);
         sd.update();
-        assertEquals(2, sd.getCount());
+        assertThat(sd.getCount()).isEqualTo(2);
     }
 
     @Test
@@ -42,11 +41,10 @@ class RouteStatusCodeMonitorTest {
         RouteStatusCodeMonitor sd2 = new RouteStatusCodeMonitor("test1", 200);
         RouteStatusCodeMonitor sd3 = new RouteStatusCodeMonitor("test", 201);
 
-        assertEquals(sd, sd1);
-        assertEquals(sd1, sd);
-        assertEquals(sd, sd);
-        assertNotEquals(sd, sd2);
-        assertNotEquals(sd, sd3);
-        assertNotEquals(sd2, sd3);
+        assertThat(sd1).isEqualTo(sd);
+        assertThat(sd).isEqualTo(sd1);
+        assertThat(sd).isNotEqualTo(sd2);
+        assertThat(sd).isNotEqualTo(sd3);
+        assertThat(sd2).isNotEqualTo(sd3);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/stats/StatsManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/stats/StatsManagerTest.java
@@ -16,10 +16,7 @@
 
 package com.netflix.zuul.stats;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.netflix.zuul.message.Headers;
@@ -42,13 +39,13 @@ class StatsManagerTest {
         int status = 500;
 
         StatsManager sm = StatsManager.getManager();
-        assertNotNull(sm);
+        assertThat(sm).isNotNull();
 
         // 1st request
         sm.collectRouteStats(route, status);
 
         ConcurrentHashMap<Integer, RouteStatusCodeMonitor> routeStatusMap = sm.routeStatusMap.get("test");
-        assertNotNull(routeStatusMap);
+        assertThat(routeStatusMap).isNotNull();
 
         // 2nd request
         sm.collectRouteStats(route, status);
@@ -57,9 +54,9 @@ class StatsManagerTest {
     @Test
     void testGetRouteStatusCodeMonitor() {
         StatsManager sm = StatsManager.getManager();
-        assertNotNull(sm);
+        assertThat(sm).isNotNull();
         sm.collectRouteStats("test", 500);
-        assertNotNull(sm.getRouteStatusCodeMonitor("test", 500));
+        assertThat(sm.getRouteStatusCodeMonitor("test", 500)).isNotNull();
     }
 
     @Test
@@ -78,39 +75,42 @@ class StatsManagerTest {
         sm.collectRequestStats(req);
 
         NamedCountingMonitor hostMonitor = sm.getHostMonitor(host);
-        assertNotNull(hostMonitor, "hostMonitor should not be null");
+        assertThat(hostMonitor).as("hostMonitor should not be null").isNotNull();
 
         NamedCountingMonitor protoMonitor = sm.getProtocolMonitor(proto);
-        assertNotNull(protoMonitor, "protoMonitor should not be null");
+        assertThat(protoMonitor).as("protoMonitor should not be null").isNotNull();
 
-        assertEquals(1, hostMonitor.getCount());
-        assertEquals(1, protoMonitor.getCount());
+        assertThat(hostMonitor.getCount()).isEqualTo(1);
+        assertThat(protoMonitor.getCount()).isEqualTo(1);
     }
 
     @Test
     void createsNormalizedHostKey() {
-        assertEquals("host_EC2.amazonaws.com", StatsManager.hostKey("ec2-174-129-179-89.compute-1.amazonaws.com"));
-        assertEquals("host_IP", StatsManager.hostKey("12.345.6.789"));
-        assertEquals("host_IP", StatsManager.hostKey("ip-10-86-83-168"));
-        assertEquals("host_CDN.nflxvideo.net", StatsManager.hostKey("002.ie.llnw.nflxvideo.net"));
-        assertEquals("host_CDN.llnwd.net", StatsManager.hostKey("netflix-635.vo.llnwd.net"));
-        assertEquals("host_CDN.nflximg.com", StatsManager.hostKey("cdn-0.nflximg.com"));
+        assertThat(StatsManager.hostKey("ec2-174-129-179-89.compute-1.amazonaws.com"))
+                .isEqualTo("host_EC2.amazonaws.com");
+        assertThat(StatsManager.hostKey("12.345.6.789")).isEqualTo("host_IP");
+        assertThat(StatsManager.hostKey("ip-10-86-83-168")).isEqualTo("host_IP");
+        assertThat(StatsManager.hostKey("002.ie.llnw.nflxvideo.net")).isEqualTo("host_CDN.nflxvideo.net");
+        assertThat(StatsManager.hostKey("netflix-635.vo.llnwd.net")).isEqualTo("host_CDN.llnwd.net");
+        assertThat(StatsManager.hostKey("cdn-0.nflximg.com")).isEqualTo("host_CDN.nflximg.com");
     }
 
     @Test
     void extractsClientIpFromXForwardedFor() {
         String ip1 = "hi";
         String ip2 = "hey";
-        assertEquals(ip1, StatsManager.extractClientIpFromXForwardedFor(ip1));
-        assertEquals(ip1, StatsManager.extractClientIpFromXForwardedFor(String.format("%s,%s", ip1, ip2)));
-        assertEquals(ip1, StatsManager.extractClientIpFromXForwardedFor(String.format("%s, %s", ip1, ip2)));
+        assertThat(StatsManager.extractClientIpFromXForwardedFor(ip1)).isEqualTo(ip1);
+        assertThat(StatsManager.extractClientIpFromXForwardedFor(String.format("%s,%s", ip1, ip2)))
+                .isEqualTo(ip1);
+        assertThat(StatsManager.extractClientIpFromXForwardedFor(String.format("%s, %s", ip1, ip2)))
+                .isEqualTo(ip1);
     }
 
     @Test
     void isIPv6() {
-        assertTrue(StatsManager.isIPv6("0:0:0:0:0:0:0:1"));
-        assertTrue(StatsManager.isIPv6("2607:fb10:2:232:72f3:95ff:fe03:a6e7"));
-        assertFalse(StatsManager.isIPv6("127.0.0.1"));
-        assertFalse(StatsManager.isIPv6("10.2.233.134"));
+        assertThat(StatsManager.isIPv6("0:0:0:0:0:0:0:1")).isTrue();
+        assertThat(StatsManager.isIPv6("2607:fb10:2:232:72f3:95ff:fe03:a6e7")).isTrue();
+        assertThat(StatsManager.isIPv6("127.0.0.1")).isFalse();
+        assertThat(StatsManager.isIPv6("10.2.233.134")).isFalse();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/stats/status/ZuulStatusCategoryTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/stats/status/ZuulStatusCategoryTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.stats.status;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -33,6 +33,6 @@ public class ZuulStatusCategoryTest {
     public void categoriesUseUniqueIds() {
         ZuulStatusCategory[] values = ZuulStatusCategory.values();
         Set<String> ids = Arrays.stream(values).map(ZuulStatusCategory::getId).collect(Collectors.toSet());
-        assertEquals(values.length, ids.size());
+        assertThat(ids.size()).isEqualTo(values.length);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
@@ -16,11 +16,7 @@
 
 package com.netflix.zuul.util;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.Headers;
@@ -40,56 +36,56 @@ class HttpUtilsTest {
 
     @Test
     void detectsGzip() {
-        assertTrue(HttpUtils.isCompressed("gzip"));
+        assertThat(HttpUtils.isCompressed("gzip")).isTrue();
     }
 
     @Test
     void detectsDeflate() {
-        assertTrue(HttpUtils.isCompressed("deflate"));
+        assertThat(HttpUtils.isCompressed("deflate")).isTrue();
     }
 
     @Test
     void detectsCompress() {
-        assertTrue(HttpUtils.isCompressed("compress"));
+        assertThat(HttpUtils.isCompressed("compress")).isTrue();
     }
 
     @Test
     void detectsBR() {
-        assertTrue(HttpUtils.isCompressed("br"));
+        assertThat(HttpUtils.isCompressed("br")).isTrue();
     }
 
     @Test
     void detectsNonGzip() {
-        assertFalse(HttpUtils.isCompressed("identity"));
+        assertThat(HttpUtils.isCompressed("identity")).isFalse();
     }
 
     @Test
     void detectsGzipAmongOtherEncodings() {
-        assertTrue(HttpUtils.isCompressed("gzip, deflate"));
+        assertThat(HttpUtils.isCompressed("gzip, deflate")).isTrue();
     }
 
     @Test
     void acceptsGzip() {
         Headers headers = new Headers();
         headers.add("Accept-Encoding", "gzip, deflate");
-        assertTrue(HttpUtils.acceptsGzip(headers));
+        assertThat(HttpUtils.acceptsGzip(headers)).isTrue();
     }
 
     @Test
     void acceptsGzip_only() {
         Headers headers = new Headers();
         headers.add("Accept-Encoding", "deflate");
-        assertFalse(HttpUtils.acceptsGzip(headers));
+        assertThat(HttpUtils.acceptsGzip(headers)).isFalse();
     }
 
     @Test
     void stripMaliciousHeaderChars() {
-        assertEquals("something", HttpUtils.stripMaliciousHeaderChars("some\r\nthing"));
-        assertEquals("some thing", HttpUtils.stripMaliciousHeaderChars("some thing"));
-        assertEquals("something", HttpUtils.stripMaliciousHeaderChars("\nsome\r\nthing\r"));
-        assertEquals("", HttpUtils.stripMaliciousHeaderChars("\r"));
-        assertEquals("", HttpUtils.stripMaliciousHeaderChars(""));
-        assertNull(HttpUtils.stripMaliciousHeaderChars(null));
+        assertThat(HttpUtils.stripMaliciousHeaderChars("some\r\nthing")).isEqualTo("something");
+        assertThat(HttpUtils.stripMaliciousHeaderChars("some thing")).isEqualTo("some thing");
+        assertThat(HttpUtils.stripMaliciousHeaderChars("\nsome\r\nthing\r")).isEqualTo("something");
+        assertThat(HttpUtils.stripMaliciousHeaderChars("\r")).isEqualTo("");
+        assertThat(HttpUtils.stripMaliciousHeaderChars("")).isEqualTo("");
+        assertThat(HttpUtils.stripMaliciousHeaderChars(null)).isNull();
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/zuul/util/JsonUtilityTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/util/JsonUtilityTest.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -38,7 +38,7 @@ class JsonUtilityTest {
         String json = JsonUtility.jsonFromMap(jsonData);
         String expected = "{\"myKey\":\"myValue\"}";
 
-        assertEquals(expected, json);
+        assertThat(json).isEqualTo(expected);
     }
 
     @Test
@@ -50,7 +50,7 @@ class JsonUtilityTest {
         String json = JsonUtility.jsonFromMap(jsonData);
         String expected = "{\"myKey\":\"myValue\",\"myKey2\":\"myValue2\"}";
 
-        assertEquals(expected, json);
+        assertThat(json).isEqualTo(expected);
     }
 
     @Test
@@ -66,7 +66,7 @@ class JsonUtilityTest {
         String json = JsonUtility.jsonFromMap(jsonData);
         String expected = "{\"myKey\":\"myValue\",\"myNestedData\":{\"myNestedKey\":\"myNestedValue\"}}";
 
-        assertEquals(expected, json);
+        assertThat(json).isEqualTo(expected);
     }
 
     @Test
@@ -84,7 +84,7 @@ class JsonUtilityTest {
         String expected =
                 "{\"myKey\":\"myValue\",\"myNestedData\":{\"myNestedKey\":\"myNestedValue\",\"myNestedKey2\":\"myNestedValue2\"}}";
 
-        assertEquals(expected, json);
+        assertThat(json).isEqualTo(expected);
     }
 
     @Test
@@ -96,7 +96,7 @@ class JsonUtilityTest {
         String json = JsonUtility.jsonFromMap(jsonData);
         String expected = "{\"myKey\":[1,2,3,4]}";
 
-        assertEquals(expected, json);
+        assertThat(json).isEqualTo(expected);
     }
 
     @Test
@@ -108,7 +108,7 @@ class JsonUtilityTest {
         String json = JsonUtility.jsonFromMap(jsonData);
         String expected = "{\"myKey\":[\"one\",\"two\",\"three\",\"four\"]}";
 
-        assertEquals(expected, json);
+        assertThat(json).isEqualTo(expected);
     }
 
     @Test
@@ -124,7 +124,7 @@ class JsonUtilityTest {
         String json = JsonUtility.jsonFromMap(jsonData);
         String expected = "{\"myKey\":[\"one\",\"two\",\"three\",\"four\"]}";
 
-        assertEquals(expected, json);
+        assertThat(json).isEqualTo(expected);
     }
 
     @Test
@@ -146,7 +146,7 @@ class JsonUtilityTest {
         String expected =
                 "{\"myKey\":\"myValue\",\"myNumbers\":[1,2,3,4],\"myNestedData\":{\"myNestedKey\":\"myNestedValue\",\"myNestedKey2\":\"myNestedValue2\",\"myStringNumbers\":[\"one\",\"two\",\"three\",\"four\"]}}";
 
-        assertEquals(expected, json);
+        assertThat(json).isEqualTo(expected);
     }
 
     @Test
@@ -170,6 +170,6 @@ class JsonUtilityTest {
         String expected =
                 "{\"messages\":[{\"a\":\"valueA1\",\"b\":\"valueB1\"},{\"a\":\"valueA2\",\"b\":\"valueB2\"}]}";
 
-        assertEquals(expected, json);
+        assertThat(json).isEqualTo(expected);
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/util/VipUtilsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/util/VipUtilsTest.java
@@ -16,8 +16,8 @@
 
 package com.netflix.zuul.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,24 +27,29 @@ import org.junit.jupiter.api.Test;
 class VipUtilsTest {
     @Test
     void testGetVIPPrefix() {
-        assertThrows(NullPointerException.class, () -> {
-            assertEquals("api-test", VipUtils.getVIPPrefix("api-test.netflix.net:7001"));
-            assertEquals("api-test", VipUtils.getVIPPrefix("api-test.netflix.net"));
-            assertEquals("api-test", VipUtils.getVIPPrefix("api-test:7001"));
-            assertEquals("api-test", VipUtils.getVIPPrefix("api-test"));
-            assertEquals("", VipUtils.getVIPPrefix(""));
-            VipUtils.getVIPPrefix(null);
-        });
+        assertThatThrownBy(() -> {
+                    assertThat(VipUtils.getVIPPrefix("api-test.netflix.net:7001"))
+                            .isEqualTo("api-test");
+                    assertThat(VipUtils.getVIPPrefix("api-test.netflix.net")).isEqualTo("api-test");
+                    assertThat(VipUtils.getVIPPrefix("api-test:7001")).isEqualTo("api-test");
+                    assertThat(VipUtils.getVIPPrefix("api-test")).isEqualTo("api-test");
+                    assertThat(VipUtils.getVIPPrefix("")).isEqualTo("");
+                    VipUtils.getVIPPrefix(null);
+                })
+                .isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void testExtractAppNameFromVIP() {
-        assertThrows(NullPointerException.class, () -> {
-            assertEquals("api", VipUtils.extractUntrustedAppNameFromVIP("api-test.netflix.net:7001"));
-            assertEquals("api", VipUtils.extractUntrustedAppNameFromVIP("api-test-blah.netflix.net:7001"));
-            assertEquals("api", VipUtils.extractUntrustedAppNameFromVIP("api"));
-            assertEquals("", VipUtils.extractUntrustedAppNameFromVIP(""));
-            VipUtils.extractUntrustedAppNameFromVIP(null);
-        });
+        assertThatThrownBy(() -> {
+                    assertThat(VipUtils.extractUntrustedAppNameFromVIP("api-test.netflix.net:7001"))
+                            .isEqualTo("api");
+                    assertThat(VipUtils.extractUntrustedAppNameFromVIP("api-test-blah.netflix.net:7001"))
+                            .isEqualTo("api");
+                    assertThat(VipUtils.extractUntrustedAppNameFromVIP("api")).isEqualTo("api");
+                    assertThat(VipUtils.extractUntrustedAppNameFromVIP("")).isEqualTo("");
+                    VipUtils.extractUntrustedAppNameFromVIP(null);
+                })
+                .isInstanceOf(NullPointerException.class);
     }
 }

--- a/zuul-discovery/build.gradle
+++ b/zuul-discovery/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     testImplementation libraries.jupiterApi, libraries.jupiterParams, libraries.jupiterEngine, libraries.junitPlatformLauncher,
             libraries.mockito,
-            libraries.truth
+            libraries.assertj
 }
 
 test {

--- a/zuul-discovery/dependencies.lock
+++ b/zuul-discovery/dependencies.lock
@@ -90,9 +90,6 @@
         "com.google.guava:guava": {
             "locked": "33.3.0-jre"
         },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
-        },
         "com.netflix.eureka:eureka-client": {
             "locked": "2.0.4"
         },
@@ -111,6 +108,9 @@
         "com.netflix.servo:servo-core": {
             "locked": "0.13.2"
         },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
+        },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.13.4"
         },
@@ -124,7 +124,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.19.0"
+            "locked": "5.20.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.36"
@@ -174,9 +174,6 @@
         "com.google.guava:guava": {
             "locked": "33.3.0-jre"
         },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
-        },
         "com.netflix.eureka:eureka-client": {
             "locked": "2.0.4"
         },
@@ -195,6 +192,9 @@
         "com.netflix.servo:servo-core": {
             "locked": "0.13.2"
         },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
+        },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.13.4"
         },
@@ -208,7 +208,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.19.0"
+            "locked": "5.20.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.16"
@@ -218,9 +218,6 @@
         "com.google.guava:guava": {
             "locked": "33.3.0-jre"
         },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
-        },
         "com.netflix.eureka:eureka-client": {
             "locked": "2.0.4"
         },
@@ -239,6 +236,9 @@
         "com.netflix.servo:servo-core": {
             "locked": "0.13.2"
         },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
+        },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.13.4"
         },
@@ -252,7 +252,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.19.0"
+            "locked": "5.20.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.16"

--- a/zuul-discovery/src/main/java/com/netflix/zuul/discovery/DiscoveryResult.java
+++ b/zuul-discovery/src/main/java/com/netflix/zuul/discovery/DiscoveryResult.java
@@ -131,7 +131,8 @@ public final class DiscoveryResult implements ResolverResult {
         return new SimpleMetaInfo(server.getMetaInfo());
     }
 
-    @Nullable public String getAvailabilityZone() {
+    @Nullable
+    public String getAvailabilityZone() {
         InstanceInfo instanceInfo = server.getInstanceInfo();
         if (instanceInfo.getDataCenterInfo() instanceof AmazonInfo) {
             return ((AmazonInfo) instanceInfo.getDataCenterInfo()).getMetadata().get("availability-zone");

--- a/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DiscoveryResultTest.java
+++ b/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DiscoveryResultTest.java
@@ -16,10 +16,8 @@
 
 package com.netflix.zuul.discovery;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.truth.Truth;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.appinfo.InstanceInfo.PortType;
 import com.netflix.client.config.DefaultClientConfigImpl;
@@ -34,21 +32,20 @@ class DiscoveryResultTest {
     @Test
     void hashCodeForNull() {
         DiscoveryResult discoveryResult = new DiscoveryResult(null);
-        assertNotNull(discoveryResult.hashCode());
-        assertEquals(0, discoveryResult.hashCode());
+        assertThat(discoveryResult.hashCode()).isEqualTo(0);
     }
 
     @Test
     void serverStatsForEmptySentinel() {
-        Truth.assertThat(DiscoveryResult.EMPTY.getServerStats().toString()).isEqualTo("no stats configured for server");
+        assertThat(DiscoveryResult.EMPTY.getServerStats().toString()).isEqualTo("no stats configured for server");
     }
 
     @Test
     void hostAndPortForNullServer() {
         DiscoveryResult discoveryResult = new DiscoveryResult(null);
 
-        assertEquals("undefined", discoveryResult.getHost());
-        assertEquals(-1, discoveryResult.getPort());
+        assertThat(discoveryResult.getHost()).isEqualTo("undefined");
+        assertThat(discoveryResult.getPort()).isEqualTo(-1);
     }
 
     @Test
@@ -66,7 +63,7 @@ class DiscoveryResultTest {
         DiscoveryResult result = new DiscoveryResult(server, lb.getLoadBalancerStats());
         DiscoveryResult result1 = new DiscoveryResult(serverSecure, lb.getLoadBalancerStats());
 
-        Truth.assertThat(result.getServerStats()).isSameInstanceAs(result1.getServerStats());
+        assertThat(result.getServerStats()).isSameAs(result1.getServerStats());
     }
 
     @Test
@@ -89,7 +86,7 @@ class DiscoveryResultTest {
         DiscoveryResult result = new DiscoveryResult(server, lb.getLoadBalancerStats());
         DiscoveryResult result1 = new DiscoveryResult(serverSecure, lb.getLoadBalancerStats());
 
-        Truth.assertThat(result.getServerStats()).isNotSameInstanceAs(result1.getServerStats());
+        assertThat(result.getServerStats()).isNotSameAs(result1.getServerStats());
     }
 
     @Test
@@ -106,7 +103,7 @@ class DiscoveryResultTest {
         DynamicServerListLoadBalancer<Server> lb = new DynamicServerListLoadBalancer<>(new DefaultClientConfigImpl());
         DiscoveryResult result = new DiscoveryResult(server, lb.getLoadBalancerStats());
 
-        Truth.assertThat(result.getIPAddr()).isEqualTo(Optional.of(ipAddr));
+        assertThat(result.getIPAddr()).isEqualTo(Optional.of(ipAddr));
     }
 
     @Test
@@ -121,7 +118,7 @@ class DiscoveryResultTest {
         DynamicServerListLoadBalancer<Server> lb = new DynamicServerListLoadBalancer<>(new DefaultClientConfigImpl());
         DiscoveryResult result = new DiscoveryResult(server, lb.getLoadBalancerStats());
 
-        Truth.assertThat(result.getIPAddr()).isEqualTo(Optional.empty());
+        assertThat(result.getIPAddr()).isEqualTo(Optional.empty());
     }
 
     @Test
@@ -140,7 +137,7 @@ class DiscoveryResultTest {
         DiscoveryResult result = new DiscoveryResult(server, lb.getLoadBalancerStats());
         DiscoveryResult otherResult = new DiscoveryResult(otherServer, lb.getLoadBalancerStats());
 
-        Truth.assertThat(result).isEqualTo(otherResult);
+        assertThat(result).isEqualTo(otherResult);
     }
 
     @Test
@@ -164,7 +161,7 @@ class DiscoveryResultTest {
         DiscoveryResult result = new DiscoveryResult(server, lb.getLoadBalancerStats());
         DiscoveryResult otherResult = new DiscoveryResult(otherServer, lb.getLoadBalancerStats());
 
-        Truth.assertThat(result).isNotEqualTo(otherResult);
+        assertThat(result).isNotEqualTo(otherResult);
     }
 
     @Test
@@ -189,7 +186,7 @@ class DiscoveryResultTest {
         DiscoveryResult result = new DiscoveryResult(server, lb.getLoadBalancerStats());
         DiscoveryResult secure = new DiscoveryResult(secureServer, lb.getLoadBalancerStats());
 
-        Truth.assertThat(result.isSecurePortEnabled()).isFalse();
-        Truth.assertThat(secure.isSecurePortEnabled()).isTrue();
+        assertThat(result.isSecurePortEnabled()).isFalse();
+        assertThat(secure.isSecurePortEnabled()).isTrue();
     }
 }

--- a/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DynamicServerResolverTest.java
+++ b/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DynamicServerResolverTest.java
@@ -16,9 +16,10 @@
 
 package com.netflix.zuul.discovery;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.truth.Truth;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.niws.loadbalancer.DiscoveryEnabledServer;
@@ -66,8 +67,7 @@ class DynamicServerResolverTest {
 
         resolver.onUpdate(ImmutableList.of(server1, server2), ImmutableList.of());
 
-        Truth.assertThat(listener.updatedList())
-                .containsExactly(new DiscoveryResult(server1), new DiscoveryResult(server2));
+        assertThat(listener.updatedList()).containsExactly(new DiscoveryResult(server1), new DiscoveryResult(server2));
     }
 
     @Test
@@ -76,8 +76,8 @@ class DynamicServerResolverTest {
 
         DiscoveryResult nonExistentServer = resolver.resolve(null);
 
-        Truth.assertThat(nonExistentServer).isSameInstanceAs(DiscoveryResult.EMPTY);
-        Truth.assertThat(nonExistentServer.getHost()).isEqualTo("undefined");
-        Truth.assertThat(nonExistentServer.getPort()).isEqualTo(-1);
+        assertThat(nonExistentServer).isSameAs(DiscoveryResult.EMPTY);
+        assertThat(nonExistentServer.getHost()).isEqualTo("undefined");
+        assertThat(nonExistentServer.getPort()).isEqualTo(-1);
     }
 }

--- a/zuul-integration-test/build.gradle
+++ b/zuul-integration-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation 'org.wiremock:wiremock:3.10.0'
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
-    testImplementation libraries.truth, libraries.jupiterApi, libraries.jupiterParams, libraries.jupiterEngine, libraries.junitPlatformLauncher, libraries.jupiterMockito, libraries.okhttp
+    testImplementation libraries.assertj, libraries.jupiterApi, libraries.jupiterParams, libraries.jupiterEngine, libraries.junitPlatformLauncher, libraries.jupiterMockito, libraries.okhttp
     testImplementation "io.netty:netty-transport-native-io_uring"
 //    testImplementation "io.netty.incubator:netty-transport-native-io_uring::linux-x86_64"
     testImplementation "org.slf4j:slf4j-api:2.0.16"

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -544,9 +544,6 @@
             ],
             "locked": "33.3.1-jre"
         },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
-        },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -723,6 +720,9 @@
         },
         "org.apache.logging.log4j:log4j-slf4j2-impl": {
             "locked": "2.24.3"
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
         },
         "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
@@ -1000,9 +1000,6 @@
             ],
             "locked": "2.19.2"
         },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
-        },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -1135,6 +1132,9 @@
         "org.apache.commons:commons-lang3": {
             "locked": "3.18.0"
         },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
+        },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.13.4"
         },
@@ -1194,9 +1194,6 @@
                 "com.netflix.zuul:zuul-discovery"
             ],
             "locked": "33.3.1-jre"
-        },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -1374,6 +1371,9 @@
         },
         "org.apache.logging.log4j:log4j-slf4j2-impl": {
             "locked": "2.24.3"
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
         },
         "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [

--- a/zuul-integration-test/src/test/java/com/netflix/netty/common/metrics/CustomLeakDetector.java
+++ b/zuul-integration-test/src/test/java/com/netflix/netty/common/metrics/CustomLeakDetector.java
@@ -15,7 +15,7 @@
  */
 package com.netflix.netty.common.metrics;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -28,7 +28,7 @@ public class CustomLeakDetector extends InstrumentedResourceLeakDetector {
         List<CustomLeakDetector> leaks = GLOBAL_REGISTRY.stream()
                 .filter(detector -> detector.leakCounter.get() > 0)
                 .collect(Collectors.toList());
-        assertTrue(leaks.isEmpty(), "LEAKS DETECTED: " + leaks);
+        assertThat(leaks.isEmpty()).as("LEAKS DETECTED: " + leaks).isTrue();
     }
 
     private final String resourceTypeName;

--- a/zuul-integration-test/src/test/java/com/netflix/zuul/integration/BaseIntegrationTest.java
+++ b/zuul-integration-test/src/test/java/com/netflix/zuul/integration/BaseIntegrationTest.java
@@ -27,10 +27,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.aayushatharva.brotli4j.decoder.DecoderJNI;
 import com.aayushatharva.brotli4j.decoder.DirectDecompress;
@@ -112,8 +109,8 @@ abstract class BaseIntegrationTest {
 
     @BeforeAll
     static void beforeAll() {
-        assertTrue(ResourceLeakDetector.isEnabled());
-        assertEquals(ResourceLeakDetector.Level.PARANOID, ResourceLeakDetector.getLevel());
+        assertThat(ResourceLeakDetector.isEnabled()).isTrue();
+        assertThat(ResourceLeakDetector.getLevel()).isEqualTo(ResourceLeakDetector.Level.PARANOID);
         int wireMockPort = wireMockExtension.getPort();
         AbstractConfiguration config = ConfigurationManager.getConfigInstance();
         config.setProperty("api.ribbon.listOfServers", "127.0.0.1:" + wireMockPort);
@@ -409,7 +406,7 @@ abstract class BaseIntegrationTest {
 
         // first call just to ensure a pooled connection will be used later
         Request getRequest = setupRequestBuilder(false, false).get().build();
-        assertEquals(200, okHttp.newCall(getRequest).execute().code());
+        assertThat(okHttp.newCall(getRequest).execute().code()).isEqualTo(200);
 
         Request request = setupRequestBuilder(false, false).get().build();
         Response response = okHttp.newCall(request).execute();
@@ -425,7 +422,7 @@ abstract class BaseIntegrationTest {
         // make sure a pooled connection will be used in ProxyEndpoint
         wireMock.register(get(anyUrl()).willReturn(aResponse().withStatus(200)));
         Request getRequest = setupRequestBuilder(false, false).get().build();
-        assertEquals(200, okHttp.newCall(getRequest).execute().code());
+        assertThat(okHttp.newCall(getRequest).execute().code()).isEqualTo(200);
 
         stubFor(post(anyUrl())
                 .inScenario("retry200")
@@ -526,16 +523,16 @@ abstract class BaseIntegrationTest {
         connection.setAllowUserInteraction(false);
         connection.setRequestProperty("Accept-Encoding", "deflate");
         InputStream inputStream = connection.getInputStream();
-        assertEquals(200, connection.getResponseCode());
-        assertEquals("text/plain", connection.getHeaderField("Content-Type"));
-        assertEquals("deflate", connection.getHeaderField("Content-Encoding"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getHeaderField("Content-Type")).isEqualTo("text/plain");
+        assertThat(connection.getHeaderField("Content-Encoding")).isEqualTo("deflate");
         byte[] compressedData = IOUtils.toByteArray(inputStream);
         Inflater inflater = new Inflater();
         inflater.setInput(compressedData);
         byte[] result = new byte[1000];
         int nBytes = inflater.inflate(result);
         String text = new String(result, 0, nBytes, TestUtil.CHARSET);
-        assertEquals(expectedResponseBody, text);
+        assertThat(text).isEqualTo(expectedResponseBody);
         inputStream.close();
         connection.disconnect();
     }
@@ -556,13 +553,13 @@ abstract class BaseIntegrationTest {
         connection.setAllowUserInteraction(false);
         connection.setRequestProperty("Accept-Encoding", "gzip");
         InputStream inputStream = connection.getInputStream();
-        assertEquals(200, connection.getResponseCode());
-        assertEquals("text/plain", connection.getHeaderField("Content-Type"));
-        assertEquals("gzip", connection.getHeaderField("Content-Encoding"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getHeaderField("Content-Type")).isEqualTo("text/plain");
+        assertThat(connection.getHeaderField("Content-Encoding")).isEqualTo("gzip");
         GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream);
         byte[] data = IOUtils.toByteArray(gzipInputStream);
         String text = new String(data, TestUtil.CHARSET);
-        assertEquals(expectedResponseBody, text);
+        assertThat(text).isEqualTo(expectedResponseBody);
         inputStream.close();
         gzipInputStream.close();
         connection.disconnect();
@@ -585,15 +582,15 @@ abstract class BaseIntegrationTest {
         connection.setAllowUserInteraction(false);
         connection.setRequestProperty("Accept-Encoding", "br");
         InputStream inputStream = connection.getInputStream();
-        assertEquals(200, connection.getResponseCode());
-        assertEquals("text/plain", connection.getHeaderField("Content-Type"));
-        assertEquals("br", connection.getHeaderField("Content-Encoding"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getHeaderField("Content-Type")).isEqualTo("text/plain");
+        assertThat(connection.getHeaderField("Content-Encoding")).isEqualTo("br");
         byte[] compressedData = IOUtils.toByteArray(inputStream);
-        assertTrue(compressedData.length > 0);
+        assertThat(compressedData.length > 0).isTrue();
         DirectDecompress decompressResult = DirectDecompress.decompress(compressedData);
-        assertEquals(DecoderJNI.Status.DONE, decompressResult.getResultStatus());
-        assertEquals(
-                "Hello Hello Hello Hello Hello", new String(decompressResult.getDecompressedData(), TestUtil.CHARSET));
+        assertThat(decompressResult.getResultStatus()).isEqualTo(DecoderJNI.Status.DONE);
+        assertThat(new String(decompressResult.getDecompressedData(), TestUtil.CHARSET))
+                .isEqualTo("Hello Hello Hello Hello Hello");
 
         inputStream.close();
         connection.disconnect();
@@ -615,12 +612,12 @@ abstract class BaseIntegrationTest {
         connection.setAllowUserInteraction(false);
         connection.setRequestProperty("Accept-Encoding", ""); // no compression
         InputStream inputStream = connection.getInputStream();
-        assertEquals(200, connection.getResponseCode());
-        assertEquals("text/plain", connection.getHeaderField("Content-Type"));
-        assertNull(connection.getHeaderField("Content-Encoding"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getHeaderField("Content-Type")).isEqualTo("text/plain");
+        assertThat(connection.getHeaderField("Content-Encoding")).isNull();
         byte[] data = IOUtils.toByteArray(inputStream);
         String text = new String(data, TestUtil.CHARSET);
-        assertEquals(expectedResponseBody, text);
+        assertThat(text).isEqualTo(expectedResponseBody);
         inputStream.close();
         connection.disconnect();
     }
@@ -641,13 +638,13 @@ abstract class BaseIntegrationTest {
         connection.setAllowUserInteraction(false);
         connection.setRequestProperty("Accept-Encoding", ""); // no compression
         InputStream inputStream = connection.getInputStream();
-        assertEquals(200, connection.getResponseCode());
-        assertEquals("text/plain", connection.getHeaderField("Content-Type"));
-        assertNull(connection.getHeaderField("Content-Encoding"));
-        assertEquals("chunked", connection.getHeaderField("Transfer-Encoding"));
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getHeaderField("Content-Type")).isEqualTo("text/plain");
+        assertThat(connection.getHeaderField("Content-Encoding")).isNull();
+        assertThat(connection.getHeaderField("Transfer-Encoding")).isEqualTo("chunked");
         byte[] data = IOUtils.toByteArray(inputStream);
         String text = new String(data, TestUtil.CHARSET);
-        assertEquals(expectedResponseBody, text);
+        assertThat(text).isEqualTo(expectedResponseBody);
         inputStream.close();
         connection.disconnect();
     }

--- a/zuul-integration-test/src/test/java/com/netflix/zuul/integration/ZuulServerExtension.java
+++ b/zuul-integration-test/src/test/java/com/netflix/zuul/integration/ZuulServerExtension.java
@@ -16,7 +16,7 @@
 
 package com.netflix.zuul.integration;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.config.ConfigurationManager;
@@ -65,7 +65,7 @@ public class ZuulServerExtension implements AfterAllCallback, BeforeAllCallback 
         config.setProperty("server.outofservice.close.timeout", "0");
         bootstrap = new Bootstrap();
         bootstrap.start();
-        assertTrue(bootstrap.isRunning());
+        assertThat(bootstrap.isRunning()).isTrue();
     }
 
     @Override

--- a/zuul-integration-test/src/test/java/com/netflix/zuul/integration/server/filters/CrossThreadBoundaryFilter.java
+++ b/zuul-integration-test/src/test/java/com/netflix/zuul/integration/server/filters/CrossThreadBoundaryFilter.java
@@ -21,11 +21,10 @@ import com.netflix.zuul.filters.FilterSyncType;
 import com.netflix.zuul.filters.FilterType;
 import com.netflix.zuul.filters.http.HttpInboundFilter;
 import com.netflix.zuul.message.http.HttpRequestMessage;
-import rx.Observable;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import rx.Observable;
 
 /**
  * @author Justin Guerra

--- a/zuul-processor/build.gradle
+++ b/zuul-processor/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation project(":zuul-core")
 
     testImplementation libraries.jupiterApi, libraries.jupiterParams, libraries.jupiterEngine, libraries.junitPlatformLauncher,
-            libraries.truth
+            libraries.assertj
     testAnnotationProcessor project(":zuul-processor")
 }
 

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -310,9 +310,6 @@
             ],
             "locked": "33.3.0-jre"
         },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
-        },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -468,6 +465,9 @@
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "2.0.1"
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
         },
         "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [
@@ -940,9 +940,6 @@
         "com.google.guava:guava": {
             "locked": "33.3.0-jre"
         },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
-        },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -1054,6 +1051,9 @@
             ],
             "locked": "2.0.1"
         },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
+        },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.13.4"
         },
@@ -1092,9 +1092,6 @@
                 "com.netflix.zuul:zuul-discovery"
             ],
             "locked": "33.3.0-jre"
-        },
-        "com.google.truth:truth": {
-            "locked": "1.4.4"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -1251,6 +1248,9 @@
                 "com.netflix.zuul:zuul-core"
             ],
             "locked": "2.0.1"
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.26.3"
         },
         "org.bouncycastle:bcpkix-jdk18on": {
             "firstLevelTransitive": [

--- a/zuul-processor/src/test/java/com/netflix/zuul/filters/processor/FilterProcessorTest.java
+++ b/zuul-processor/src/test/java/com/netflix/zuul/filters/processor/FilterProcessorTest.java
@@ -16,7 +16,8 @@
 
 package com.netflix.zuul.filters.processor;
 
-import com.google.common.truth.Truth;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.netflix.zuul.StaticFilterLoader;
 import com.netflix.zuul.filters.ZuulFilter;
 import com.netflix.zuul.filters.processor.override.SubpackageFilter;
@@ -34,13 +35,15 @@ class FilterProcessorTest {
         Collection<Class<ZuulFilter<?, ?>>> filters =
                 StaticFilterLoader.loadFilterTypesFromResources(getClass().getClassLoader());
 
-        Truth.assertThat(filters)
-                .containsExactly(
-                        OuterClassFilter.class,
-                        TopLevelFilter.class,
-                        TopLevelFilter.StaticSubclassFilter.class,
-                        TopLevelFilter.SubclassFilter.class,
-                        OverrideFilter.class,
-                        SubpackageFilter.class);
+        @SuppressWarnings("unchecked")
+        Class<ZuulFilter<?, ?>>[] expected = new Class[] {
+            OuterClassFilter.class,
+            TopLevelFilter.class,
+            TopLevelFilter.StaticSubclassFilter.class,
+            TopLevelFilter.SubclassFilter.class,
+            OverrideFilter.class,
+            SubpackageFilter.class
+        };
+        assertThat(filters).containsExactlyInAnyOrder(expected);
     }
 }

--- a/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SampleSSEPushClientProtocolHandler.java
+++ b/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SampleSSEPushClientProtocolHandler.java
@@ -42,7 +42,7 @@ public class SampleSSEPushClientProtocolHandler extends PushClientProtocolHandle
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object mesg) throws Exception {
         if (mesg instanceof FullHttpRequest req) {
-            
+
             if (req.method().equals(HttpMethod.GET)
                     && PushProtocol.SSE.getPath().equals(req.uri())) {
                 ctx.pipeline().fireUserEventTriggered(PushProtocol.SSE.getHandshakeCompleteEvent());

--- a/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SampleWebSocketPushClientProtocolHandler.java
+++ b/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SampleWebSocketPushClientProtocolHandler.java
@@ -48,7 +48,7 @@ public class SampleWebSocketPushClientProtocolHandler extends PushClientProtocol
                 logger.debug("received close frame");
                 ctx.close();
             } else if (msg instanceof TextWebSocketFrame tf) {
-                
+
                 String text = tf.text();
                 logger.debug("received test frame: {}", text);
                 if (text != null && text.startsWith("ECHO ")) { // echo protocol


### PR DESCRIPTION
This replaces any usage of junit asserts or google truth with assertj.

Tweak spotless format to not format annotations and bulk format the repository again.