### PR TITLE
Build origin requests and client responses with the allocation-free `Headers` iterators

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpResponseMessageImpl.java
@@ -19,7 +19,6 @@ import com.netflix.config.DynamicIntProperty;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.filters.ZuulFilter;
-import com.netflix.zuul.message.Header;
 import com.netflix.zuul.message.Headers;
 import com.netflix.zuul.message.ZuulMessage;
 import com.netflix.zuul.message.ZuulMessageImpl;
@@ -198,30 +197,9 @@ public class HttpResponseMessageImpl implements HttpResponseMessage {
     @Override
     public boolean removeExistingSetCookie(String cookieName) {
         String cookieNamePrefix = cookieName + "=";
-        boolean dirty = false;
-        Headers filtered = new Headers();
-        for (Header hdr : getHeaders().entries()) {
-            if (hdr.getName().equals(HttpHeaderNames.SET_COOKIE)) {
-                String value = hdr.getValue();
-
-                // Strip out this set-cookie as requested.
-                if (value.startsWith(cookieNamePrefix)) {
-                    // Don't copy it.
-                    dirty = true;
-                } else {
-                    // Copy all other headers.
-                    filtered.add(hdr.getName(), hdr.getValue());
-                }
-            } else {
-                // Copy all other headers.
-                filtered.add(hdr.getName(), hdr.getValue());
-            }
-        }
-
-        if (dirty) {
-            setHeaders(filtered);
-        }
-        return dirty;
+        return getHeaders()
+                .removeAllNormalised((name, value) ->
+                        HttpHeaderNames.SET_COOKIE.getNormalised().equals(name) && value.startsWith(cookieNamePrefix));
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientResponseWriter.java
@@ -27,7 +27,6 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.zuul.RequestCompleteHandler;
 import com.netflix.zuul.context.CommonContextKeys;
 import com.netflix.zuul.exception.ZuulException;
-import com.netflix.zuul.message.Header;
 import com.netflix.zuul.message.http.HttpRequestInfo;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpResponseMessage;
@@ -186,9 +185,7 @@ public class ClientResponseWriter extends ChannelInboundHandlerAdapter {
 
         // Now set all of the response headers - note this is a multi-set in keeping with HTTP semantics
         HttpHeaders nativeHeaders = nativeResponse.headers();
-        for (Header entry : zuulResp.getHeaders().entries()) {
-            nativeHeaders.add(entry.getKey(), entry.getValue());
-        }
+        zuulResp.getHeaders().forEach((name, value) -> nativeHeaders.add(name, value));
 
         // Netty does not automatically add Content-Length or Transfer-Encoding: chunked. So we add here if missing.
         if (!HttpUtil.isContentLengthSet(nativeResponse) && !HttpUtil.isTransferEncodingChunked(nativeResponse)) {

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/OriginResponseReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/OriginResponseReceiver.java
@@ -22,7 +22,6 @@ import com.netflix.zuul.exception.OutboundErrorType;
 import com.netflix.zuul.exception.OutboundException;
 import com.netflix.zuul.exception.ZuulException;
 import com.netflix.zuul.filters.endpoint.ProxyEndpoint;
-import com.netflix.zuul.message.Header;
 import com.netflix.zuul.message.http.HttpQueryParams;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.netty.ChannelUtils;
@@ -182,9 +181,7 @@ public class OriginResponseReceiver extends ChannelDuplexHandler {
         DefaultHttpRequest nettyReq =
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method), uri, false);
         // Copy headers across.
-        for (Header h : zuulRequest.getHeaders().entries()) {
-            nettyReq.headers().add(h.getKey(), h.getValue());
-        }
+        zuulRequest.getHeaders().forEach((name, value) -> nettyReq.headers().add(name, value));
 
         return nettyReq;
     }

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpResponseMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpResponseMessageImplTest.java
@@ -80,6 +80,35 @@ class HttpResponseMessageImplTest {
     }
 
     @Test
+    void removeExistingSetCookieReportsWhetherAnyWereRemovedAndKeepsOtherHeaders() {
+        response.getHeaders().add("Set-Cookie", "c1=1234; Path=/");
+        response.getHeaders().add("X-Other", "keep");
+
+        assertThat(response.removeExistingSetCookie("c1")).isTrue();
+        assertThat(response.removeExistingSetCookie("c1")).isFalse();
+        assertThat(response.getHeaders().getFirst("X-Other")).isEqualTo("keep");
+    }
+
+    @Test
+    void removeExistingSetCookieOnlyMatchesTheExactCookieNamePrefix() {
+        response.getHeaders().add("Set-Cookie", "c1=1234; Path=/");
+        response.getHeaders().add("Set-Cookie", "c12=5678; Path=/");
+
+        response.removeExistingSetCookie("c1");
+
+        assertThat(response.hasSetCookieWithName("c1")).isFalse();
+        assertThat(response.hasSetCookieWithName("c12")).isTrue();
+    }
+
+    @Test
+    void removeExistingSetCookieMatchesSetCookieHeaderCaseInsensitively() {
+        response.getHeaders().add("set-cookie", "c1=1234; Path=/");
+
+        assertThat(response.removeExistingSetCookie("c1")).isTrue();
+        assertThat(response.hasSetCookieWithName("c1")).isFalse();
+    }
+
+    @Test
     void testContentLengthHeaderHasCorrectValue() {
         assertThat(response.getHeaders().getAll("Content-Length").size()).isEqualTo(0);
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientResponseWriterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientResponseWriterTest.java
@@ -143,6 +143,51 @@ class ClientResponseWriterTest {
     }
 
     @Test
+    void buildHttpResponseCopiesAllHeadersToNettyResponse() {
+        ClientResponseWriter responseWriter = new ClientResponseWriter(new BasicRequestCompleteHandler());
+        EmbeddedChannel channel = new EmbeddedChannel(responseWriter);
+
+        AtomicReference<HttpResponse> nettyResp = new AtomicReference<>();
+        channel.pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                if (msg instanceof HttpResponse response) {
+                    nettyResp.set(response);
+                }
+                ReferenceCountUtil.safeRelease(msg);
+            }
+        });
+
+        SessionContext ctx = new SessionContext();
+        HttpRequestMessage request = new HttpRequestBuilder(ctx).build();
+        request.storeInboundRequest();
+
+        Headers headers = new Headers();
+        headers.add("X-Custom-Header", "one");
+        headers.add("Set-Cookie", "a=1");
+        headers.add("Set-Cookie", "b=2");
+        HttpResponseMessageImpl response = new HttpResponseMessageImpl(ctx, request, 200);
+        response.setHeaders(headers);
+
+        channel.attr(ClientRequestReceiver.ATTR_ZUUL_REQ).set(request);
+        DefaultHttpRequest nettyRequest = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        ctx.set(CommonContextKeys.NETTY_HTTP_REQUEST, nettyRequest);
+
+        channel.pipeline().fireUserEventTriggered(new HttpLifecycleChannelHandler.StartEvent(nettyRequest));
+        channel.writeInbound(response);
+
+        HttpResponse out = nettyResp.get();
+        assertThat(out).isNotNull();
+
+        // original (non-normalised) case is preserved
+        assertThat(out.headers().names()).contains("X-Custom-Header");
+        assertThat(out.headers().get("X-Custom-Header")).isEqualTo("one");
+
+        // every entry is copied, including repeated names
+        assertThat(out.headers().getAll("Set-Cookie")).containsExactly("a=1", "b=2");
+    }
+
+    @Test
     void doesNotWriteSecondResponseWhenFlushReentersChannelRead() {
         ClientResponseWriter responseWriter = new ClientResponseWriter(new BasicRequestCompleteHandler());
         EmbeddedChannel channel = new EmbeddedChannel(responseWriter);

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/OriginResponseReceiverTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/OriginResponseReceiverTest.java
@@ -22,7 +22,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.filters.endpoint.ProxyEndpoint;
+import com.netflix.zuul.message.Headers;
+import com.netflix.zuul.message.http.HttpRequestMessage;
+import com.netflix.zuul.message.util.HttpRequestBuilder;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -31,6 +35,7 @@ import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpContent;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
@@ -168,6 +173,30 @@ class OriginResponseReceiverTest {
 
         verify(proxyEndpoint, never()).invokeNext(any(HttpContent.class));
         assertThat(chunk.refCnt()).isEqualTo(0);
+    }
+
+    @Test
+    void buildOriginHttpRequestCopiesAllHeadersPreservingCaseAndMultiValue() {
+        Headers headers = new Headers();
+        headers.add("X-Custom-Header", "one");
+        headers.add("Accept", "value-a");
+        headers.add("Accept", "value-b");
+        HttpRequestMessage zuulRequest = new HttpRequestBuilder(new SessionContext())
+                .withHeaders(headers)
+                .build();
+
+        EmbeddedChannel outboundChannel = new EmbeddedChannel(new OriginResponseReceiver(proxyEndpoint));
+        assertThat(outboundChannel.writeOutbound(zuulRequest)).isTrue();
+
+        HttpRequest nettyRequest = outboundChannel.readOutbound();
+        assertThat(nettyRequest).isNotNull();
+
+        // original (non-normalised) case is preserved
+        assertThat(nettyRequest.headers().names()).contains("X-Custom-Header");
+        assertThat(nettyRequest.headers().get("X-Custom-Header")).isEqualTo("one");
+
+        // every entry is copied, including repeated names
+        assertThat(nettyRequest.headers().getAll("Accept")).containsExactly("value-a", "value-b");
     }
 
     private void verifyProxyLink(OriginResponseReceiver receiver, boolean expectedNull) throws Exception {


### PR DESCRIPTION
`OriginResponseReceiver` rebuilds a netty request from the zuul `Headers` on every proxied request, and `ClientResponseWriter` rebuilds a netty response on every reply - both via `entries()`, which allocates an `ArrayList` plus a `Header` and a `HeaderName` for every header. `HttpResponseMessageImpl.removeExistingSetCookie` does the same to rebuild a filtered copy.

Now that `Headers` has allocation-free iteration in #2154, this swaps those three over to the new helpers.