### PR TITLE
fix(docs): correct typos found during code review

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -252,7 +252,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
         }
 
         NettyOrigin origin = null;
-        // allow implementors to override the origin with custom injection logic
+        // allow implementers to override the origin with custom injection logic
         OriginName overrideOriginName = injectCustomOriginName(request);
         if (overrideOriginName != null) {
             // Use the custom vip instead if one has been provided.

--- a/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessage.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessage.java
@@ -145,7 +145,7 @@ public interface ZuulMessage extends Cloneable {
     ZuulMessage clone();
 
     /**
-     * Returns a string that reprsents this message which is suitable for debugging.
+     * Returns a string that represents this message which is suitable for debugging.
      */
     String getInfoForLogging();
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
@@ -263,7 +263,7 @@ public class DefaultClientChannelManager implements ClientChannelManager {
         if (pool != null) {
             return pool.remove(conn);
         } else {
-            // The pool for this server no longer exists (maybe due to it failling out of
+            // The pool for this server no longer exists (maybe due to it failing out of
             // discovery).
             conn.setInPool(false);
             metrics.connsInPool().decrementAndGet();

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseServerStartup.java
@@ -157,7 +157,7 @@ public abstract class BaseServerStartup {
 
     protected void addChannelDependencies(
             ChannelConfig channelDeps,
-            @SuppressWarnings("unused") String listenAddressName) { // listenAddressName may be overriden by subclasse
+            @SuppressWarnings("unused") String listenAddressName) { // listenAddressName may be overridden by subclasse
         channelDeps.set(ZuulDependencyKeys.registry, registry);
 
         channelDeps.set(ZuulDependencyKeys.applicationInfoManager, applicationInfoManager);
@@ -185,7 +185,7 @@ public abstract class BaseServerStartup {
 
     protected void addChannelDependencies(
             ChannelConfig channelDeps,
-            @SuppressWarnings("unused") ListenerSpec listenerSpec) { // listenerSpec may be overriden by subclasses
+            @SuppressWarnings("unused") ListenerSpec listenerSpec) { // listenerSpec may be overridden by subclasses
         channelDeps.set(ZuulDependencyKeys.registry, registry);
 
         channelDeps.set(ZuulDependencyKeys.applicationInfoManager, applicationInfoManager);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -246,7 +246,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
                         // lastcontent
                         // of response to the channel, which causes this CompleteEvent to fire before we have cleaned up
                         // state. But
-                        // thats ok, so don't log in that case.
+                        // that's ok, so don't log in that case.
                         if (Objects.equals(zuulRequest.getProtocol(), "HTTP/2")) {
                             LOG.debug(
                                     "Client {} request UUID {} to {} completed with reason = {}, {}",

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
@@ -153,7 +153,7 @@ public class ClientResponseWriter extends ChannelInboundHandlerAdapter {
     }
 
     protected boolean shouldAllowPreemptiveResponse(Channel channel) {
-        // If the request timed-out while being read, then there won't have been any LastContent, but thats ok because
+        // If the request timed-out while being read, then there won't have been any LastContent, but that's ok because
         // the connection will have to be discarded anyway.
         StatusCategory status =
                 StatusCategoryUtils.getStatusCategory(ClientRequestReceiver.getRequestFromChannel(channel));

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/psk/ZuulPskServer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/psk/ZuulPskServer.java
@@ -147,7 +147,7 @@ public class ZuulPskServer extends AbstractTlsServer {
     /**
      * TODO: Ask BC folks to see if getExternalPSK can throw a checked exception
      * https://github.com/bcgit/bc-java/issues/1673
-     * We are using SneakyThrows here because getExternalPSK is an override and we cant have throws in the method signature
+     * We are using SneakyThrows here because getExternalPSK is an override and we can't have throws in the method signature
      * and we dont want to catch and wrap in RuntimeException.
      * SneakyThrows allows up to compile and it will throw the exception at runtime.
      */

--- a/zuul-sample/src/main/resources/application.properties
+++ b/zuul-sample/src/main/resources/application.properties
@@ -20,7 +20,7 @@ eureka.preferSameZone=false
 # Don't register locally running instances.
 eureka.registration.enabled=false
 
-# By default don't valudate eureka instance is from the cloud
+# By default don't validate eureka instance is from the cloud
 eureka.validateInstanceId=false
 
 # Loading Filters


### PR DESCRIPTION
Non-functional changes only:
- Fixed minor spelling mistakes in comments
- Corrected typos in user-facing strings
- No variables, logic, or functional code was modified.

Signed-off-by: Marcel Petrick <mail@marcelpetrick.it>