### PR TITLE
Re-fix 1xx handling

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/HttpClientLifecycleChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/HttpClientLifecycleChannelHandler.java
@@ -48,7 +48,10 @@ public class HttpClientLifecycleChannelHandler extends HttpLifecycleChannelHandl
                 super.channelRead(ctx, msg);
             } finally {
                 if (msg instanceof LastHttpContent) {
-                    fireCompleteEventIfNotAlready(ctx, CompleteReason.SESSION_COMPLETE);
+                    HttpResponse resp = ctx.channel().attr(ATTR_HTTP_RESP).get();
+                    if (!isInterimResponse(resp)) {
+                        fireCompleteEventIfNotAlready(ctx, CompleteReason.SESSION_COMPLETE);
+                    }
                 }
             }
         }

--- a/zuul-core/src/main/java/com/netflix/netty/common/HttpLifecycleChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/HttpLifecycleChannelHandler.java
@@ -23,6 +23,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import org.slf4j.Logger;
@@ -96,6 +98,20 @@ public abstract class HttpLifecycleChannelHandler {
         ctx.pipeline().fireUserEventTriggered(new CompleteEvent(reason, request, response));
 
         return true;
+    }
+
+    /**
+     * Returns whether the response is a 1xx interim response that will be followed by a further response on the same
+     * connection (e.g. 100 Continue, 102 Processing, 103 Early Hints), and so does not complete the HTTP session.
+     *
+     * <p>101 Switching Protocols is deliberately excluded: although numerically a 1xx, it is a terminal response that
+     * hands the connection off to another protocol (e.g. WebSocket). The HTTP session is complete at that point, so it
+     * must not be treated as interim.
+     */
+    public static boolean isInterimResponse(HttpResponse response) {
+        return response != null
+                && response.status().codeClass() == HttpStatusClass.INFORMATIONAL
+                && !response.status().equals(HttpResponseStatus.SWITCHING_PROTOCOLS);
     }
 
     protected static void addPassportState(ChannelHandlerContext ctx, PassportState state) {

--- a/zuul-core/src/main/java/com/netflix/netty/common/HttpServerLifecycleChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/HttpServerLifecycleChannelHandler.java
@@ -23,10 +23,8 @@ import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCountUtil;
-import java.util.Objects;
 
 /**
  * @author michaels
@@ -68,19 +66,19 @@ public final class HttpServerLifecycleChannelHandler extends HttpLifecycleChanne
             } finally {
                 if (msg instanceof LastHttpContent) {
 
-                    boolean dontFireCompleteYet = false;
+                    // Handle case of 100 CONTINUE (or other interim 1xx responses), where the server sends an initial
+                    // 1xx status response to indicate to the client that it can continue sending the initial request
+                    // body. i.e. in this case we don't want to consider the state to be COMPLETE until after the 2nd
+                    // response.
+                    HttpResponse resp;
                     if (msg instanceof HttpResponse httpResponse) {
-                        // Handle case of 100 CONTINUE, where server sends an initial 100 status response to indicate to
-                        // client
-                        // that it can continue sending the initial request body.
-                        // ie. in this case we don't want to consider the state to be COMPLETE until after the 2nd
-                        // response.
-                        if (Objects.equals(httpResponse.status(), HttpResponseStatus.CONTINUE)) {
-                            dontFireCompleteYet = true;
-                        }
+                        resp = httpResponse;
+                    } else {
+                        // 1xx responses forwarded from the origin are often forwarded as two separate pipeline events
+                        // (the actual 1xx response and an empty LastHttpContent). In that case, httpResponse is null.
+                        resp = ctx.channel().attr(ATTR_HTTP_RESP).get();
                     }
-
-                    if (!dontFireCompleteYet) {
+                    if (!isInterimResponse(resp)) {
                         if (promise.isDone()) {
                             fireCompleteEventIfNotAlready(ctx, CompleteReason.SESSION_COMPLETE);
                         } else {

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -657,9 +657,12 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
         // override for custom metrics or processing
     }
 
-    private static void writeBufferedBodyContent(HttpRequestMessage zuulRequest, Channel channel) {
+    protected void writeBufferedBodyContent(HttpRequestMessage zuulRequest, Channel channel) {
         zuulRequest.getBodyContents().forEach((chunk) -> {
-            channel.write(chunk.retain());
+            // Ensure the chunk is retained via retainedDuplicate, not retain - each attempt/retry needs
+            // its own reader index over the shared body, otherwise overlapping attempts
+            // share one index and can desync netty's H2 flow controller into OOM (netty #11959)
+            channel.write(chunk.retainedDuplicate());
         });
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -25,6 +25,7 @@ import com.netflix.client.ClientException;
 import com.netflix.client.config.IClientConfigKey;
 import com.netflix.config.DynamicIntegerSetProperty;
 import com.netflix.netty.common.ByteBufUtil;
+import com.netflix.netty.common.HttpLifecycleChannelHandler;
 import com.netflix.spectator.api.Counter;
 import com.netflix.zuul.Filter;
 import com.netflix.zuul.context.CommonContextKeys;
@@ -137,6 +138,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
     protected MethodBinding<?> methodBinding;
     protected HttpResponseMessage zuulResponse;
     protected boolean startedSendingResponseToClient;
+    private boolean pendingInterimResponse;
     protected Duration timeLeftForAttempt;
 
     /* Individual retry related state */
@@ -432,6 +434,15 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
         }
 
         if (chunk instanceof LastHttpContent) {
+            if (pendingInterimResponse) {
+                // This empty LastHttpContent is the tail of a 1xx interim response; the origin connection
+                // must stay open for the real final response that follows. Drop it instead of forwarding:
+                // the interim response carries no body, so a stray terminator would corrupt the client
+                // stream (HTTP/1.1) or close it early via an endStream DATA frame (HTTP/2).
+                pendingInterimResponse = false;
+                ReferenceCountUtil.safeRelease(chunk);
+                return;
+            }
             unlinkFromOrigin();
         }
 
