### PR TITLE
update netty to v4.2.15

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 versions_ribbon=2.4.4
-versions_netty=4.2.13.Final
+versions_netty=4.2.15.Final
 versions_brotli4j=1.16.0
 release.scope=patch
 release.version=3.3.0-SNAPSHOT

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -48,43 +48,43 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -176,43 +176,43 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -307,7 +307,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -316,40 +316,40 @@
             "locked": "1.10"
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.77.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -471,46 +471,46 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.77.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -586,7 +586,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -595,37 +595,37 @@
             "locked": "1.10"
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -735,7 +735,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -744,40 +744,40 @@
             "locked": "1.10"
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "locked": "2.0.77.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -78,7 +78,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -102,43 +102,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -150,25 +150,25 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -276,7 +276,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -294,46 +294,46 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -437,7 +437,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -455,46 +455,46 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -617,7 +617,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -638,43 +638,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -686,28 +686,28 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -876,7 +876,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -894,43 +894,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -942,28 +942,28 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1082,7 +1082,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1103,49 +1103,49 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1292,7 +1292,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1313,43 +1313,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1361,28 +1361,28 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -63,7 +63,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -78,43 +78,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -218,7 +218,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -233,43 +233,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -377,7 +377,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -392,43 +392,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -440,25 +440,25 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -606,7 +606,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -621,43 +621,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -669,25 +669,25 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -818,7 +818,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -842,43 +842,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -890,25 +890,25 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1016,7 +1016,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1031,43 +1031,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1184,7 +1184,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1199,43 +1199,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1247,25 +1247,25 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -78,7 +78,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -102,43 +102,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -150,25 +150,25 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -273,7 +273,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -291,43 +291,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -440,7 +440,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -458,43 +458,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -614,7 +614,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -632,43 +632,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -680,25 +680,25 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -843,7 +843,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -861,43 +861,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -909,25 +909,25 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1052,7 +1052,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1070,43 +1070,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1220,7 +1220,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.6"
+            "locked": "1.9.8"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1238,43 +1238,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
@@ -1286,25 +1286,25 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.13.Final"
+            "locked": "4.2.15.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
v4.2.14 has a number of bugfixes:  https://netty.io/news/2026/05/20/4-2-14-Final.html
v4.2.15 has a whole lot of security fixes: https://netty.io/news/2026/06/01/4-2-15-Final.html

 This also brought along a minor version update to spectator-api (1.9.6 -> 1.9.8).