### PR TITLE
Fix reentrant double responses on origin errors

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
@@ -302,10 +302,12 @@ public class ClientResponseWriter extends ChannelInboundHandlerAdapter {
         if (isHandlingRequest
                 && !startedSendingResponseToClient
                 && ctx.channel().isActive()) {
+            // mark the request is being send _before_ flushing: the flush can re-enter channelRead with a buffered
+            // response so we need to make sure we don't attempt to send again on the same stream
+            startedSendingResponseToClient = true;
             HttpResponse httpResponse =
                     new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(status));
             ctx.writeAndFlush(httpResponse).addListener(ChannelFutureListener.CLOSE);
-            startedSendingResponseToClient = true;
         } else {
             ctx.close();
         }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientResponseWriterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientResponseWriterTest.java
@@ -44,6 +44,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.ReferenceCountUtil;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -139,6 +140,47 @@ class ClientResponseWriterTest {
                 .fireUserEventTriggered(new HttpLifecycleChannelHandler.CompleteEvent(
                         HttpLifecycleChannelHandler.CompleteReason.SESSION_COMPLETE, null, nettyResp.get()));
         assertThat(responseWriter.getZuulResponse()).isNull();
+    }
+
+    @Test
+    void doesNotWriteSecondResponseWhenFlushReentersChannelRead() {
+        ClientResponseWriter responseWriter = new ClientResponseWriter(new BasicRequestCompleteHandler());
+        EmbeddedChannel channel = new EmbeddedChannel(responseWriter);
+
+        SessionContext ctx = new SessionContext();
+        HttpRequestMessage request = new HttpRequestBuilder(ctx).build();
+        request.storeInboundRequest();
+        DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        ctx.set(CommonContextKeys.NETTY_HTTP_REQUEST, nettyRequest);
+        channel.attr(ClientRequestReceiver.ATTR_ZUUL_REQ).set(request);
+
+        HttpResponseMessageImpl bufferedResponse = new HttpResponseMessageImpl(ctx, request, 200);
+        bufferedResponse.setHeaders(new Headers());
+
+        AtomicInteger responsesWritten = new AtomicInteger();
+
+        // simulate an error response flush completing and firing a CompleteEvent back up
+        channel.pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
+            private boolean reentered;
+
+            @Override
+            public void write(ChannelHandlerContext context, Object msg, ChannelPromise promise) throws Exception {
+                if (msg instanceof HttpResponse) {
+                    responsesWritten.incrementAndGet();
+                }
+                ReferenceCountUtil.safeRelease(msg);
+                promise.setSuccess();
+                if (!reentered) {
+                    reentered = true;
+                    context.fireChannelRead(bufferedResponse);
+                }
+            }
+        });
+
+        channel.pipeline().fireUserEventTriggered(new HttpLifecycleChannelHandler.StartEvent(nettyRequest));
+        channel.pipeline().fireExceptionCaught(new RuntimeException("origin read timeout"));
+
+        assertThat(responsesWritten.get()).isEqualTo(1);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
 When an origin read times out while a response is still buffered inside a body-buffering response filter, `ClientResponseWriter.exceptionCaught` writes an error response and flushes it. That flush can complete synchronously and fire a `CompleteEvent`, which causes `ZuulFilterChainHandler.finishResponseFilters` to re-deliver the still-buffered response into `channelRead`. Resulting in a _second_ `HttpResponse` on the same stream. 
`HttpContentEncoder` then throws `IllegalStateException: cannot send more responses than requests`.

The reentrant `channelRead` runs before `exceptionCaught` sets `startedSendingResponseToClient = true` (as this is in the same event loop, synchronous), so the existing guard in `channelRead` doesn't catch it. This PR sets the flag before the `writeAndFlush` so the reentrant delivery takes the dispose-and-close path instead of writing a second response.

```
java.lang.IllegalStateException: cannot send more responses than requests
    at io.netty.handler.codec.http.HttpContentEncoder.encode(HttpContentEncoder.java:130)   // (2) second response rejected
    ...
    at com.netflix.zuul.netty.server.ClientResponseWriter.channelRead(ClientResponseWriter.java:133)   // re-delivered buffered response -> 2nd write
    at com.netflix.zuul.netty.filter.ZuulFilterChainRunner.runFilters(ZuulFilterChainRunner.java:170)
    at com.netflix.zuul.netty.filter.ZuulFilterChainHandler.finishResponseFilters(ZuulFilterChainHandler.java:148)
    at com.netflix.zuul.netty.filter.ZuulFilterChainHandler.fireEndpointFinish(ZuulFilterChainHandler.java:132)
    at com.netflix.zuul.netty.filter.ZuulFilterChainHandler.userEventTriggered(ZuulFilterChainHandler.java:91)   // CompleteEvent fires back up the pipeline
    ...
    at com.netflix.netty.common.HttpLifecycleChannelHandler.fireCompleteEventIfNotAlready(HttpLifecycleChannelHandler.java:96)
    at com.netflix.netty.common.HttpServerLifecycleChannelHandler$HttpServerLifecycleOutboundChannelHandler.lambda$write$0(HttpServerLifecycleChannelHandler.java:88)
    ...
    at io.netty.channel.ChannelOutboundBuffer.remove(ChannelOutboundBuffer.java:302)   // flushed error response completes synchronously
    ...
    at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:776)
    at com.netflix.zuul.netty.server.ClientResponseWriter.exceptionCaught(ClientResponseWriter.java:307)   // (1) error response written + flushed
```