### PR TITLE
Make prop name follow naming convention

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -157,7 +157,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
     private static final DynamicIntegerSetProperty RETRIABLE_STATUSES_FOR_IDEMPOTENT_METHODS =
             new DynamicIntegerSetProperty("zuul.retry.allowed.statuses.idempotent", "500");
     private static final DynamicBooleanProperty ENABLE_MODERN_QUERY_PARSING =
-            new DynamicBooleanProperty("zuul.feature.enabled.modern.query.parsing", true);
+            new DynamicBooleanProperty("zuul.modern.query.parsing.enabled", true);
 
     /**
      * Indicates how long Zuul should remember throttle events for an origin.  As of this writing, throttling is used


### PR DESCRIPTION
I misunderstood the comment [here](https://github.com/Netflix/zuul/pull/2018#discussion_r2455337695) and went too quickly without double checking my assumption. 
We should use the common naming convention for consistency. 