### PR TITLE
Add `getServers` to `Resolver` and `ClientChannelManager` to expose the origin pool

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ClientChannelManager.java
@@ -21,6 +21,7 @@ import com.netflix.zuul.passport.CurrentPassport;
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Promise;
 import java.net.InetAddress;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -53,6 +54,15 @@ public interface ClientChannelManager {
             AtomicReference<? super InetAddress> selectedHostAddr);
 
     boolean isCold();
+
+    /**
+     * Returns a read-only snapshot of all origin servers this manager currently load-balances over, or an
+     * empty list when the manager cannot expose them. This does not pick or acquire a connection - it is a
+     * view for callers that need per-server discovery metadata.
+     */
+    default List<DiscoveryResult> getServers() {
+        return List.of();
+    }
 
     boolean remove(PooledConnection conn);
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManager.java
@@ -123,6 +123,11 @@ public class DefaultClientChannelManager implements ClientChannelManager {
     }
 
     @Override
+    public List<DiscoveryResult> getServers() {
+        return dynamicServerResolver.getServers();
+    }
+
+    @Override
     public boolean isCold() {
         return false;
     }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManagerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/DefaultClientChannelManagerTest.java
@@ -46,6 +46,7 @@ import io.netty.util.concurrent.Promise;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.SocketAddress;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -120,6 +121,27 @@ class DefaultClientChannelManagerTest {
                 .as(socketAddress.toString())
                 .isTrue();
         assertThat(socketAddress.getPort()).isEqualTo(443);
+    }
+
+    @Test
+    void getServersDelegatesToResolver() {
+        OriginName originName = OriginName.fromVip("vip", "test");
+        DefaultClientConfigImpl clientConfig = new DefaultClientConfigImpl();
+        DynamicServerResolver resolver = mock(DynamicServerResolver.class);
+
+        DiscoveryResult result = DiscoveryResult.from(
+                InstanceInfo.Builder.newBuilder()
+                        .setAppName("server-list")
+                        .setHostName("server-list")
+                        .setPort(7777)
+                        .build(),
+                false);
+        when(resolver.getServers()).thenReturn(List.of(result));
+
+        DefaultClientChannelManager clientChannelManager =
+                new DefaultClientChannelManager(originName, clientConfig, resolver, new DefaultRegistry());
+
+        assertThat(clientChannelManager.getServers()).containsExactly(result);
     }
 
     @Test

--- a/zuul-discovery/src/main/java/com/netflix/zuul/discovery/DynamicServerResolver.java
+++ b/zuul-discovery/src/main/java/com/netflix/zuul/discovery/DynamicServerResolver.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import com.netflix.client.config.CommonClientConfigKey;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.DynamicServerListLoadBalancer;
+import com.netflix.loadbalancer.LoadBalancerStats;
 import com.netflix.loadbalancer.Server;
 import com.netflix.niws.loadbalancer.DiscoveryEnabledServer;
 import com.netflix.zuul.resolver.Resolver;
@@ -85,6 +86,15 @@ public class DynamicServerResolver implements Resolver<DiscoveryResult> {
     @Override
     public boolean hasServers() {
         return !loadBalancer.getReachableServers().isEmpty();
+    }
+
+    @Override
+    public List<DiscoveryResult> getServers() {
+        LoadBalancerStats lbStats = loadBalancer.getLoadBalancerStats();
+        return loadBalancer.getAllServers().stream()
+                .filter(DiscoveryEnabledServer.class::isInstance)
+                .map(server -> new DiscoveryResult((DiscoveryEnabledServer) server, lbStats))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/zuul-discovery/src/main/java/com/netflix/zuul/resolver/Resolver.java
+++ b/zuul-discovery/src/main/java/com/netflix/zuul/resolver/Resolver.java
@@ -16,6 +16,8 @@
 
 package com.netflix.zuul.resolver;
 
+import java.util.List;
+
 /**
  * @author Argha C
  * @since 2/25/21
@@ -37,6 +39,16 @@ public interface Resolver<T> {
      * @return true if the resolver has available servers, false otherwise
      */
     boolean hasServers();
+
+    /**
+     * Returns a snapshot of all servers currently known to the resolver, or an empty list when the
+     * resolver does not expose its server list. Unlike resolve, this does not pick or load-balance - it
+     * is a read-only view for callers that need to inspect the whole pool (e.g. per-server discovery
+     * metadata).
+     */
+    default List<T> getServers() {
+        return List.of();
+    }
 
     /**
      * hook to perform activities on shutdown

--- a/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DynamicServerResolverTest.java
+++ b/zuul-discovery/src/test/java/com/netflix/zuul/discovery/DynamicServerResolverTest.java
@@ -17,11 +17,16 @@
 package com.netflix.zuul.discovery;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.netflix.appinfo.InstanceInfo;
 import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.loadbalancer.DynamicServerListLoadBalancer;
+import com.netflix.loadbalancer.LoadBalancerStats;
+import com.netflix.loadbalancer.Server;
 import com.netflix.niws.loadbalancer.DiscoveryEnabledServer;
 import com.netflix.zuul.resolver.ResolverListener;
 import java.util.List;
@@ -68,6 +73,41 @@ class DynamicServerResolverTest {
         resolver.onUpdate(ImmutableList.of(server1, server2), ImmutableList.of());
 
         assertThat(listener.updatedList()).containsExactly(new DiscoveryResult(server1), new DiscoveryResult(server2));
+    }
+
+    @Test
+    void getServersMapsDiscoveryServersAndSkipsNonDiscoveryServers() {
+        InstanceInfo first = InstanceInfo.Builder.newBuilder()
+                .setAppName("zuul-discovery-1")
+                .setHostName("zuul-discovery-1")
+                .setIPAddr("100.10.10.1")
+                .setPort(443)
+                .build();
+        InstanceInfo second = InstanceInfo.Builder.newBuilder()
+                .setAppName("zuul-discovery-2")
+                .setHostName("zuul-discovery-2")
+                .setIPAddr("100.10.10.2")
+                .setPort(443)
+                .build();
+        DiscoveryEnabledServer server1 = new DiscoveryEnabledServer(first, true);
+        DiscoveryEnabledServer server2 = new DiscoveryEnabledServer(second, true);
+        Server plainServer = new Server("100.10.10.3", 443);
+
+        @SuppressWarnings("unchecked")
+        DynamicServerListLoadBalancer<Server> loadBalancer = mock(DynamicServerListLoadBalancer.class);
+        when(loadBalancer.getAllServers()).thenReturn(List.of(server1, plainServer, server2));
+        when(loadBalancer.getLoadBalancerStats()).thenReturn(new LoadBalancerStats("test"));
+
+        DynamicServerResolver resolver = new DynamicServerResolver(loadBalancer);
+
+        assertThat(resolver.getServers()).containsExactly(new DiscoveryResult(server1), new DiscoveryResult(server2));
+    }
+
+    @Test
+    void getServersIsEmptyWhenLoadBalancerHasNoServers() {
+        DynamicServerResolver resolver = new DynamicServerResolver(new DefaultClientConfigImpl());
+
+        assertThat(resolver.getServers()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
`Resolver` and `ClientChannelManager` only expose `resolve`, which load-balances and hands back a single server - there's no way to read the full set of origins they currently know about without picking one. That's fine for routing, but not for callers that want to inspect per-server discovery metadata across the whole pool.

This PR adds a `getServers()`, returning a read-only snapshot of all known servers without picking or acquiring a connection.