### PR TITLE
Matthoffman/unpin brotli4j

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 versions_ribbon=2.4.4
 versions_netty=4.2.15.Final
-versions_brotli4j=1.16.0
 release.scope=patch
 release.version=3.3.0-SNAPSHOT
 org.gradle.jvmargs=-Xms1g -Xmx2g

--- a/zuul-integration-test/build.gradle
+++ b/zuul-integration-test/build.gradle
@@ -1,14 +1,6 @@
 apply plugin: "java"
 apply plugin: 'application'
 
-// brotli4j is not pinned independently: its version is read from the netty release we
-// depend on (the `brotli4j.version` property in netty-parent), so a netty bump moves
-// brotli4j with it.
-def brotli4jVersion = new groovy.xml.XmlSlurper()
-        .parse(configurations.detachedConfiguration(
-                dependencies.create("io.netty:netty-parent:${versions_netty}@pom")).singleFile)
-        .'properties'.'brotli4j.version'.text()
-
 dependencies {
     implementation project(":zuul-core"),
             project(":zuul-discovery")
@@ -27,14 +19,16 @@ dependencies {
 //    testImplementation "io.netty.incubator:netty-transport-native-io_uring::linux-x86_64"
     testImplementation "org.slf4j:slf4j-api:2.0.16"
     testImplementation 'org.apache.commons:commons-lang3:3.18.0'
-    // Version derived from netty (see brotli4jVersion above) so brotli4j tracks netty.
-    testImplementation "com.aayushatharva.brotli4j:brotli4j:${brotli4jVersion}"
+    // netty-parent owns the brotli4j version, so brotli4j tracks whatever the current
+    // netty release depends on without pinning it ourselves.
+    testImplementation platform("io.netty:netty-parent:${versions_netty}")
+    testImplementation "com.aayushatharva.brotli4j:brotli4j"
     testRuntimeOnly 'org.apache.logging.log4j:log4j-core:2.25.2'
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j2-impl:2.25.2'
-    testRuntimeOnly "com.aayushatharva.brotli4j:native-osx-aarch64:${brotli4jVersion}"
-    testRuntimeOnly "com.aayushatharva.brotli4j:native-osx-x86_64:${brotli4jVersion}"
-    testRuntimeOnly "com.aayushatharva.brotli4j:native-linux-x86_64:${brotli4jVersion}"
-    testRuntimeOnly "com.aayushatharva.brotli4j:native-linux-aarch64:${brotli4jVersion}"
+    testRuntimeOnly "com.aayushatharva.brotli4j:native-osx-aarch64"
+    testRuntimeOnly "com.aayushatharva.brotli4j:native-osx-x86_64"
+    testRuntimeOnly "com.aayushatharva.brotli4j:native-linux-x86_64"
+    testRuntimeOnly "com.aayushatharva.brotli4j:native-linux-aarch64"
     testRuntimeOnly "io.netty:netty-transport-native-epoll::linux-x86_64"
 }
 

--- a/zuul-integration-test/build.gradle
+++ b/zuul-integration-test/build.gradle
@@ -1,6 +1,14 @@
 apply plugin: "java"
 apply plugin: 'application'
 
+// brotli4j is not pinned independently: its version is read from the netty release we
+// depend on (the `brotli4j.version` property in netty-parent), so a netty bump moves
+// brotli4j with it.
+def brotli4jVersion = new groovy.xml.XmlSlurper()
+        .parse(configurations.detachedConfiguration(
+                dependencies.create("io.netty:netty-parent:${versions_netty}@pom")).singleFile)
+        .'properties'.'brotli4j.version'.text()
+
 dependencies {
     implementation project(":zuul-core"),
             project(":zuul-discovery")
@@ -19,13 +27,14 @@ dependencies {
 //    testImplementation "io.netty.incubator:netty-transport-native-io_uring::linux-x86_64"
     testImplementation "org.slf4j:slf4j-api:2.0.16"
     testImplementation 'org.apache.commons:commons-lang3:3.18.0'
-    testImplementation "com.aayushatharva.brotli4j:brotli4j:$versions_brotli4j"
+    // Version derived from netty (see brotli4jVersion above) so brotli4j tracks netty.
+    testImplementation "com.aayushatharva.brotli4j:brotli4j:${brotli4jVersion}"
     testRuntimeOnly 'org.apache.logging.log4j:log4j-core:2.25.2'
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j2-impl:2.25.2'
-    testRuntimeOnly "com.aayushatharva.brotli4j:native-osx-aarch64:$versions_brotli4j"
-    testRuntimeOnly "com.aayushatharva.brotli4j:native-osx-x86_64:$versions_brotli4j"
-    testRuntimeOnly "com.aayushatharva.brotli4j:native-linux-x86_64:$versions_brotli4j"
-    testRuntimeOnly "com.aayushatharva.brotli4j:native-linux-aarch64:$versions_brotli4j"
+    testRuntimeOnly "com.aayushatharva.brotli4j:native-osx-aarch64:${brotli4jVersion}"
+    testRuntimeOnly "com.aayushatharva.brotli4j:native-osx-x86_64:${brotli4jVersion}"
+    testRuntimeOnly "com.aayushatharva.brotli4j:native-linux-x86_64:${brotli4jVersion}"
+    testRuntimeOnly "com.aayushatharva.brotli4j:native-linux-aarch64:${brotli4jVersion}"
     testRuntimeOnly "io.netty:netty-transport-native-epoll::linux-x86_64"
 }
 

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -529,19 +529,19 @@
     },
     "jmhRuntimeClasspath": {
         "com.aayushatharva.brotli4j:brotli4j": {
-            "locked": "1.16.0"
+            "locked": "1.23.0"
         },
         "com.aayushatharva.brotli4j:native-linux-aarch64": {
-            "locked": "1.16.0"
+            "locked": "1.23.0"
         },
         "com.aayushatharva.brotli4j:native-linux-x86_64": {
-            "locked": "1.16.0"
+            "locked": "1.23.0"
         },
         "com.aayushatharva.brotli4j:native-osx-aarch64": {
-            "locked": "1.16.0"
+            "locked": "1.23.0"
         },
         "com.aayushatharva.brotli4j:native-osx-x86_64": {
-            "locked": "1.16.0"
+            "locked": "1.23.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [
@@ -1025,7 +1025,7 @@
     },
     "testCompileClasspath": {
         "com.aayushatharva.brotli4j:brotli4j": {
-            "locked": "1.16.0"
+            "locked": "1.23.0"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
@@ -1204,19 +1204,19 @@
     },
     "testRuntimeClasspath": {
         "com.aayushatharva.brotli4j:brotli4j": {
-            "locked": "1.16.0"
+            "locked": "1.23.0"
         },
         "com.aayushatharva.brotli4j:native-linux-aarch64": {
-            "locked": "1.16.0"
+            "locked": "1.23.0"
         },
         "com.aayushatharva.brotli4j:native-linux-x86_64": {
-            "locked": "1.16.0"
+            "locked": "1.23.0"
         },
         "com.aayushatharva.brotli4j:native-osx-aarch64": {
-            "locked": "1.16.0"
+            "locked": "1.23.0"
         },
         "com.aayushatharva.brotli4j:native-osx-x86_64": {
-            "locked": "1.16.0"
+            "locked": "1.23.0"
         },
         "com.fasterxml.jackson.core:jackson-core": {
             "firstLevelTransitive": [

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -676,6 +676,9 @@
             ],
             "locked": "4.2.15.Final"
         },
+        "io.netty:netty-parent": {
+            "locked": "4.2.15.Final"
+        },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -734,13 +737,13 @@
             "locked": "3.18.0"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.25.2"
+            "locked": "2.25.4"
         },
         "org.apache.logging.log4j:log4j-slf4j2-impl": {
             "locked": "2.25.2"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3"
+            "locked": "3.27.7"
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.2"
@@ -749,19 +752,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.83"
+            "locked": "1.84"
         },
         "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.83"
+            "locked": "1.84"
         },
         "org.bouncycastle:bctls-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.83"
+            "locked": "1.84"
         },
         "org.jspecify:jspecify": {
             "firstLevelTransitive": [
@@ -770,16 +773,16 @@
             "locked": "1.0.0"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.13.4"
+            "locked": "5.14.3"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.13.4"
+            "locked": "5.14.3"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.13.4"
+            "locked": "5.14.3"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.13.4"
+            "locked": "1.14.3"
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.13.0"
@@ -1135,6 +1138,9 @@
             ],
             "locked": "4.2.15.Final"
         },
+        "io.netty:netty-parent": {
+            "locked": "4.2.15.Final"
+        },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -1166,7 +1172,7 @@
             "locked": "3.18.0"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3"
+            "locked": "3.27.7"
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.2"
@@ -1178,16 +1184,16 @@
             "locked": "1.0.0"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.13.4"
+            "locked": "5.14.3"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.13.4"
+            "locked": "5.14.3"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.13.4"
+            "locked": "5.14.3"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.13.4"
+            "locked": "1.14.3"
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.13.0"
@@ -1196,7 +1202,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.16"
+            "locked": "2.0.17"
         },
         "org.wiremock:wiremock": {
             "locked": "3.10.0"
@@ -1351,6 +1357,9 @@
             ],
             "locked": "4.2.15.Final"
         },
