### PR TITLE
Improve logging on decode failures

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/ChannelUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/ChannelUtils.java
@@ -25,14 +25,22 @@ public class ChannelUtils {
             return "null";
         }
 
-        String channelInfo = ch.toString()
-                + ", active=" + ch.isActive()
-                + ", open=" + ch.isOpen()
-                + ", registered=" + ch.isRegistered()
-                + ", writable=" + ch.isWritable()
-                + ", id=" + ch.id();
-
-        CurrentPassport passport = CurrentPassport.fromChannel(ch);
-        return "Channel: " + channelInfo + ", Passport: " + String.valueOf(passport);
+        String passport = CurrentPassport.fromChannel(ch).toString();
+        StringBuilder builder = new StringBuilder(256 + passport.length());
+        builder.append("Channel: ")
+                .append(ch)
+                .append(", active=")
+                .append(ch.isActive())
+                .append(", open=")
+                .append(ch.isOpen())
+                .append(", registered=")
+                .append(ch.isRegistered())
+                .append(", writable=")
+                .append(ch.isWritable())
+                .append(", id=")
+                .append(ch.id())
+                .append(", Passport: ")
+                .append(passport);
+        return builder.toString();
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/ChannelUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/ChannelUtils.java
@@ -37,8 +37,6 @@ public class ChannelUtils {
                 .append(ch.isRegistered())
                 .append(", writable=")
                 .append(ch.isWritable())
-                .append(", id=")
-                .append(ch.id())
                 .append(", Passport: ")
                 .append(passport);
         return builder.toString();


### PR DESCRIPTION
Switch to logging the clientIp instead of the duplicate uri. Also updated the logging in ChannelUtils to use a StringBuilder and removed the redundant inclusion of id