### PR TITLE
Rely on jvm's lazy hashCode caching

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/HeaderName.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/HeaderName.java
@@ -28,7 +28,6 @@ import java.util.Locale;
 public final class HeaderName {
     private final String name;
     private final String normalised;
-    private final int hashCode;
 
     public HeaderName(String name) {
         if (name == null) {
@@ -36,13 +35,11 @@ public final class HeaderName {
         }
         this.name = name;
         this.normalised = normalize(name);
-        this.hashCode = this.normalised.hashCode();
     }
 
     HeaderName(String name, String normalised) {
         this.name = name;
         this.normalised = normalised;
-        this.hashCode = normalised.hashCode();
     }
 
     /**
@@ -74,7 +71,7 @@ public final class HeaderName {
 
     @Override
     public int hashCode() {
-        return hashCode;
+        return normalised.hashCode();
     }
 
     @Override

--- a/zuul-core/src/test/java/com/netflix/zuul/message/HeaderNameTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/HeaderNameTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.message;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Justin Guerra
+ * @since 2/22/26
+ */
+class HeaderNameTest {
+
+    @Test
+    void casingTest() {
+        HeaderName lowerCase = new HeaderName("x-whatever");
+        HeaderName mixed = new HeaderName("X-Whatever");
+
+        assertThat(lowerCase.hashCode()).isEqualTo(mixed.hashCode());
+        assertThat(lowerCase).isEqualTo(mixed);
+        assertThat(lowerCase.getNormalised()).isEqualTo(mixed.getNormalised());
+        assertThat(lowerCase.getName()).isNotEqualTo(mixed.getName());
+
+        assertThat(lowerCase.getName()).isEqualTo("x-whatever");
+        assertThat(mixed.getName()).isEqualTo("X-Whatever");
+    }
+}


### PR DESCRIPTION
There isn't any reason to eagerly compute and cache the hashcode of a string, as the jvm lazily caches it already. By relying on string's hashcode we may be able to benefit from some jvm optimizations derived string's hash being `@Stable` 