### PR TITLE
Remove SourceAddressChannelHandler after use

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/SourceAddressChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/SourceAddressChannelHandler.java
@@ -28,7 +28,8 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Stores the source IP address as an attribute of the channel. This has the advantage of allowing us to overwrite it if
@@ -36,6 +37,7 @@ import javax.annotation.Nullable;
  * <p>
  * User: michaels@netflix.com Date: 4/14/16 Time: 4:29 PM
  */
+@NullMarked
 @ChannelHandler.Sharable
 public final class SourceAddressChannelHandler extends ChannelInboundHandlerAdapter {
 
@@ -62,7 +64,8 @@ public final class SourceAddressChannelHandler extends ChannelInboundHandlerAdap
      * The host address of the source.   This is derived from {@link #ATTR_REMOTE_ADDR}.   If the address is an IPv6
      * address, the scope identifier is absent.
      */
-    public static final AttributeKey<String> ATTR_SOURCE_ADDRESS = AttributeKey.newInstance("_source_address");
+    public static final AttributeKey<@Nullable String> ATTR_SOURCE_ADDRESS =
+            AttributeKey.newInstance("_source_address");
 
     /**
      * Indicates the local address of the channel.  This can be different than the one {@link Channel} returns if the
@@ -83,7 +86,7 @@ public final class SourceAddressChannelHandler extends ChannelInboundHandlerAdap
      * #ATTR_SERVER_LOCAL_ADDRESS}, this value is overwritten with the Proxy Protocol local address (e.g. the LB's local
      * address), if enabled.
      */
-    public static final AttributeKey<String> ATTR_LOCAL_ADDRESS = AttributeKey.newInstance("_local_address");
+    public static final AttributeKey<@Nullable String> ATTR_LOCAL_ADDRESS = AttributeKey.newInstance("_local_address");
 
     /**
      * The actual local address of the channel, in string form.  If the address is an IPv6 address, the scope identifier
@@ -104,22 +107,29 @@ public final class SourceAddressChannelHandler extends ChannelInboundHandlerAdap
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
-        ctx.channel().attr(ATTR_REMOTE_ADDR).set(ctx.channel().remoteAddress());
-        InetSocketAddress sourceAddress = sourceAddress(ctx.channel());
-        ctx.channel().attr(ATTR_SOURCE_INET_ADDR).setIfAbsent(sourceAddress);
-        ctx.channel().attr(ATTR_SOURCE_ADDRESS).setIfAbsent(getHostAddress(sourceAddress));
-        ctx.channel().attr(ATTR_LOCAL_ADDR).set(ctx.channel().localAddress());
-        InetSocketAddress localAddress = localAddress(ctx.channel());
-        ctx.channel().attr(ATTR_LOCAL_INET_ADDR).setIfAbsent(localAddress);
-        ctx.channel().attr(ATTR_LOCAL_ADDRESS).setIfAbsent(getHostAddress(localAddress));
-        // ATTR_LOCAL_ADDRESS and ATTR_LOCAL_PORT get overwritten with what is received in
-        // Proxy Protocol (via the LB), so set local server's address, port explicitly
-        ctx.channel()
-                .attr(ATTR_SERVER_LOCAL_ADDRESS)
-                .setIfAbsent(localAddress.getAddress().getHostAddress());
-        ctx.channel().attr(ATTR_SERVER_LOCAL_PORT).setIfAbsent(localAddress.getPort());
+        Channel channel = ctx.channel();
+        channel.attr(ATTR_REMOTE_ADDR).set(channel.remoteAddress());
+        InetSocketAddress sourceAddress = sourceAddress(channel);
+        if (sourceAddress != null) {
+            channel.attr(ATTR_SOURCE_INET_ADDR).setIfAbsent(sourceAddress);
+            channel.attr(ATTR_SOURCE_ADDRESS).setIfAbsent(getHostAddress(sourceAddress));
+        }
 
-        super.channelActive(ctx);
+        channel.attr(ATTR_LOCAL_ADDR).set(channel.localAddress());
+
+        InetSocketAddress localAddress = localAddress(channel);
+        if (localAddress != null) {
+            channel.attr(ATTR_LOCAL_INET_ADDR).setIfAbsent(localAddress);
+            channel.attr(ATTR_LOCAL_ADDRESS).setIfAbsent(getHostAddress(localAddress));
+            // ATTR_LOCAL_ADDRESS and ATTR_LOCAL_PORT get overwritten with what is received in
+            // Proxy Protocol (via the LB), so set local server's address, port explicitly
+            channel.attr(ATTR_SERVER_LOCAL_ADDRESS)
+                    .setIfAbsent(localAddress.getAddress().getHostAddress());
+            channel.attr(ATTR_SERVER_LOCAL_PORT).setIfAbsent(localAddress.getPort());
+        }
+
+        ctx.pipeline().remove(this);
+        ctx.fireChannelActive();
     }
 
     /**
@@ -141,11 +151,11 @@ public final class SourceAddressChannelHandler extends ChannelInboundHandlerAdap
         } else if (address instanceof Inet4Address) {
             return address.getHostAddress();
         } else {
-            assert address == null;
             return null;
         }
     }
 
+    @Nullable
     private InetSocketAddress sourceAddress(Channel channel) {
         SocketAddress remoteSocketAddr = channel.remoteAddress();
         if (remoteSocketAddr != null && InetSocketAddress.class.isAssignableFrom(remoteSocketAddr.getClass())) {
@@ -157,6 +167,7 @@ public final class SourceAddressChannelHandler extends ChannelInboundHandlerAdap
         return null;
     }
 
+    @Nullable
     private InetSocketAddress localAddress(Channel channel) {
         SocketAddress localSocketAddress = channel.localAddress();
         if (localSocketAddress != null && InetSocketAddress.class.isAssignableFrom(localSocketAddress.getClass())) {

--- a/zuul-core/src/test/java/com/netflix/netty/common/SourceAddressChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/SourceAddressChannelHandlerTest.java
@@ -18,15 +18,21 @@ package com.netflix.netty.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.net.InetAddresses;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
+import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.TestAbortedException;
@@ -106,5 +112,56 @@ class SourceAddressChannelHandlerTest {
         TestAbortedException failure = new TestAbortedException("No Compatible Nics were found");
         failures.forEach(failure::addSuppressed);
         throw failure;
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void handlerRemovedAfterActive() {
+        InetSocketAddress remoteAddr = new InetSocketAddress(InetAddresses.forString("175.45.177.0"), 12345);
+        InetSocketAddress localAddr = new InetSocketAddress(InetAddresses.forString("127.0.0.1"), 8080);
+
+        AtomicBoolean activeSeen = new AtomicBoolean();
+        EmbeddedChannel channel =
+                new EmbeddedChannel(new SourceAddressChannelHandler(), new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelActive(ChannelHandlerContext ctx) {
+                        activeSeen.set(true);
+                    }
+                }) {
+                    @Override
+                    protected SocketAddress remoteAddress0() {
+                        return remoteAddr;
+                    }
+
+                    @Override
+                    protected SocketAddress localAddress0() {
+                        return localAddr;
+                    }
+                };
+
+        assertThat(activeSeen).isTrue();
+        assertThat(channel.pipeline().get(SourceAddressChannelHandler.class)).isNull();
+
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get())
+                .isEqualTo(remoteAddr);
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_INET_ADDR)
+                        .get())
+                .isEqualTo(remoteAddr);
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get())
+                .isEqualTo("175.45.177.0");
+
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDR).get())
+                .isEqualTo(localAddr);
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_INET_ADDR)
+                        .get())
+                .isEqualTo(localAddr);
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_LOCAL_ADDRESS).get())
+                .isEqualTo("127.0.0.1");
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_ADDRESS)
+                        .get())
+                .isEqualTo("127.0.0.1");
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT)
+                        .get())
+                .isEqualTo(8080);
     }
 }


### PR DESCRIPTION
SourceAddressChannelHandler is only needed for channelActive, so we can remove it from the pipeline afterwards. 

While writing the unit tests I ran into some null issues so I added some more annotations + null checking as well