### PR TITLE
Update netty to 4.2.9.Final

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 versions_ribbon=2.4.4
-versions_netty=4.2.6.Final
+versions_netty=4.2.9.Final
 versions_brotli4j=1.16.0
 release.scope=patch
 release.version=3.1.0-SNAPSHOT

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -48,43 +48,43 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -173,43 +173,43 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -301,7 +301,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -310,40 +310,40 @@
             "locked": "1.10"
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -382,7 +382,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.20.0"
+            "locked": "5.21.0"
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.13.0"
@@ -462,46 +462,46 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -574,7 +574,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -583,37 +583,37 @@
             "locked": "1.10"
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -652,7 +652,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.20.0"
+            "locked": "5.21.0"
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.13.0"
@@ -717,7 +717,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -726,40 +726,40 @@
             "locked": "1.10"
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -798,7 +798,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.20.0"
+            "locked": "5.21.0"
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.13.0"

--- a/zuul-discovery/dependencies.lock
+++ b/zuul-discovery/dependencies.lock
@@ -124,7 +124,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.20.0"
+            "locked": "5.21.0"
         },
         "org.openjdk.jmh:jmh-core": {
             "locked": "1.36"
@@ -208,7 +208,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.20.0"
+            "locked": "5.21.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.16"
@@ -252,7 +252,7 @@
             "locked": "1.13.4"
         },
         "org.mockito:mockito-core": {
-            "locked": "5.20.0"
+            "locked": "5.21.0"
         },
         "org.slf4j:slf4j-api": {
             "locked": "2.0.16"

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -78,7 +78,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -102,73 +102,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -270,7 +270,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -288,46 +288,46 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -425,7 +425,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -443,46 +443,46 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -599,7 +599,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -620,76 +620,76 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -716,10 +716,10 @@
             "locked": "3.18.0"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.24.3"
+            "locked": "2.25.2"
         },
         "org.apache.logging.log4j:log4j-slf4j2-impl": {
-            "locked": "2.24.3"
+            "locked": "2.25.2"
         },
         "org.assertj:assertj-core": {
             "locked": "3.26.3"
@@ -768,7 +768,7 @@
                 "com.netflix.zuul:zuul-core",
                 "com.netflix.zuul:zuul-discovery"
             ],
-            "locked": "2.0.16"
+            "locked": "2.0.17"
         },
         "org.wiremock:wiremock": {
             "locked": "3.10.0"
@@ -849,7 +849,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -867,76 +867,76 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1049,7 +1049,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1070,49 +1070,49 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1250,7 +1250,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1271,76 +1271,76 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1367,10 +1367,10 @@
             "locked": "3.18.0"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.24.3"
+            "locked": "2.25.2"
         },
         "org.apache.logging.log4j:log4j-slf4j2-impl": {
-            "locked": "2.24.3"
+            "locked": "2.25.2"
         },
         "org.assertj:assertj-core": {
             "locked": "3.26.3"
@@ -1413,7 +1413,7 @@
                 "com.netflix.zuul:zuul-core",
                 "com.netflix.zuul:zuul-discovery"
             ],
-            "locked": "2.0.16"
+            "locked": "2.0.17"
         },
         "org.wiremock:wiremock": {
             "locked": "3.10.0"

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -63,7 +63,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -78,43 +78,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -212,7 +212,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -227,43 +227,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -365,7 +365,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -380,73 +380,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -588,7 +588,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -603,73 +603,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -794,7 +794,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -818,73 +818,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -986,7 +986,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1001,43 +1001,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1148,7 +1148,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1163,73 +1163,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -78,7 +78,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -102,73 +102,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -267,7 +267,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -285,43 +285,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -428,7 +428,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -446,43 +446,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -596,7 +596,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -614,73 +614,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -819,7 +819,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -837,73 +837,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1022,7 +1022,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1040,43 +1040,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1184,7 +1184,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.0"
+            "locked": "1.9.2"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1202,73 +1202,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.73.Final"
+            "locked": "2.0.74.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.6.Final"
+            "locked": "4.2.9.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SampleWebSocketPushChannelInitializer.java
+++ b/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SampleWebSocketPushChannelInitializer.java
@@ -36,6 +36,8 @@ public class SampleWebSocketPushChannelInitializer extends PushChannelInitialize
     private final PushConnectionRegistry pushConnectionRegistry;
     private final PushAuthHandler pushAuthHandler;
 
+    private static final int MAX_CONTENT_LENGTH = 65536; // 64KB
+
     public SampleWebSocketPushChannelInitializer(
             String metricId, ChannelConfig channelConfig, ChannelConfig channelDependencies, ChannelGroup channels) {
         super(metricId, channelConfig, channelDependencies, channels);
@@ -46,7 +48,7 @@ public class SampleWebSocketPushChannelInitializer extends PushChannelInitialize
     @Override
     protected void addPushHandlers(ChannelPipeline pipeline) {
         pipeline.addLast(PushAuthHandler.NAME, pushAuthHandler);
-        pipeline.addLast(new WebSocketServerCompressionHandler(0));
+        pipeline.addLast(new WebSocketServerCompressionHandler(MAX_CONTENT_LENGTH));
         pipeline.addLast(new WebSocketServerProtocolHandler(PushProtocol.WEBSOCKET.getPath(), null, true));
         pipeline.addLast(new PushRegistrationHandler(pushConnectionRegistry, PushProtocol.WEBSOCKET));
         pipeline.addLast(new SampleWebSocketPushClientProtocolHandler());

--- a/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SampleWebSocketPushChannelInitializer.java
+++ b/zuul-sample/src/main/java/com/netflix/zuul/sample/push/SampleWebSocketPushChannelInitializer.java
@@ -46,7 +46,7 @@ public class SampleWebSocketPushChannelInitializer extends PushChannelInitialize
     @Override
     protected void addPushHandlers(ChannelPipeline pipeline) {
         pipeline.addLast(PushAuthHandler.NAME, pushAuthHandler);
-        pipeline.addLast(new WebSocketServerCompressionHandler());
+        pipeline.addLast(new WebSocketServerCompressionHandler(0));
         pipeline.addLast(new WebSocketServerProtocolHandler(PushProtocol.WEBSOCKET.getPath(), null, true));
         pipeline.addLast(new PushRegistrationHandler(pushConnectionRegistry, PushProtocol.WEBSOCKET));
         pipeline.addLast(new SampleWebSocketPushClientProtocolHandler());


### PR DESCRIPTION
1. Update netty to 4.2.9.Final: https://netty.io/news/2025/12/15/4-2-9.html
2. Fix deprecated WebSocketServerCompressionHandler(): https://netty.io/4.1/api/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandler.html#WebSocketServerCompressionHandler--