### PR TITLE
Preserve failure nf status set by recordFinalError in buildZuulHttpResponse

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -910,7 +910,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
         // Collect some info about the received response.
         origin.recordFinalResponse(zuulResponse);
         origin.recordFinalError(zuulRequest, ex);
-        StatusCategoryUtils.setStatusCategory(zuulCtx, statusCategory);
+        StatusCategoryUtils.storeStatusCategoryIfNotAlreadyFailure(zuulCtx, statusCategory);
         zuulCtx.setError(ex);
         zuulCtx.put("origin_http_status", Integer.toString(respStatus));
 


### PR DESCRIPTION
When origin.recordFinalError() sets a specific failure StatusCategory (e.g. from an origin subclass override), the subsequent unconditional setStatusCategory call was overwriting it with the generic status derived from the response code. 

This PR switches to use storeStatusCategoryIfNotAlreadyFailure so that a failure status set by recordFinalError is not overwritten.