### PR TITLE
Correctly handle http conn state when origin responds before `LastHttpContent` is sent

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/HttpClientLifecycleChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/HttpClientLifecycleChannelHandler.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.AttributeKey;
 
 /**
  * @author michaels
@@ -31,6 +32,9 @@ import io.netty.handler.codec.http.LastHttpContent;
 public class HttpClientLifecycleChannelHandler extends HttpLifecycleChannelHandler {
     public static final ChannelHandler INBOUND_CHANNEL_HANDLER = new HttpClientLifecycleInboundChannelHandler();
     public static final ChannelHandler OUTBOUND_CHANNEL_HANDLER = new HttpClientLifecycleOutboundChannelHandler();
+
+    public static final AttributeKey<Boolean> ATTR_OUTBOUND_LAST_CONTENT_PENDING =
+            AttributeKey.newInstance("_outbound_last_content_pending");
 
     @ChannelHandler.Sharable
     private static class HttpClientLifecycleInboundChannelHandler extends ChannelInboundHandlerAdapter {
@@ -64,7 +68,17 @@ public class HttpClientLifecycleChannelHandler extends HttpLifecycleChannelHandl
         @Override
         public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
             if (msg instanceof HttpRequest httpRequest) {
+                ctx.channel().attr(ATTR_OUTBOUND_LAST_CONTENT_PENDING).set(Boolean.TRUE);
                 fireStartEvent(ctx, httpRequest);
+            }
+
+            if (msg instanceof LastHttpContent) {
+                // only clear after content write succeeds to account for retrans
+                promise.addListener(future -> {
+                    if (future.isSuccess()) {
+                        ctx.channel().attr(ATTR_OUTBOUND_LAST_CONTENT_PENDING).set(null);
+                    }
+                });
             }
 
             super.write(ctx, msg, promise);

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolHandler.java
@@ -19,6 +19,7 @@ package com.netflix.zuul.netty.connectionpool;
 import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
 import static com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
 
+import com.netflix.netty.common.HttpClientLifecycleChannelHandler;
 import com.netflix.spectator.api.Spectator;
 import com.netflix.zuul.netty.ChannelUtils;
 import com.netflix.zuul.origins.OriginName;
@@ -80,6 +81,15 @@ public class ConnectionPoolHandler extends ChannelDuplexHandler {
                                 + " - completed because of expired keep-alive. "
                                 + ChannelUtils.channelInfoForLogging(ctx.channel());
                         metrics.headerCloseCounter().increment();
+                        closeConnection(ctx, msg);
+                    } else if (isOutboundLastContentPending(ctx)) {
+                        // response arrived before zuul finished writing the request body; the
+                        // HttpClientCodec encoder is mid-body and the connection cannot be reused
+                        metrics.outboundIncompleteCounter().increment();
+                        String msg = "Origin channel for origin - " + originName
+                                + " - response completed before request body fully written, closing. "
+                                + ChannelUtils.channelInfoForLogging(ctx.channel());
+                        LOG.warn(msg);
                         closeConnection(ctx, msg);
                     } else {
                         conn.setConnectionState(PooledConnection.ConnectionState.WRITE_READY);
@@ -146,6 +156,12 @@ public class ConnectionPoolHandler extends ChannelDuplexHandler {
             pooledConnection.flagShouldClose();
             pooledConnection.release();
         }
+    }
+
+    private static boolean isOutboundLastContentPending(ChannelHandlerContext ctx) {
+        return Boolean.TRUE.equals(ctx.channel()
+                .attr(HttpClientLifecycleChannelHandler.ATTR_OUTBOUND_LAST_CONTENT_PENDING)
+                .get());
     }
 
     private static String getConnectionHeader(CompleteEvent completeEvt) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetrics.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetrics.java
@@ -50,7 +50,8 @@ public record ConnectionPoolMetrics(
         Counter inactiveCounter,
         Counter errorCounter,
         Counter headerCloseCounter,
-        Counter sslCloseCompletionCounter) {
+        Counter sslCloseCompletionCounter,
+        Counter outboundIncompleteCounter) {
 
     public static ConnectionPoolMetrics create(OriginName originName, Registry registry) {
         Counter createNewConnCounter = newCounter("connectionpool_create", originName, registry);
@@ -77,6 +78,7 @@ public record ConnectionPoolMetrics(
         Counter errorCounter = newCounter("connectionpool_error", originName, registry);
         Counter headerCloseCounter = newCounter("connectionpool_headerClose", originName, registry);
         Counter sslCloseCompletionCounter = newCounter("connectionpool_sslClose", originName, registry);
+        Counter outboundIncompleteCounter = newCounter("connectionpool_outboundIncomplete", originName, registry);
 
         PercentileTimer connEstablishTimer = PercentileTimer.get(
                 registry, registry.createId("connectionpool_createTiming", "id", originName.getMetricId()));
@@ -107,7 +109,8 @@ public record ConnectionPoolMetrics(
                 inactiveCounter,
                 errorCounter,
                 headerCloseCounter,
-                sslCloseCompletionCounter);
+                sslCloseCompletionCounter,
+                outboundIncompleteCounter);
     }
 
     private static Counter newCounter(String metricName, OriginName originName, Registry registry) {

--- a/zuul-core/src/test/java/com/netflix/netty/common/HttpClientLifecycleChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/HttpClientLifecycleChannelHandlerTest.java
@@ -25,14 +25,26 @@ import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class HttpClientLifecycleChannelHandlerTest {
 
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    void setup() {
+        channel = new EmbeddedChannel(HttpClientLifecycleChannelHandler.OUTBOUND_CHANNEL_HANDLER);
+    }
+
+    @AfterEach
+    void tearDown() {
+        channel.finishAndReleaseAll();
+    }
+
     @Test
     void lastContentPendingAfterRequestHeadersOnly() {
-        EmbeddedChannel channel = new EmbeddedChannel(HttpClientLifecycleChannelHandler.OUTBOUND_CHANNEL_HANDLER);
-
         channel.writeOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/foo"));
         channel.writeOutbound(new DefaultHttpContent(Unpooled.wrappedBuffer(new byte[] {1, 2, 3})));
 
@@ -43,8 +55,6 @@ class HttpClientLifecycleChannelHandlerTest {
 
     @Test
     void lastContentPendingClearedAfterLastHttpContent() {
-        EmbeddedChannel channel = new EmbeddedChannel(HttpClientLifecycleChannelHandler.OUTBOUND_CHANNEL_HANDLER);
-
         channel.writeOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/foo"));
         channel.writeOutbound(new DefaultHttpContent(Unpooled.wrappedBuffer(new byte[] {1, 2, 3})));
         channel.writeOutbound(new DefaultLastHttpContent());
@@ -56,8 +66,6 @@ class HttpClientLifecycleChannelHandlerTest {
 
     @Test
     void lastContentPendingResetsOnNewRequest() {
-        EmbeddedChannel channel = new EmbeddedChannel(HttpClientLifecycleChannelHandler.OUTBOUND_CHANNEL_HANDLER);
-
         channel.writeOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/first"));
         channel.writeOutbound(new DefaultLastHttpContent());
         assertThat(channel.attr(HttpClientLifecycleChannelHandler.ATTR_OUTBOUND_LAST_CONTENT_PENDING)

--- a/zuul-core/src/test/java/com/netflix/netty/common/HttpClientLifecycleChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/HttpClientLifecycleChannelHandlerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.netty.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.jupiter.api.Test;
+
+class HttpClientLifecycleChannelHandlerTest {
+
+    @Test
+    void lastContentPendingAfterRequestHeadersOnly() {
+        EmbeddedChannel channel = new EmbeddedChannel(HttpClientLifecycleChannelHandler.OUTBOUND_CHANNEL_HANDLER);
+
+        channel.writeOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/foo"));
+        channel.writeOutbound(new DefaultHttpContent(Unpooled.wrappedBuffer(new byte[] {1, 2, 3})));
+
+        assertThat(channel.attr(HttpClientLifecycleChannelHandler.ATTR_OUTBOUND_LAST_CONTENT_PENDING)
+                        .get())
+                .isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void lastContentPendingClearedAfterLastHttpContent() {
+        EmbeddedChannel channel = new EmbeddedChannel(HttpClientLifecycleChannelHandler.OUTBOUND_CHANNEL_HANDLER);
+
+        channel.writeOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/foo"));
+        channel.writeOutbound(new DefaultHttpContent(Unpooled.wrappedBuffer(new byte[] {1, 2, 3})));
+        channel.writeOutbound(new DefaultLastHttpContent());
+
+        assertThat(channel.attr(HttpClientLifecycleChannelHandler.ATTR_OUTBOUND_LAST_CONTENT_PENDING)
+                        .get())
+                .isNull();
+    }
+
+    @Test
+    void lastContentPendingResetsOnNewRequest() {
+        EmbeddedChannel channel = new EmbeddedChannel(HttpClientLifecycleChannelHandler.OUTBOUND_CHANNEL_HANDLER);
+
+        channel.writeOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/first"));
+        channel.writeOutbound(new DefaultLastHttpContent());
+        assertThat(channel.attr(HttpClientLifecycleChannelHandler.ATTR_OUTBOUND_LAST_CONTENT_PENDING)
+                        .get())
+                .isNull();
+
+        // mimic the response side completing the previous request so a second start event will fire
+        channel.attr(HttpLifecycleChannelHandler.ATTR_STATE).set(null);
+
+        channel.writeOutbound(new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/second"));
+        assertThat(channel.attr(HttpClientLifecycleChannelHandler.ATTR_OUTBOUND_LAST_CONTENT_PENDING)
+                        .get())
+                .isEqualTo(Boolean.TRUE);
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolHandlerTest.java
@@ -26,6 +26,7 @@ import com.netflix.spectator.api.DefaultRegistry;
 import com.netflix.zuul.discovery.DiscoveryResult;
 import com.netflix.zuul.origins.OriginName;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,6 +42,7 @@ class ConnectionPoolHandlerTest {
     private DefaultRegistry registry;
     private ConnectionPoolMetrics metrics;
     private ConnectionPoolHandler handler;
+    private EmbeddedChannel channel;
 
     @BeforeEach
     void setup() {
@@ -48,12 +50,17 @@ class ConnectionPoolHandlerTest {
         OriginName originName = OriginName.fromVipAndApp("whatever", "whatever");
         metrics = ConnectionPoolMetrics.create(originName, registry);
         handler = new ConnectionPoolHandler(metrics);
+        channel = new EmbeddedChannel(handler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        channel.finishAndReleaseAll();
     }
 
     @Test
     void sessionCompleteReleasesConnectionToPoolWhenNothingPending() {
-        EmbeddedChannel channel = new EmbeddedChannel(handler);
-        PooledConnection conn = newPooledConnection(channel);
+        PooledConnection conn = newPooledConnection();
 
         channel.pipeline().fireUserEventTriggered(new CompleteEvent(CompleteReason.SESSION_COMPLETE, null, null));
 
@@ -64,8 +71,7 @@ class ConnectionPoolHandlerTest {
 
     @Test
     void sessionCompleteClosesConnectionWhenLastContentStillPending() {
-        EmbeddedChannel channel = new EmbeddedChannel(handler);
-        PooledConnection conn = newPooledConnection(channel);
+        PooledConnection conn = newPooledConnection();
         channel.attr(HttpClientLifecycleChannelHandler.ATTR_OUTBOUND_LAST_CONTENT_PENDING)
                 .set(Boolean.TRUE);
 
@@ -76,7 +82,7 @@ class ConnectionPoolHandlerTest {
         verify(channelManager).release(conn);
     }
 
-    private PooledConnection newPooledConnection(EmbeddedChannel channel) {
+    private PooledConnection newPooledConnection() {
         return new PooledConnection(
                 channel,
                 DiscoveryResult.EMPTY,

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.netty.connectionpool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.netflix.netty.common.HttpClientLifecycleChannelHandler;
+import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
+import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.zuul.discovery.DiscoveryResult;
+import com.netflix.zuul.origins.OriginName;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConnectionPoolHandlerTest {
+
+    @Mock
+    private ClientChannelManager channelManager;
+
+    private DefaultRegistry registry;
+    private ConnectionPoolMetrics metrics;
+    private ConnectionPoolHandler handler;
+
+    @BeforeEach
+    void setup() {
+        registry = new DefaultRegistry();
+        OriginName originName = OriginName.fromVipAndApp("whatever", "whatever");
+        metrics = ConnectionPoolMetrics.create(originName, registry);
+        handler = new ConnectionPoolHandler(metrics);
+    }
+
+    @Test
+    void sessionCompleteReleasesConnectionToPoolWhenNothingPending() {
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+        PooledConnection conn = newPooledConnection(channel);
+
+        channel.pipeline().fireUserEventTriggered(new CompleteEvent(CompleteReason.SESSION_COMPLETE, null, null));
+
+        verify(channelManager).release(conn);
+        assertThat(metrics.outboundIncompleteCounter().count()).isZero();
+        assertThat(channel.isOpen()).isTrue();
+    }
+
+    @Test
+    void sessionCompleteClosesConnectionWhenLastContentStillPending() {
+        EmbeddedChannel channel = new EmbeddedChannel(handler);
+        PooledConnection conn = newPooledConnection(channel);
+        channel.attr(HttpClientLifecycleChannelHandler.ATTR_OUTBOUND_LAST_CONTENT_PENDING)
+                .set(Boolean.TRUE);
+
+        channel.pipeline().fireUserEventTriggered(new CompleteEvent(CompleteReason.SESSION_COMPLETE, null, null));
+
+        assertThat(metrics.outboundIncompleteCounter().count()).isEqualTo(1);
+        assertThat(conn.isShouldClose()).isTrue();
+        verify(channelManager).release(conn);
+    }
+
+    private PooledConnection newPooledConnection(EmbeddedChannel channel) {
+        return new PooledConnection(
+                channel,
+                DiscoveryResult.EMPTY,
+                channelManager,
+                registry.counter("close"),
+                registry.counter("closeBusy"));
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetricsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolMetricsTest.java
@@ -60,6 +60,7 @@ class ConnectionPoolMetricsTest {
         validateCounter("connectionpool_error", metrics.errorCounter());
         validateCounter("connectionpool_headerClose", metrics.headerCloseCounter());
         validateCounter("connectionpool_sslClose", metrics.sslCloseCompletionCounter());
+        validateCounter("connectionpool_outboundIncomplete", metrics.outboundIncompleteCounter());
     }
 
     private void validateCounter(String name, Counter counter) {

--- a/zuul-integration-test/build.gradle
+++ b/zuul-integration-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation 'org.wiremock:wiremock:3.10.0'
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
-    testImplementation libraries.assertj, libraries.jupiterApi, libraries.jupiterParams, libraries.jupiterEngine, libraries.junitPlatformLauncher, libraries.jupiterMockito, libraries.okhttp
+    testImplementation libraries.assertj, libraries.awaitility, libraries.jupiterApi, libraries.jupiterParams, libraries.jupiterEngine, libraries.junitPlatformLauncher, libraries.jupiterMockito, libraries.okhttp
     testImplementation "io.netty:netty-transport-native-io_uring"
 //    testImplementation "io.netty.incubator:netty-transport-native-io_uring::linux-x86_64"
     testImplementation "org.slf4j:slf4j-api:2.0.16"

--- a/zuul-integration-test/src/test/java/com/netflix/zuul/integration/EarlyOriginResponseConnectionReuseTest.java
+++ b/zuul-integration-test/src/test/java/com/netflix/zuul/integration/EarlyOriginResponseConnectionReuseTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.netflix.config.ConfigurationManager;
+import com.netflix.netty.common.metrics.CustomLeakDetector;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ResourceLeakDetector;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Verifies that when an origin sends an early HTTP/1.1 response (e.g. a 302 redirect) before zuul
+ * has finished writing the request body, the affected origin connection is closed rather than
+ * returned to the pool, so a follow-up request gets a fresh connection and succeeds.
+ */
+class EarlyOriginResponseConnectionReuseTest {
+
+    static {
+        System.setProperty("io.netty.customResourceLeakDetector", CustomLeakDetector.class.getCanonicalName());
+    }
+
+    private static final Duration ORIGIN_READ_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(5);
+
+    @RegisterExtension
+    static ZuulServerExtension zuulExtension = ZuulServerExtension.newBuilder()
+            .withEventLoopThreads(1)
+            .withOriginReadTimeout(ORIGIN_READ_TIMEOUT)
+            .build();
+
+    private static EventLoopGroup originGroup;
+    private static Channel originChannel;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        assertThat(ResourceLeakDetector.isEnabled()).isTrue();
+        assertThat(ResourceLeakDetector.getLevel()).isEqualTo(ResourceLeakDetector.Level.PARANOID);
+        CustomLeakDetector.assertZeroLeaks();
+
+        originGroup = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+        ServerBootstrap b = new ServerBootstrap()
+                .group(originGroup)
+                .channel(NioServerSocketChannel.class)
+                .childHandler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    protected void initChannel(SocketChannel ch) {
+                        ch.pipeline().addLast(new HttpServerCodec());
+                        ch.pipeline().addLast(new EarlyResponseOriginHandler());
+                    }
+                });
+        originChannel = b.bind(0).sync().channel();
+        int originPort = ((InetSocketAddress) originChannel.localAddress()).getPort();
+
+        AbstractConfiguration config = ConfigurationManager.getConfigInstance();
+        config.setProperty("api.ribbon.listOfServers", "127.0.0.1:" + originPort);
+    }
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        if (originChannel != null) {
+            originChannel.close().sync();
+        }
+        if (originGroup != null) {
+            originGroup.shutdownGracefully().sync();
+        }
+        ConfigurationManager.getConfigInstance().clearProperty("api.ribbon.listOfServers");
+        CustomLeakDetector.assertZeroLeaks();
+    }
+
+    @AfterEach
+    void afterEach() {
+        EarlyResponseOriginHandler.reset();
+    }
+
+    @Test
+    void poisonedConnectionIsNotReusedAfterEarlyOriginResponse() throws Exception {
+        int zuulPort = zuulExtension.getServerPort();
+
+        // declare 2000-byte body but only send 100; origin will respond 302 on headers and never
+        // consume the rest, leaving the outbound HttpClientCodec encoder mid-body
+        String partialPost = "POST /redirect-on-headers HTTP/1.1\r\n"
+                + "Host: localhost:" + zuulPort + "\r\n"
+                + "Content-Type: application/octet-stream\r\n"
+                + "Content-Length: 2000\r\n"
+                + "Connection: keep-alive\r\n"
+                + "\r\n"
+                + "X".repeat(100);
+
+        try (Socket clientSocket = new Socket("localhost", zuulPort)) {
+            clientSocket.setSoTimeout((int) AWAIT_TIMEOUT.toMillis());
+            clientSocket.getOutputStream().write(partialPost.getBytes(StandardCharsets.US_ASCII));
+            clientSocket.getOutputStream().flush();
+
+            assertThat(readStatusLine(clientSocket)).contains("302");
+        }
+
+        // wait for zuul to actually tear down the poisoned origin connection
+        await().atMost(AWAIT_TIMEOUT).until(() -> EarlyResponseOriginHandler.disconnectedCount.get() == 1);
+
+        try (Socket followupSocket = new Socket("localhost", zuulPort)) {
+            followupSocket.setSoTimeout((int) AWAIT_TIMEOUT.toMillis());
+            String followupRequest = "GET /healthy HTTP/1.1\r\n"
+                    + "Host: localhost:" + zuulPort + "\r\n"
+                    + "Connection: close\r\n"
+                    + "\r\n";
+            followupSocket.getOutputStream().write(followupRequest.getBytes(StandardCharsets.US_ASCII));
+            followupSocket.getOutputStream().flush();
+
+            assertThat(readStatusLine(followupSocket)).contains("200");
+        }
+
+        assertThat(EarlyResponseOriginHandler.connectionCount.get())
+                .as("a fresh origin connection should have been opened for the follow-up request")
+                .isEqualTo(2);
+    }
+
+    private static String readStatusLine(Socket socket) throws IOException {
+        return new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII)).readLine();
+    }
+
+    /**
+     * Origin server: replies 302 on POST without consuming the body, 200 on GET. Tracks how many
+     * TCP connections zuul has opened and closed so the test can synchronise on connection state.
+     */
+    private static class EarlyResponseOriginHandler extends ChannelInboundHandlerAdapter {
+
+        static final AtomicInteger connectionCount = new AtomicInteger();
+        static final AtomicInteger disconnectedCount = new AtomicInteger();
+
+        static void reset() {
+            connectionCount.set(0);
+            disconnectedCount.set(0);
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            connectionCount.incrementAndGet();
+            super.channelActive(ctx);
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            disconnectedCount.incrementAndGet();
+            super.channelInactive(ctx);
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+            try {
+                if (msg instanceof HttpRequest request) {
+                    if (request.method().equals(HttpMethod.POST)) {
+                        ctx.writeAndFlush(buildResponse(HttpResponseStatus.FOUND, "keep-alive"));
+                    } else if (request.method().equals(HttpMethod.GET)) {
+                        ctx.writeAndFlush(buildResponse(HttpResponseStatus.OK, "close"));
+                    }
+                }
+            } finally {
+                ReferenceCountUtil.release(msg);
+            }
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            ctx.close();
+        }
+
+        private static DefaultFullHttpResponse buildResponse(HttpResponseStatus status, String connection) {
+            DefaultFullHttpResponse response =
+                    new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, Unpooled.EMPTY_BUFFER);
+            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+            response.headers().set(HttpHeaderNames.CONNECTION, connection);
+            return response;
+        }
+    }
+}


### PR DESCRIPTION
This PR ensures we close the origin connection (rather than returning it to the pool) when an HTTP/1.1 origin sends a response before zuul finishes streaming the request body to it.

If an origin responds before zuul finishes sending the request body without signally to close the connection, the outbound `HttpClientCodec` encoder is left mid-body (state `ST_CONTENT_NON_CHUNK`). When the connection is reused for the next request, the encoder rejects it with `IllegalStateException: unexpected message type: DefaultHttpRequest, state: 1`, resulting in a HTTP 500 response to an unrelated request.

Per RFC 9112 / RFC 7230, an origin that produces a response without consuming the full request body is expected to signal `Connection: close` so the connection is not reused. However, some origins don't, so we ensure the connection pool correctly protects against this case.