### PR TITLE
Add HTTP/1.1 request framing enforcer

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializer.java
@@ -99,6 +99,9 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
     public static final CachedDynamicIntProperty HTTP_REQUEST_HEADERS_READ_TIMEOUT =
             new CachedDynamicIntProperty("server.http.request.headers.read.timeout", 10000);
 
+    public static final CachedDynamicBooleanProperty HTTP1_FRAMING_ENFORCEMENT_ENABLED =
+            new CachedDynamicBooleanProperty("zuul.http1.framing.enforcement.enabled", true);
+
     /**
      * The port that the server intends to listen on.  Subclasses should NOT use this field, as it may not be set, and
      * may differ from the actual listening port.  For example:
@@ -256,6 +259,10 @@ public abstract class BaseZuulChannelInitializer extends ChannelInitializer<Chan
 
     protected void addHttp1Handlers(ChannelPipeline pipeline) {
         pipeline.addLast(HTTP_CODEC_HANDLER_NAME, createHttpServerCodec());
+
+        if (HTTP1_FRAMING_ENFORCEMENT_ENABLED.get()) {
+            pipeline.addLast(new Http1FramingEnforcingHandler());
+        }
 
         pipeline.addLast(new Http1ConnectionCloseHandler());
         pipeline.addLast(

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/Http1FramingEnforcingHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/Http1FramingEnforcingHandler.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.netty.server;
+
+import com.google.common.base.Splitter;
+import com.netflix.netty.common.throttle.RejectionUtils;
+import com.netflix.zuul.stats.status.ZuulStatusCategory;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.ReferenceCountUtil;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Enforces HTTP/1.1 message framing rules from RFC 9112 section 6.3, rejecting requests with ambiguous framing that
+ * enable request smuggling. Drops the connection with no response when Transfer-Encoding and Content-Length are both
+ * present, when Content-Length appears multiple times or is not a non-negative integer, or when Transfer-Encoding is
+ * set without chunked as the final coding.
+ * <br/>
+ * Force-closing (rather than writing a 400) is deliberate: once framing is ambiguous, we cannot trust where the
+ * message body ends, and any bytes left in the decoder buffer would otherwise be parsed as the next request.
+ */
+@NullMarked
+@Slf4j
+public final class Http1FramingEnforcingHandler extends ChannelInboundHandlerAdapter {
+
+    private static final Splitter TRANSFER_ENCODING_SPLITTER =
+            Splitter.on(',').trimResults().omitEmptyStrings();
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (!(msg instanceof HttpRequest req)) {
+            super.channelRead(ctx, msg);
+            return;
+        }
+
+        List<String> contentLengthHeaders = req.headers().getAll(HttpHeaderNames.CONTENT_LENGTH);
+        List<String> transferEncodingHeaders = req.headers().getAll(HttpHeaderNames.TRANSFER_ENCODING);
+
+        if (contentLengthHeaders.size() > 1) {
+            rejectAndClose(ctx, req, msg, "multiple content-length headers");
+            return;
+        }
+
+        if (!contentLengthHeaders.isEmpty() && !transferEncodingHeaders.isEmpty()) {
+            rejectAndClose(ctx, req, msg, "both transfer-encoding and content-length present");
+            return;
+        }
+
+        if (!contentLengthHeaders.isEmpty() && !isValidContentLength(contentLengthHeaders.getFirst())) {
+            rejectAndClose(ctx, req, msg, "invalid content-length");
+            return;
+        }
+
+        if (!transferEncodingHeaders.isEmpty() && !isChunkedFinalCoding(transferEncodingHeaders)) {
+            rejectAndClose(ctx, req, msg, "transfer-encoding without chunked as final coding");
+            return;
+        }
+
+        super.channelRead(ctx, msg);
+    }
+
+    private static boolean isValidContentLength(String value) {
+        try {
+            return Long.parseLong(value) >= 0;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if the final transfer coding is `chunked`. Per RFC 9112 section 6.1, when any transfer coding
+     * other than chunked is applied, chunked MUST be applied as the final coding, otherwise the message body has no
+     * reliable end marker.
+     */
+    private static boolean isChunkedFinalCoding(List<String> transferEncodingHeaders) {
+        if (transferEncodingHeaders.isEmpty()) {
+            return false;
+        }
+
+        // headers are in order, so fetch the last Transfer-Encoding one and find the last listed encoding
+        List<String> encodings = TRANSFER_ENCODING_SPLITTER.splitToList(transferEncodingHeaders.getLast());
+        if (encodings.isEmpty()) {
+            return false;
+        }
+
+        return HttpHeaderValues.CHUNKED.contentEqualsIgnoreCase(stripTransferParameters(encodings.getLast()));
+    }
+
+    private static String stripTransferParameters(String coding) {
+        int paramStart = coding.indexOf(';');
+        return paramStart == -1 ? coding : coding.substring(0, paramStart).trim();
+    }
+
+    private static void rejectAndClose(ChannelHandlerContext ctx, HttpRequest req, Object msg, String detail) {
+        log.debug("Rejecting HTTP/1.1 request with ambiguous framing: {}, uri={}", detail, req.uri());
+
+        RejectionUtils.rejectByClosingConnection(
+                ctx, ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST, "http1_framing_violation", req, null);
+        ReferenceCountUtil.safeRelease(msg);
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/BaseZuulChannelInitializerTest.java
@@ -18,6 +18,8 @@ package com.netflix.zuul.netty.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.netflix.config.ConfigurationManager;
+import com.netflix.netty.common.Http1ConnectionCloseHandler;
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.netty.common.channel.config.ChannelConfig;
 import com.netflix.netty.common.channel.config.CommonChannelConfigKeys;
@@ -28,16 +30,29 @@ import com.netflix.spectator.api.NoopRegistry;
 import com.netflix.zuul.netty.insights.ServerStateHandler;
 import com.netflix.zuul.netty.ratelimiting.NullChannelHandlerProvider;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.util.concurrent.GlobalEventExecutor;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link BaseZuulChannelInitializer}.
  */
 class BaseZuulChannelInitializerTest {
+
+    @AfterEach
+    void resetProperties() {
+        AbstractConfiguration config = ConfigurationManager.getConfigInstance();
+        config.clearProperty("zuul.http1.framing.enforcement.enabled");
+    }
 
     @Test
     void tcpHandlersAdded() {
@@ -124,6 +139,83 @@ class BaseZuulChannelInitializerTest {
         assertThat(channel.pipeline().context(ServerStateHandler.InboundHandler.class))
                 .isNotNull();
         assertThat(channel.pipeline().context(ServerStateHandler.OutboundHandler.class))
+                .isNotNull();
+    }
+
+    @Test
+    void http1FramingEnforcerRunsBetweenCodecAndConnectionCloseHandler() {
+        ChannelConfig channelConfig = new ChannelConfig();
+        ChannelConfig channelDependencies = new ChannelConfig();
+        channelDependencies.set(ZuulDependencyKeys.registry, new NoopRegistry());
+        channelDependencies.set(
+                ZuulDependencyKeys.rateLimitingChannelHandlerProvider, new NullChannelHandlerProvider());
+        channelDependencies.set(
+                ZuulDependencyKeys.sslClientCertCheckChannelHandlerProvider, new NullChannelHandlerProvider());
+
+        ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+        BaseZuulChannelInitializer init =
+                new BaseZuulChannelInitializer("1234", channelConfig, channelDependencies, channelGroup) {
+                    @Override
+                    protected void initChannel(Channel ch) {}
+                };
+        EmbeddedChannel channel = new EmbeddedChannel();
+
+        init.addHttp1Handlers(channel.pipeline());
+        assertThat(channel.pipeline().context(Http1FramingEnforcingHandler.class))
+                .as("Http1FramingEnforcingHandler must be wired into the HTTP/1.1 pipeline")
+                .isNotNull();
+
+        List<Class<? extends ChannelHandler>> handlerClasses = StreamSupport.stream(
+                        channel.pipeline().spliterator(), false)
+                .map(entry -> entry.getValue().getClass())
+                .collect(Collectors.toList());
+
+        int codecIndex = handlerClasses.indexOf(HttpServerCodec.class);
+        int enforcerIndex = handlerClasses.indexOf(Http1FramingEnforcingHandler.class);
+        int closeHandlerIndex = handlerClasses.indexOf(Http1ConnectionCloseHandler.class);
+
+        assertThat(codecIndex).as("HttpServerCodec must be present").isNotNegative();
+        assertThat(closeHandlerIndex)
+                .as("Http1ConnectionCloseHandler must be present")
+                .isNotNegative();
+        assertThat(enforcerIndex)
+                .as("Http1FramingEnforcingHandler must run after HttpServerCodec")
+                .isGreaterThan(codecIndex);
+        assertThat(enforcerIndex)
+                .as("Http1FramingEnforcingHandler must run before Http1ConnectionCloseHandler")
+                .isLessThan(closeHandlerIndex);
+    }
+
+    @Test
+    void http1FramingEnforcerIsOmittedWhenDisabled() {
+        AbstractConfiguration config = ConfigurationManager.getConfigInstance();
+        config.setProperty("zuul.http1.framing.enforcement.enabled", "false");
+
+        ChannelConfig channelConfig = new ChannelConfig();
+        ChannelConfig channelDependencies = new ChannelConfig();
+        channelDependencies.set(ZuulDependencyKeys.registry, new NoopRegistry());
+        channelDependencies.set(
+                ZuulDependencyKeys.rateLimitingChannelHandlerProvider, new NullChannelHandlerProvider());
+        channelDependencies.set(
+                ZuulDependencyKeys.sslClientCertCheckChannelHandlerProvider, new NullChannelHandlerProvider());
+        ChannelGroup channelGroup = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
+        BaseZuulChannelInitializer init =
+                new BaseZuulChannelInitializer("1234", channelConfig, channelDependencies, channelGroup) {
+                    @Override
+                    protected void initChannel(Channel ch) {}
+                };
+        EmbeddedChannel channel = new EmbeddedChannel();
+
+        init.addHttp1Handlers(channel.pipeline());
+
+        assertThat(channel.pipeline().context(Http1FramingEnforcingHandler.class))
+                .as("Http1FramingEnforcingHandler must not be wired when the killswitch is disabled")
+                .isNull();
+        assertThat(channel.pipeline().context(HttpServerCodec.class))
+                .as("HttpServerCodec is still wired even when the enforcement handler is off")
+                .isNotNull();
+        assertThat(channel.pipeline().context(Http1ConnectionCloseHandler.class))
+                .as("Http1ConnectionCloseHandler is still wired even when the enforcement handler is off")
                 .isNotNull();
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/Http1FramingEnforcingHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/Http1FramingEnforcingHandlerTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.netty.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.netty.common.throttle.RejectionUtils;
+import com.netflix.netty.common.throttle.RequestRejectedEvent;
+import com.netflix.zuul.stats.status.ZuulStatusCategory;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class Http1FramingEnforcingHandlerTest {
+
+    private EmbeddedChannel channel;
+    private List<RequestRejectedEvent> capturedEvents;
+
+    @BeforeEach
+    void setup() {
+        capturedEvents = new ArrayList<>();
+        channel = new EmbeddedChannel(
+                new Http1FramingEnforcingHandler(),
+                // capture user events fired up the pipeline so we can assert RequestRejectedEvent was fired
+                new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                        if (evt instanceof RequestRejectedEvent rejectedEvent) {
+                            capturedEvents.add(rejectedEvent);
+                        }
+                        super.userEventTriggered(ctx, evt);
+                    }
+                });
+    }
+
+    @Test
+    void validRequestWithContentLengthPassesThrough() {
+        DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().set(HttpHeaderNames.CONTENT_LENGTH, 3);
+
+        channel.writeInbound(req);
+
+        assertThat(channel.<Object>readInbound()).isSameAs(req);
+        assertThat(channel.<Object>readOutbound()).isNull();
+        assertThat(channel.isOpen()).isTrue();
+        assertThat(capturedEvents).isEmpty();
+    }
+
+    @Test
+    void validRequestWithTransferEncodingChunkedPassesThrough() {
+        DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+
+        channel.writeInbound(req);
+
+        assertThat(channel.<Object>readInbound()).isSameAs(req);
+        assertThat(channel.<Object>readOutbound()).isNull();
+        assertThat(channel.isOpen()).isTrue();
+    }
+
+    @Test
+    void requestWithNoFramingHeadersPassesThrough() {
+        DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+
+        channel.writeInbound(req);
+
+        assertThat(channel.<Object>readInbound()).isSameAs(req);
+        assertThat(channel.<Object>readOutbound()).isNull();
+        assertThat(channel.isOpen()).isTrue();
+    }
+
+    @Test
+    void teAndClRequestIsRejectedByForceClose() {
+        DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/poc");
+        req.headers().set(HttpHeaderNames.CONTENT_LENGTH, 4);
+        req.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+
+        channel.writeInbound(req);
+
+        assertThat(channel.<Object>readInbound())
+                .as("request must not propagate past the handler")
+                .isNull();
+        assertThat(channel.<Object>readOutbound())
+                .as("no response is written - framing is too ambiguous to safely respond to")
+                .isNull();
+        assertThat(channel.isOpen())
+                .as("connection must be closed so residual bytes are not re-parsed as a new request")
+                .isFalse();
+
+        assertThat(capturedEvents).hasSize(1);
+        RequestRejectedEvent event = capturedEvents.getFirst();
+        assertThat(event.httpStatus()).isEqualTo(RejectionUtils.REJECT_CLOSING_STATUS);
+        assertThat(event.nfStatus()).isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
+        assertThat(event.reason()).isEqualTo("http1_framing_violation");
+        assertThat(event.request()).isSameAs(req);
+    }
+
+    @Test
+    void duplicateContentLengthIsRejected() {
+        DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().add(HttpHeaderNames.CONTENT_LENGTH, 1);
+        req.headers().add(HttpHeaderNames.CONTENT_LENGTH, 2);
+
+        channel.writeInbound(req);
+
+        assertThat(channel.<Object>readOutbound()).isNull();
+        assertThat(channel.isOpen()).isFalse();
+        assertThat(capturedEvents.getFirst().reason()).isEqualTo("http1_framing_violation");
+    }
+
+    @Test
+    void nonNumericContentLengthIsRejected() {
+        DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().set(HttpHeaderNames.CONTENT_LENGTH, "not_a_number");
+
+        channel.writeInbound(req);
+
+        assertThat(channel.<Object>readOutbound()).isNull();
+        assertThat(channel.isOpen()).isFalse();
+        assertThat(capturedEvents.getFirst().reason()).isEqualTo("http1_framing_violation");
+    }
+
+    @Test
+    void negativeContentLengthIsRejected() {
+        DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().set(HttpHeaderNames.CONTENT_LENGTH, -1);
+
+        channel.writeInbound(req);
+
+        assertThat(channel.<Object>readOutbound()).isNull();
+        assertThat(channel.isOpen()).isFalse();
+        assertThat(capturedEvents.getFirst().reason()).isEqualTo("http1_framing_violation");
+    }
+
+    @Test
+    void transferEncodingWithoutChunkedFinalIsRejected() {
+        DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().set(HttpHeaderNames.TRANSFER_ENCODING, "gzip");
+
+        channel.writeInbound(req);
+
+        assertThat(channel.<Object>readOutbound()).isNull();
+        assertThat(channel.isOpen()).isFalse();
+        assertThat(capturedEvents.getFirst().reason()).isEqualTo("http1_framing_violation");
+    }
+
+    @Test
+    void transferEncodingChunkedAsLastCodingPassesThrough() {
+        DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().set(HttpHeaderNames.TRANSFER_ENCODING, "gzip, chunked");
+
+        channel.writeInbound(req);
+
+        assertThat(channel.<Object>readInbound()).isSameAs(req);
+        assertThat(channel.<Object>readOutbound()).isNull();
+        assertThat(channel.isOpen()).isTrue();
+    }
+
+    @Test
+    void multipleTransferEncodingHeadersWithChunkedAsFinalPasses() {
+        DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        req.headers().add(HttpHeaderNames.TRANSFER_ENCODING, "gzip");
+        req.headers().add(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+
+        channel.writeInbound(req);
+
+        assertThat(channel.<Object>readInbound()).isSameAs(req);
+        assertThat(channel.<Object>readOutbound()).isNull();
+    }
+
+    @Test
+    void nonHttpRequestMessagesArePassedThrough() {
+        channel.writeInbound("not-an-http-request");
+
+        assertThat(channel.<Object>readInbound()).isEqualTo("not-an-http-request");
+    }
+}


### PR DESCRIPTION
This adds a `Http1FramingEnforcingHandler`, immediately after `HttpServerCodec` in the HTTP/1.1 pipeline, which rejects requests with ambiguous message framing per [RFC 9112 section 6.3](https://www.rfc-editor.org/rfc/rfc9112.html#name-message-body-length):
- `Transfer-Encoding` and `Content-Length` both present
- `Content-Length` header appearing more than once
- `Content-Length` that is not a non-negative integer
- `Transfer-Encoding` set without `chunked` as the final coding

This is enabled by default, however can be disabled via `zuul.http1.framing.enforcement.enabled` as needed.