### PR TITLE
Ensure `SslExceptionsHandler` swallows all client SSL exceptions, not just handshake failures

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/SslExceptionsHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/SslExceptionsHandler.java
@@ -20,7 +20,7 @@ import com.netflix.spectator.api.Registry;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,12 +44,31 @@ public class SslExceptionsHandler extends ChannelInboundHandlerAdapter {
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         // In certain cases, depending on the client, these stack traces can get very deep.
         // We intentionally avoid propagating this up the pipeline, to avoid verbose disk logging.
-        if (cause.getCause() instanceof SSLHandshakeException) {
-            logger.debug("SSL handshake failed on channel {}", ctx.channel(), cause);
-            registry.counter("server.ssl.exception.swallowed", "cause", "SSLHandshakeException")
+        SSLException sslException = findSslException(cause);
+        if (sslException != null) {
+            logger.debug("SSL exception swallowed on channel {}", ctx.channel(), cause);
+            registry.counter(
+                            "server.ssl.exception.swallowed",
+                            "cause",
+                            sslException.getClass().getSimpleName())
                     .increment();
         } else {
             super.exceptionCaught(ctx, cause);
         }
+    }
+
+    // SSL errors raised during decode arrive wrapped in a DecoderException,
+    // so the SSLException is not the top-level cause
+    private static SSLException findSslException(Throwable cause) {
+        Throwable current = cause;
+        while (current != null) {
+            if (current instanceof SSLException sslException) {
+                return sslException;
+            }
+
+            current = current.getCause();
+        }
+
+        return null;
     }
 }

--- a/zuul-core/src/test/java/com/netflix/netty/common/SslExceptionsHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/SslExceptionsHandlerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.netty.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.Registry;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+import org.junit.jupiter.api.Test;
+
+class SslExceptionsHandlerTest {
+
+    private final Registry registry = new DefaultRegistry();
+
+    @Test
+    void swallowsSslExceptionWrappedInDecoderException() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SslExceptionsHandler(registry));
+
+        channel.pipeline()
+                .fireExceptionCaught(new DecoderException(
+                        new SSLException("error:1e000065:Cipher functions:OPENSSL_internal:BAD_DECRYPT")));
+
+        assertThatCode(channel::checkException).doesNotThrowAnyException();
+        assertThat(swallowedCount("SSLException")).isEqualTo(1);
+    }
+
+    @Test
+    void swallowsTopLevelSslException() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SslExceptionsHandler(registry));
+
+        channel.pipeline().fireExceptionCaught(new SSLException("not an SSL/TLS record"));
+
+        assertThatCode(channel::checkException).doesNotThrowAnyException();
+        assertThat(swallowedCount("SSLException")).isEqualTo(1);
+    }
+
+    @Test
+    void swallowsHandshakeExceptionTaggedByType() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SslExceptionsHandler(registry));
+
+        channel.pipeline().fireExceptionCaught(new DecoderException(new SSLHandshakeException("no cipher overlap")));
+
+        assertThatCode(channel::checkException).doesNotThrowAnyException();
+        assertThat(swallowedCount("SSLHandshakeException")).isEqualTo(1);
+    }
+
+    @Test
+    void swallowsDeeplyNestedSslException() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SslExceptionsHandler(registry));
+
+        channel.pipeline()
+                .fireExceptionCaught(
+                        new RuntimeException("outer", new DecoderException(new SSLException("WRONG_VERSION_NUMBER"))));
+
+        assertThatCode(channel::checkException).doesNotThrowAnyException();
+        assertThat(swallowedCount("SSLException")).isEqualTo(1);
+    }
+
+    @Test
+    void propagatesNonSslException() {
+        EmbeddedChannel channel = new EmbeddedChannel(new SslExceptionsHandler(registry));
+
+        channel.pipeline().fireExceptionCaught(new IllegalStateException("boom"));
+
+        assertThatThrownBy(channel::checkException).isInstanceOf(IllegalStateException.class);
+        assertThat(swallowedCount("SSLException")).isZero();
+    }
+
+    private long swallowedCount(String cause) {
+        return registry.counter("server.ssl.exception.swallowed", "cause", cause)
+                .count();
+    }
+}


### PR DESCRIPTION
`SslExceptionsHandler` only swallows TLS handshake failures, and only when wrapped exactly one level deep (`cause.getCause() instanceof SSLHandshakeException`). Other client-induced TLS decode errors - `BAD_DECRYPT`, `WRONG_VERSION_NUMBER` and friends, typically a client speaking plaintext to the TLS port or sending a corrupt record - surface as a generic `OpenSslException` (an `SSLException`, *not* an `SSLHandshakeException`) wrapped in a `DecoderException`, so those propagate through.

The result is a full stack trace logged per bad connection: on HTTP/1.1 at ERROR via `ZuulFilterChainHandler`, and on HTTP/2 parent connections at WARN once the exception reaches the pipeline tail.

```
# currently
ERROR ZuulFilterChainHandler  zuul filter chain handler caught exception on channel: ...   # h1
WARN  DefaultChannelPipeline  An exceptionCaught() event ... reached at the tail ...        # h2 parent
io.netty.handler.codec.DecoderException: ...OpenSslException: ...OPENSSL_internal:BAD_DECRYPT

# now
debug-only; server.ssl.exception.swallowed{cause=OpenSslException} incremented
```

This PR walks the cause chain for any `SSLException` rather than checking a single level for one subtype, ensuring we catch and handle all client-side TLS errors.