+        "io.netty:netty-parent": {
+            "locked": "4.2.15.Final"
+        },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
@@ -1409,13 +1418,13 @@
             "locked": "3.18.0"
         },
         "org.apache.logging.log4j:log4j-core": {
-            "locked": "2.25.2"
+            "locked": "2.25.4"
         },
         "org.apache.logging.log4j:log4j-slf4j2-impl": {
             "locked": "2.25.2"
         },
         "org.assertj:assertj-core": {
-            "locked": "3.26.3"
+            "locked": "3.27.7"
         },
         "org.awaitility:awaitility": {
             "locked": "4.2.2"
@@ -1424,19 +1433,19 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.83"
+            "locked": "1.84"
         },
         "org.bouncycastle:bcprov-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.83"
+            "locked": "1.84"
         },
         "org.bouncycastle:bctls-jdk18on": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.83"
+            "locked": "1.84"
         },
         "org.jspecify:jspecify": {
             "firstLevelTransitive": [
@@ -1445,16 +1454,16 @@
             "locked": "1.0.0"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.13.4"
+            "locked": "5.14.3"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.13.4"
+            "locked": "5.14.3"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.13.4"
+            "locked": "5.14.3"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.13.4"
+            "locked": "1.14.3"
         },
         "org.mockito:mockito-junit-jupiter": {
             "locked": "5.13.0"


### PR DESCRIPTION
This is a little more complicated than just removing the version pin, with a little more blast radius. But in practice, it means linking *more* deps to the versions Netty uses, which probably isn't a bad thing. 

This change brings in netty-parent as a platform dependency (pom dependency), which lets us inherit netty's dependencyManagement versions.  This is necessary because Netty has brotli4j in dependencyManagement in its pom, but not directly in the dependency, and brotli4j is an optional dep.  So its version isn't reflected in transitive dependencies. So we depend on  the parent pom in order to get those.

You'll see minor version bumps for log4j, slf4j, bouncycastle, and a couple test deps (assert4j and junit). No major version bumps. 