### PR TITLE
Validate protocol versions and reject path traversal segments

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -435,6 +435,12 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
             }
         }
 
+        // Hardening: Prevent path traversal by ensuring no ".." segments are processed.
+        if (path.contains("..")) {
+            LOG.warn("Suspicious path segment detected and rejected: {}", path);
+            throw new IllegalArgumentException("Path contains invalid segments");
+        }
+
         int queryIndex = path.indexOf('?');
         if (queryIndex > -1) {
             return path.substring(0, queryIndex);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
@@ -175,9 +175,12 @@ public class ClientResponseWriter extends ChannelInboundHandlerAdapter {
         String inboundProtocol = zuulRequest.getProtocol();
         if (inboundProtocol.startsWith("HTTP/1")) {
             responseHttpVersion = HttpVersion.valueOf(inboundProtocol);
-        } else {
-            // Default to 1.1. We do this to cope with HTTP/2 inbound requests.
+        } else if (inboundProtocol.startsWith("HTTP/2") || inboundProtocol.startsWith("HTTP/3")) {
+            // Default to 1.1. We do this to cope with inbound modern protocols.
             responseHttpVersion = HttpVersion.HTTP_1_1;
+        } else {
+            // Validate the protocol string to prevent downgrade attacks or arbitrary protocol injection.
+            throw new IllegalArgumentException("Unsupported or invalid protocol: " + inboundProtocol);
         }
 
         // Create the main http response to send, with body.


### PR DESCRIPTION
Added protocol version checks in `ClientResponseWriter` to catch unsupported or malformed strings before they hit the response cycle. This blocks potential downgrade attempts by ensuring the gateway only processes known HTTP versions.

Updated `parsePath` in `ClientRequestReceiver` to explicitly reject absolute URIs containing path traversal segments. Catching `..` sequences at the entry point provides a reliable safeguard against unauthorized file access probes, even for cases that might otherwise be handled downstream.