### PR TITLE
Close the context instead of the pipeline

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/throttle/MaxInboundConnectionsHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/throttle/MaxInboundConnectionsHandler.java
@@ -64,7 +64,7 @@ public class MaxInboundConnectionsHandler extends ChannelInboundHandlerAdapter {
                 Channel channel = ctx.channel();
                 channel.attr(ATTR_CH_THROTTLED).set(Boolean.TRUE);
                 CurrentPassport.fromChannel(channel).add(PassportState.SERVER_CH_THROTTLING);
-                channel.close();
+                ctx.close();
                 connectionThrottled.increment();
             }
         }

--- a/zuul-core/src/test/java/com/netflix/netty/common/throttle/MaxInboundConnectionsHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/throttle/MaxInboundConnectionsHandlerTest.java
@@ -25,7 +25,11 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.zuul.netty.server.http2.DummyChannelHandler;
 import com.netflix.zuul.passport.CurrentPassport;
 import com.netflix.zuul.passport.PassportState;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,19 +37,19 @@ class MaxInboundConnectionsHandlerTest {
 
     private final Registry registry = new DefaultRegistry();
     private final String listener = "test-throttled";
+
     private Id counterId;
+    private EmbeddedChannel channel;
 
     @BeforeEach
     void setup() {
         counterId = registry.createId("server.connections.throttled").withTags("id", listener);
+        channel = new EmbeddedChannel(new MaxInboundConnectionsHandler(registry, listener, 1));
     }
 
     @Test
     void verifyPassportStateAndAttrs() {
-
-        EmbeddedChannel channel = new EmbeddedChannel();
-        channel.pipeline().addLast(new DummyChannelHandler());
-        channel.pipeline().addLast(new MaxInboundConnectionsHandler(registry, listener, 1));
+        channel.pipeline().addFirst(new DummyChannelHandler());
 
         // Fire twice to increment current conns. count
         channel.pipeline().context(DummyChannelHandler.class).fireChannelActive();
@@ -57,5 +61,23 @@ class MaxInboundConnectionsHandlerTest {
         assertThat(CurrentPassport.fromChannel(channel).getState()).isEqualTo(PassportState.SERVER_CH_THROTTLING);
         assertThat(channel.attr(MaxInboundConnectionsHandler.ATTR_CH_THROTTLED).get())
                 .isTrue();
+    }
+
+    @Test
+    void verifyCloseNotOnPipeline() {
+        AtomicBoolean seen = new AtomicBoolean(false);
+        channel.pipeline().addLast(new ChannelDuplexHandler() {
+            @Override
+            public void close(ChannelHandlerContext ctx, ChannelPromise promise) {
+                seen.set(true);
+                ctx.close(promise);
+            }
+        });
+
+        channel.pipeline().fireChannelActive();
+        channel.pipeline().fireChannelActive();
+
+        assertThat(channel.isActive()).isFalse();
+        assertThat(seen).isFalse();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/netty/common/throttle/MaxInboundConnectionsHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/throttle/MaxInboundConnectionsHandlerTest.java
@@ -35,14 +35,14 @@ import org.junit.jupiter.api.Test;
 
 class MaxInboundConnectionsHandlerTest {
 
-    private final Registry registry = new DefaultRegistry();
-    private final String listener = "test-throttled";
-
+    private Registry registry;
     private Id counterId;
     private EmbeddedChannel channel;
 
     @BeforeEach
     void setup() {
+        String listener = "test-throttled";
+        registry = new DefaultRegistry();
         counterId = registry.createId("server.connections.throttled").withTags("id", listener);
         channel = new EmbeddedChannel(new MaxInboundConnectionsHandler(registry, listener, 1));
     }
@@ -51,9 +51,8 @@ class MaxInboundConnectionsHandlerTest {
     void verifyPassportStateAndAttrs() {
         channel.pipeline().addFirst(new DummyChannelHandler());
 
-        // Fire twice to increment current conns. count
-        channel.pipeline().context(DummyChannelHandler.class).fireChannelActive();
-        channel.pipeline().context(DummyChannelHandler.class).fireChannelActive();
+        // Fire 1 time, since EmbeddedChannel calls channelActive in the constructor
+        channel.pipeline().fireChannelActive();
 
         Counter throttledCount = (Counter) registry.get(counterId);
 
@@ -74,7 +73,6 @@ class MaxInboundConnectionsHandlerTest {
             }
         });
 
-        channel.pipeline().fireChannelActive();
         channel.pipeline().fireChannelActive();
 
         assertThat(channel.isActive()).isFalse();


### PR DESCRIPTION
Upon reaching connections limits, immediately close the connection instead of sending it to the end of the pipeline for closing