### PR TITLE
Add zero-allocation iteration helpers to `Headers`

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -162,6 +163,17 @@ public final class Headers {
     }
 
     /**
+     * Iterates over the header entries with the given consumer. The first argument will be the original
+     * (non-normalised) header name as returned by {@link HeaderName#getName()}, the second the value. Do not
+     * modify the headers during iteration.
+     */
+    public void forEach(BiConsumer<? super String, ? super String> entryConsumer) {
+        for (int i = 0; i < size(); i++) {
+            entryConsumer.accept(originalName(i), value(i));
+        }
+    }
+
+    /**
      * Iterates over the header entries with the given consumer.  The first argument will be the normalised header
      * name as returned by {@link HeaderName#getNormalised()}.  The second argument will be the value.  Do not modify
      * the headers during iteration.
@@ -170,6 +182,19 @@ public final class Headers {
         for (int i = 0; i < size(); i++) {
             entryConsumer.accept(name(i), value(i));
         }
+    }
+
+    /**
+     * Returns {@code true} if any header entry matches the predicate, stopping at the first match. The first
+     * argument is the normalised header name as returned by {@link HeaderName#getNormalised()}, the second the value.
+     */
+    public boolean anyMatchNormalised(BiPredicate<? super String, ? super String> predicate) {
+        for (int i = 0; i < size(); i++) {
+            if (predicate.test(name(i), value(i))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -463,6 +488,31 @@ public final class Headers {
         int w = 0;
         for (int r = 0; r < size(); r++) {
             if (filter.test(new SimpleImmutableEntry<>(new HeaderName(originalName(r), name(r)), value(r)))) {
+                removed = true;
+            } else {
+                originalName(w, originalName(r));
+                name(w, name(r));
+                value(w, value(r));
+                w++;
+            }
+        }
+        truncate(w);
+        return removed;
+    }
+
+    /**
+     * Removes all header entries for which the predicate returns {@code true}. The first argument is the normalised
+     * header name as returned by {@link HeaderName#getNormalised()}, the second the value. Do not access the headers
+     * from inside the {@link BiPredicate#test} body.
+     *
+     * @return if any elements were removed.
+     */
+    public boolean removeAllNormalised(BiPredicate<? super String, ? super String> filter) {
+        Objects.requireNonNull(filter, "filter");
+        boolean removed = false;
+        int w = 0;
+        for (int r = 0; r < size(); r++) {
+            if (filter.test(name(r), value(r))) {
                 removed = true;
             } else {
                 originalName(w, originalName(r));

--- a/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
@@ -109,6 +109,23 @@ class HeadersTest {
     }
 
     @Test
+    void forEach() {
+        Headers headers = new Headers();
+        headers.add("ViA", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Cookie", "frizzle=Frazzle");
+        Map<String, List<String>> result = new LinkedHashMap<>();
+
+        headers.forEach((k, v) ->
+                result.computeIfAbsent(k, discard -> new ArrayList<>()).add(v));
+
+        assertThat(result)
+                .containsExactly(
+                        entry("ViA", Collections.singletonList("duct")),
+                        entry("Cookie", Arrays.asList("this=that", "frizzle=Frazzle")));
+    }
+
+    @Test
     void forEachNormalised() {
         Headers headers = new Headers();
         headers.add("Via", "duct");
@@ -123,6 +140,41 @@ class HeadersTest {
                 .containsExactly(
                         entry("via", Collections.singletonList("duct")),
                         entry("cookie", Arrays.asList("this=that", "frizzle=Frazzle")));
+    }
+
+    @Test
+    void anyMatchNormalised() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+
+        assertThat(headers.anyMatchNormalised((name, value) -> name.equals("cookie")))
+                .isTrue();
+        assertThat(headers.anyMatchNormalised((name, value) -> value.equals("duct")))
+                .isTrue();
+        assertThat(headers.anyMatchNormalised((name, value) -> name.isEmpty())).isFalse();
+    }
+
+    @Test
+    void anyMatchNormalisedIsEmptyForNoHeaders() {
+        assertThat(new Headers().anyMatchNormalised((name, value) -> true)).isFalse();
+    }
+
+    @Test
+    void anyMatchNormalisedStopsAtFirstMatch() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Host", "example.com");
+
+        List<String> visited = new ArrayList<>();
+        boolean matched = headers.anyMatchNormalised((name, value) -> {
+            visited.add(name);
+            return name.equals("cookie");
+        });
+
+        assertThat(matched).isTrue();
+        assertThat(visited).containsExactly("via", "cookie");
     }
 
     @Test
@@ -549,6 +601,47 @@ class HeadersTest {
         assertThat(removed).isTrue();
         assertThat(headers.getAll("cOoKie")).containsExactly("frizzle=frazzle");
         assertThat(headers.size()).isEqualTo(3);
+    }
+
+    @Test
+    void removeAllNormalised() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("COOkie", "frizzle=frazzle");
+        headers.add("Soup", "salad");
+
+        boolean removed = headers.removeAllNormalised((name, value) -> name.equals("cookie"));
+
+        assertThat(removed).isTrue();
+        assertThat(headers.contains("cookie")).isFalse();
+        assertThat(headers.getFirst("Via")).isEqualTo("duct");
+        assertThat(headers.getFirst("Soup")).isEqualTo("salad");
+        assertThat(headers.size()).isEqualTo(2);
+    }
+
+    @Test
+    void removeAllNormalisedCanFilterOnValue() {
+        Headers headers = new Headers();
+        headers.add("Accept", "application/json");
+        headers.add("Accept", "text/plain");
+
+        boolean removed = headers.removeAllNormalised((name, value) -> value.equals("text/plain"));
+
+        assertThat(removed).isTrue();
+        assertThat(headers.getAll("accept")).containsExactly("application/json");
+    }
+
+    @Test
+    void removeAllNormalisedReturnsFalseWhenNothingMatches() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Soup", "salad");
+
+        boolean removed = headers.removeAllNormalised((name, value) -> name.equals("cookie"));
+
+        assertThat(removed).isFalse();
+        assertThat(headers.size()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
`Headers` only offers `entries()` and `keySet()` for walking headers, and both allocate sets of objects per call. Particularly if you just want to find if a header exists or remove a batch of headers, requires double-loop structures in the call-sites, with all these allocated objects being thrown away immediately.

This PR adds three helpers to allow for more efficient interaction with the headers:

* `forEach(BiConsumer<String, String>)` - walk original-case name + value, the counterpart to `forEachNormalised` for paths that re-emit headers to origins/clients and must preserve case
* `anyMatchNormalised(BiPredicate<String, String>)` - short-circuiting matching
* `removeAllNormalised(BiPredicate<String, String>)` - in-place delete, the allocation-free counterpart to `removeIf` (which builds a `HeaderName` + `Map.Entry` per entry)