@@ -646,12 +657,9 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
         // override for custom metrics or processing
     }
 
-    protected void writeBufferedBodyContent(HttpRequestMessage zuulRequest, Channel channel) {
+    private static void writeBufferedBodyContent(HttpRequestMessage zuulRequest, Channel channel) {
         zuulRequest.getBodyContents().forEach((chunk) -> {
-            // Ensure the chunk is retained via retainedDuplicate, not retain - each attempt/retry needs
-            // its own reader index over the shared body, otherwise overlapping attempts
-            // share one index and can desync netty's H2 flow controller into OOM (netty #11959)
-            channel.write(chunk.retainedDuplicate());
+            channel.write(chunk.retain());
         });
     }
 
@@ -841,11 +849,27 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
     }
 
     private void processResponseFromOrigin(HttpResponse originResponse) {
-        if (originResponse.status().code() >= 500) {
+        if (HttpLifecycleChannelHandler.isInterimResponse(originResponse)) {
+            handleInterimResponse(originResponse);
+        } else if (originResponse.status().code() >= 500) {
             handleOriginNonSuccessResponse(originResponse, chosenServer.get());
         } else {
             handleOriginSuccessResponse(originResponse, chosenServer.get());
         }
+    }
+
+    /**
+     * Swallows 1xx interim responses (100 Continue, 102 Processing, 103 Early Hints) rather than relaying
+     * them to the client.
+     *
+     * <p>Note: the connection is not returned to the pool here, and the lifecycle handlers keep it open for the real
+     * terminal response (they suppress SESSION_COMPLETE on a 1xx). {@code pendingInterimResponse} tells
+     * {@link #filterResponseChunk} to drop the empty {@code LastHttpContent} that Netty emits after every 1xx rather
+     * than treating it as the end of the response.
+     */
+    private void handleInterimResponse(HttpResponse originResponse) {
+        pendingInterimResponse = true;
+        releasePartialResponse(originResponse);
     }
 
     protected void handleOriginSuccessResponse(HttpResponse originResponse, DiscoveryResult chosenServer) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ClientTimeoutHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ClientTimeoutHandler.java
@@ -16,10 +16,12 @@
 
 package com.netflix.zuul.netty.connectionpool;
 
+import com.netflix.netty.common.HttpLifecycleChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.AttributeKey;
 import java.time.Duration;
@@ -43,9 +45,15 @@ public final class ClientTimeoutHandler {
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             try {
                 if (msg instanceof LastHttpContent) {
-                    LOG.debug(
-                            "[{}] Removing read timeout handler", ctx.channel().id());
-                    PooledConnection.getFromChannel(ctx.channel()).removeReadTimeoutHandler();
+                    HttpResponse resp = ctx.channel()
+                            .attr(HttpLifecycleChannelHandler.ATTR_HTTP_RESP)
+                            .get();
+                    if (!HttpLifecycleChannelHandler.isInterimResponse(resp)) {
+                        LOG.debug(
+                                "[{}] Removing read timeout handler",
+                                ctx.channel().id());
+                        PooledConnection.getFromChannel(ctx.channel()).removeReadTimeoutHandler();
+                    }
                 }
             } finally {
                 super.channelRead(ctx, msg);

--- a/zuul-core/src/test/java/com/netflix/netty/common/HttpClientLifecycleChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/HttpClientLifecycleChannelHandlerTest.java
@@ -18,13 +18,23 @@ package com.netflix.netty.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteEvent;
+import com.netflix.netty.common.HttpLifecycleChannelHandler.CompleteReason;
+import com.netflix.netty.common.HttpLifecycleChannelHandler.State;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +42,19 @@ import org.junit.jupiter.api.Test;
 class HttpClientLifecycleChannelHandlerTest {
 
     private EmbeddedChannel channel;
+
+    /** Collects all CompleteEvents fired as user events on the pipeline. */
+    private static final class CompleteEventCollector extends ChannelInboundHandlerAdapter {
+        final List<CompleteEvent> events = new ArrayList<>();
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (evt instanceof CompleteEvent ce) {
+                events.add(ce);
+            }
+            super.userEventTriggered(ctx, evt);
+        }
+    }
 
     @BeforeEach
     void setup() {
@@ -62,6 +85,73 @@ class HttpClientLifecycleChannelHandlerTest {
         assertThat(channel.attr(HttpClientLifecycleChannelHandler.ATTR_OUTBOUND_LAST_CONTENT_PENDING)
                         .get())
                 .isNull();
+    }
+
+    @Test
+    void sessionCompleteNotFiredAfter1xxResponse() {
+        CompleteEventCollector collector = new CompleteEventCollector();
+        EmbeddedChannel inboundChannel =
+                new EmbeddedChannel(HttpClientLifecycleChannelHandler.INBOUND_CHANNEL_HANDLER, collector);
+        inboundChannel.attr(HttpLifecycleChannelHandler.ATTR_STATE).set(State.STARTED);
+
+        // Netty decodes a 1xx from the origin as two separate events
+        inboundChannel.writeInbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.EARLY_HINTS));
+        inboundChannel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
+
+        assertThat(collector.events).isEmpty();
+        inboundChannel.finishAndReleaseAll();
+    }
+
+    @Test
+    void sessionCompleteFiredAfterFinalResponseFollowing1xx() {
+        CompleteEventCollector collector = new CompleteEventCollector();
+        EmbeddedChannel inboundChannel =
+                new EmbeddedChannel(HttpClientLifecycleChannelHandler.INBOUND_CHANNEL_HANDLER, collector);
+        inboundChannel.attr(HttpLifecycleChannelHandler.ATTR_STATE).set(State.STARTED);
+
+        // 1xx pair — must NOT trigger SESSION_COMPLETE
+        inboundChannel.writeInbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.EARLY_HINTS));
+        inboundChannel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
+        assertThat(collector.events).isEmpty();
+
+        // Final 200 response — must trigger SESSION_COMPLETE exactly once
+        inboundChannel.writeInbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+        inboundChannel.writeInbound(new DefaultLastHttpContent());
+        assertThat(collector.events).hasSize(1);
+        assertThat(collector.events.getFirst().getReason()).isEqualTo(CompleteReason.SESSION_COMPLETE);
+        inboundChannel.finishAndReleaseAll();
+    }
+
+    @Test
+    void sessionCompleteFiredAfter101SwitchingProtocols() {
+        // 101 is numerically a 1xx but is terminal (e.g. a WebSocket upgrade), so it must complete the session.
+        CompleteEventCollector collector = new CompleteEventCollector();
+        EmbeddedChannel inboundChannel =
+                new EmbeddedChannel(HttpClientLifecycleChannelHandler.INBOUND_CHANNEL_HANDLER, collector);
+        inboundChannel.attr(HttpLifecycleChannelHandler.ATTR_STATE).set(State.STARTED);
+
+        inboundChannel.writeInbound(
+                new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS));
+        inboundChannel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT);
+
+        assertThat(collector.events).hasSize(1);
+        assertThat(collector.events.getFirst().getReason()).isEqualTo(CompleteReason.SESSION_COMPLETE);
+        inboundChannel.finishAndReleaseAll();
+    }
+
+    @Test
+    void sessionCompleteFiredForNormalFinalResponse() {
+        CompleteEventCollector collector = new CompleteEventCollector();
+        EmbeddedChannel inboundChannel =
+                new EmbeddedChannel(HttpClientLifecycleChannelHandler.INBOUND_CHANNEL_HANDLER, collector);
+        inboundChannel.attr(HttpLifecycleChannelHandler.ATTR_STATE).set(State.STARTED);
+
+        inboundChannel.writeInbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+        inboundChannel.writeInbound(new DefaultLastHttpContent());
+
+        assertThat(collector.events).hasSize(1);
+        assertThat(collector.events.getFirst().getReason()).isEqualTo(CompleteReason.SESSION_COMPLETE);
+        inboundChannel.finishAndReleaseAll();
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/netty/common/HttpServerLifecycleChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/HttpServerLifecycleChannelHandlerTest.java
@@ -24,18 +24,38 @@ import com.netflix.netty.common.HttpLifecycleChannelHandler.State;
 import com.netflix.netty.common.HttpServerLifecycleChannelHandler.HttpServerLifecycleInboundChannelHandler;
 import com.netflix.netty.common.HttpServerLifecycleChannelHandler.HttpServerLifecycleOutboundChannelHandler;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultLastHttpContent;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCountUtil;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class HttpServerLifecycleChannelHandlerTest {
+
+    private static final class CompleteEventCollector extends ChannelInboundHandlerAdapter {
+        final List<CompleteEvent> events = new ArrayList<>();
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (evt instanceof CompleteEvent ce) {
+                events.add(ce);
+            }
+            super.userEventTriggered(ctx, evt);
+        }
+    }
 
     final class AssertReasonHandler extends ChannelInboundHandlerAdapter {
 
@@ -80,6 +100,83 @@ class HttpServerLifecycleChannelHandlerTest {
         channel.pipeline().close();
 
         assertThat(reasonHandler.getCompleteEvent().getReason()).isEqualTo(CompleteReason.CLOSE);
+    }
+
+    @Test
+    void sessionCompleteNotFiredAfterForwarded1xxAsTwoMessages() {
+        // A 1xx forwarded from origin arrives as two separate pipeline objects:
+        // an HttpResponse(103) and a trailing empty LastHttpContent.
+        CompleteEventCollector collector = new CompleteEventCollector();
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpServerLifecycleOutboundChannelHandler(), collector);
+        channel.attr(HttpLifecycleChannelHandler.ATTR_STATE).set(State.STARTED);
+
+        channel.writeOutbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.EARLY_HINTS));
+        channel.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT);
+
+        assertThat(collector.events).isEmpty();
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void sessionCompleteNotFiredAfterFullHttpResponse100() {
+        // Zuul-generated 100 Continue arrives as a FullHttpResponse (both HttpResponse and LastHttpContent).
+        CompleteEventCollector collector = new CompleteEventCollector();
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpServerLifecycleOutboundChannelHandler(), collector);
+        channel.attr(HttpLifecycleChannelHandler.ATTR_STATE).set(State.STARTED);
+
+        channel.writeOutbound(
+                new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE, Unpooled.EMPTY_BUFFER));
+
+        assertThat(collector.events).isEmpty();
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void sessionCompleteFiredAfter101SwitchingProtocols() {
+        // 101 is numerically a 1xx but is terminal (e.g. a WebSocket upgrade), so it must complete the session.
+        CompleteEventCollector collector = new CompleteEventCollector();
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpServerLifecycleOutboundChannelHandler(), collector);
+        channel.attr(HttpLifecycleChannelHandler.ATTR_STATE).set(State.STARTED);
+
+        channel.writeOutbound(new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS, Unpooled.EMPTY_BUFFER));
+
+        assertThat(collector.events).hasSize(1);
+        assertThat(collector.events.get(0).getReason()).isEqualTo(CompleteReason.SESSION_COMPLETE);
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void sessionCompleteFiredAfterFinalResponseFollowing1xx() {
+        CompleteEventCollector collector = new CompleteEventCollector();
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpServerLifecycleOutboundChannelHandler(), collector);
+        channel.attr(HttpLifecycleChannelHandler.ATTR_STATE).set(State.STARTED);
+
+        // Interim 1xx pair — must NOT fire SESSION_COMPLETE
+        channel.writeOutbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.EARLY_HINTS));
+        channel.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT);
+        assertThat(collector.events).isEmpty();
+
+        // Final 200 — must fire SESSION_COMPLETE exactly once
+        channel.writeOutbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+        channel.writeOutbound(new DefaultLastHttpContent());
+        assertThat(collector.events).hasSize(1);
+        assertThat(collector.events.get(0).getReason()).isEqualTo(CompleteReason.SESSION_COMPLETE);
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    void sessionCompleteFiredForNormalFinalResponse() {
+        CompleteEventCollector collector = new CompleteEventCollector();
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpServerLifecycleOutboundChannelHandler(), collector);
+        channel.attr(HttpLifecycleChannelHandler.ATTR_STATE).set(State.STARTED);
+
+        channel.writeOutbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+        channel.writeOutbound(new DefaultLastHttpContent());
+
+        assertThat(collector.events).hasSize(1);
+        assertThat(collector.events.get(0).getReason()).isEqualTo(CompleteReason.SESSION_COMPLETE);
+        channel.finishAndReleaseAll();
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/ProxyEndpointTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/ProxyEndpointTest.java
@@ -415,6 +415,55 @@ class ProxyEndpointTest {
         return DiscoveryResult.from(instanceInfo, true);
     }
 
