### PR TITLE
Add reason when flagging a request to brownout

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/CommonContextKeys.java
@@ -48,6 +48,8 @@ public class CommonContextKeys {
     public static final SessionContext.Key<RequestAttempts> REQUEST_ATTEMPTS =
             SessionContext.newKey("request_attempts");
 
+    public static final SessionContext.Key<String> BROWNOUT_REASON = SessionContext.newKey("brownout_reason");
+
     public static final SessionContext.Key<IClientConfig> REST_CLIENT_CONFIG =
             SessionContext.newKey("rest_client_config");
 

--- a/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
@@ -19,6 +19,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.zuul.filters.FilterError;
 import com.netflix.zuul.message.http.HttpResponseMessage;
+import jakarta.annotation.Nullable;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,7 +31,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
-import javax.annotation.Nullable;
 import lombok.NonNull;
 
 /**
@@ -475,8 +475,22 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
         return brownoutMode;
     }
 
+    /**
+     * Flag the server is getting overloaded.
+     * @deprecated use setInBrownoutMode(String reason)
+     */
+    @Deprecated
     public void setInBrownoutMode() {
         this.brownoutMode = true;
+    }
+
+    public void setInBrownoutMode(@NonNull String reason) {
+        this.brownoutMode = true;
+        put(CommonContextKeys.BROWNOUT_REASON, reason);
+    }
+
+    public @Nullable String getBrownoutReason() {
+        return get(CommonContextKeys.BROWNOUT_REASON);
     }
 
     /**

--- a/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
@@ -139,4 +139,14 @@ class SessionContextTest {
 
         assertThat(context.containsKey(key)).isFalse();
     }
+
+    @Test
+    void setInBrownoutModeWithReason() {
+        SessionContext context = new SessionContext();
+        assertThat(context.getBrownoutReason()).isNull();
+        context.setInBrownoutMode("High CPU usage");
+
+        assertThat(context.isInBrownoutMode()).isTrue();
+        assertThat(context.getBrownoutReason()).isEqualTo("High CPU usage");
+    }
 }


### PR DESCRIPTION
Store a brownout reason in the session context and deprecate the existing no-reason-provided method.