+    // --- 1xx interim response tests ---
+
+    @Test
+    void interimResponseIsSwallowedWithoutForwardingOrStartingResponse() {
+        proxyEndpoint.responseFromOrigin(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.EARLY_HINTS));
+
+        // 1xx is swallowed: nothing is forwarded to the client and the response cycle has not started
+        verify(proxyEndpoint, never()).invokeNext(any(HttpResponseMessage.class));
+        assertThat(proxyEndpoint.startedSendingResponseToClient).isFalse();
+    }
+
+    @Test
+    void finalResponseIsForwardedAfterSwallowedInterimResponse() {
+        // 1xx from origin: HttpResponse(103) then empty LastHttpContent
+        proxyEndpoint.responseFromOrigin(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.EARLY_HINTS));
+        proxyEndpoint.invokeNext(LastHttpContent.EMPTY_LAST_CONTENT);
+
+        // Real 200 arrives next - must still be routed to the client
+        proxyEndpoint.responseFromOrigin(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+
+        // only the final 200 is forwarded; the 103 was swallowed
+        verify(proxyEndpoint, times(1)).invokeNext(any(HttpResponseMessage.class));
+        assertThat(proxyEndpoint.startedSendingResponseToClient).isTrue();
+    }
+
+    @Test
+    void multipleInterimResponsesAreSwallowedBeforeFinalResponse() {
+        proxyEndpoint.responseFromOrigin(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.PROCESSING));
+        proxyEndpoint.invokeNext(LastHttpContent.EMPTY_LAST_CONTENT);
+
+        proxyEndpoint.responseFromOrigin(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.EARLY_HINTS));
+        proxyEndpoint.invokeNext(LastHttpContent.EMPTY_LAST_CONTENT);
+
+        proxyEndpoint.responseFromOrigin(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+
+        // both 1xx responses are swallowed; only the final 200 is forwarded
+        verify(proxyEndpoint, times(1)).invokeNext(any(HttpResponseMessage.class));
+        assertThat(proxyEndpoint.startedSendingResponseToClient).isTrue();
+    }
+
+    @Test
+    void interimResponseTrailingLastContentIsNotForwarded() {
+        proxyEndpoint.responseFromOrigin(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.EARLY_HINTS));
+        proxyEndpoint.invokeNext(LastHttpContent.EMPTY_LAST_CONTENT);
+
+        // the empty terminator that Netty emits after a 1xx must be dropped, not forwarded to the client
+        verify(chc, never()).fireChannelRead(any());
+    }
+
     private void createResponse(HttpResponseStatus status) {
         response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
     }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ClientTimeoutHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ClientTimeoutHandlerTest.java
@@ -22,18 +22,24 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.netflix.netty.common.HttpLifecycleChannelHandler;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import io.netty.util.ReferenceCountUtil;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -126,6 +132,74 @@ class ClientTimeoutHandlerTest {
         public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
             seenWrite = true;
             super.write(ctx, msg, promise);
+        }
+    }
+
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    class InboundHandlerTest {
+
+        @Mock
+        private PooledConnection pooledConnection;
+
+        private EmbeddedChannel channel;
+
+        @BeforeEach
+        public void setup() {
+            channel = new EmbeddedChannel();
+            channel.attr(PooledConnection.CHANNEL_ATTR).set(pooledConnection);
+            channel.pipeline().addLast(new ClientTimeoutHandler.InboundHandler());
+        }
+
+        @AfterEach
+        public void cleanup() {
+            channel.finishAndReleaseAll();
+        }
+
+        @Test
+        public void removeReadTimeoutHandlerOnTerminalResponse() {
+            simulateInboundResponse(HttpResponseStatus.OK);
+            channel.writeInbound(new DefaultLastHttpContent());
+            verify(pooledConnection).removeReadTimeoutHandler();
+        }
+
+        @Test
+        public void doesNotRemoveReadTimeoutHandlerOn1xxInterimResponse() {
+            simulateInboundResponse(HttpResponseStatus.EARLY_HINTS);
+            channel.writeInbound(new DefaultLastHttpContent());
+            verify(pooledConnection, never()).removeReadTimeoutHandler();
+        }
+
+        @Test
+        public void removesReadTimeoutHandlerOn101SwitchingProtocols() {
+            // 101 is numerically a 1xx but is terminal (e.g. a WebSocket upgrade), so the timeout must be disarmed.
+            simulateInboundResponse(HttpResponseStatus.SWITCHING_PROTOCOLS);
+            channel.writeInbound(new DefaultLastHttpContent());
+            verify(pooledConnection).removeReadTimeoutHandler();
+        }
+
+        @Test
+        public void removesReadTimeoutHandlerAfterTerminalResponseFollowing1xx() {
+            simulateInboundResponse(HttpResponseStatus.EARLY_HINTS);
+            channel.writeInbound(new DefaultLastHttpContent());
+            verify(pooledConnection, never()).removeReadTimeoutHandler();
+
+            simulateInboundResponse(HttpResponseStatus.OK);
+            channel.writeInbound(new DefaultLastHttpContent());
+            verify(pooledConnection).removeReadTimeoutHandler();
+        }
+
+        @Test
+        public void removesReadTimeoutHandlerIfAttrNotSet() {
+            // null attr is treated as non-informational - safe default is to disarm the timeout
+            channel.writeInbound(new DefaultLastHttpContent());
+            verify(pooledConnection).removeReadTimeoutHandler();
+        }
+
+        private void simulateInboundResponse(HttpResponseStatus status) {
+            // simulate what HttpClientLifecycleChannelHandler does upstream in the pipeline
+            HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
+            channel.attr(HttpLifecycleChannelHandler.ATTR_HTTP_RESP).set(response);
         }
     }
 }


### PR DESCRIPTION
This is a re-application of #2137.  It was inadvertently swallowing HTTP 101 responses, which are fundamentally different from other 1xx responses – they're terminal, and used for web socket upgrades.  

Original PR comment: 
We were returning the origin connection to the pool after getting a 1xx HTTP response, which was incorrect – those are responses that indicate a further response was coming. In some cases, the origin's eventual (real) response could actually go to the wrong client in these cases.

This also fixes an issue where the client -> proxy connection explicitly handled HTTP 100 (Continue), but not any other 1xx response. The others aren't common, but we should handle them anyway.

IMPORTANT NOTE: with this change, we're still not passing 1xx HTTP responses from origin back to clients – they're swallowed by Zuul. I originally started on a larger change that did pass them back, but it would require more changes, and more risk. It messes with backpressure, and probably requires injecting the interim responses directly to clients, bypassing the outbound filter chain, which seems ... potentially problematic? Meanwhile, we have no actual use case for returning interim responses to the client right now (and we never handled them correctly before, so while it's technically a behavior change, it's not one anyone would be relying on).