### PR TITLE
Add single-pass `setAll` to `Headers` that preserves multi-valued headers

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/Headers.java
@@ -23,6 +23,7 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -33,6 +34,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
+import lombok.NonNull;
 
 /**
  * An abstraction over a collection of http headers. Allows multiple headers with same name, and header names are
@@ -452,6 +454,40 @@ public final class Headers {
         for (int i = 0; i < headers.size(); i++) {
             addNormal(headers.originalName(i), headers.name(i), headers.value(i));
         }
+    }
+
+    /**
+     * Replaces all values for each name present in entries with the values from entries, leaving
+     * names absent from entries untouched. Multiple values per name are preserved, so unlike
+     * repeated set(...) calls this does not collapse multi-valued headers such as Set-Cookie.
+     */
+    public void setAll(@NonNull Iterable<? extends Map.Entry<String, String>> entries) {
+        int existing = size();
+        Set<String> replacedNames = new HashSet<>();
+        for (Map.Entry<String, String> entry : entries) {
+            String normalName = HeaderName.normalize(entry.getKey());
+            replacedNames.add(normalName);
+            addNormal(entry.getKey(), normalName, entry.getValue());
+        }
+
+        if (size() == existing) {
+            return;
+        }
+
+        // compact away the pre-existing entries we just replaced, keeping the newly appended ones
+        int w = 0;
+        for (int r = 0; r < size(); r++) {
+            if (r < existing && replacedNames.contains(name(r))) {
+                continue;
+            }
+
+            originalName(w, originalName(r));
+            name(w, name(r));
+            value(w, value(r));
+            w++;
+        }
+
+        truncate(w);
     }
 
     /**

--- a/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/HeadersTest.java
@@ -525,6 +525,88 @@ class HeadersTest {
     }
 
     @Test
+    void setAllPreservesMultipleValues() {
+        Headers headers = new Headers();
+        headers.add("Set-Cookie", "a");
+
+        headers.setAll(List.of(Map.entry("Set-Cookie", "b"), Map.entry("Set-Cookie", "c")));
+
+        assertThat(headers.getAll("set-cookie")).containsExactly("b", "c");
+        assertThat(headers.size()).isEqualTo(2);
+    }
+
+    @Test
+    void setAllReplacesCaseInsensitively() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("COOKie", "this=that");
+        headers.add("cookIE", "frizzle=frazzle");
+
+        headers.setAll(List.of(Map.entry("cookie", "a=b")));
+
+        assertThat(headers.getAll("Cookie")).containsExactly("a=b");
+        assertThat(headers.getFirst("Via")).isEqualTo("duct");
+        assertThat(headers.size()).isEqualTo(2);
+    }
+
+    @Test
+    void setAllEmptyReplacementIsNoOp() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+
+        List<Map.Entry<String, String>> empty = List.of();
+        headers.setAll(empty);
+
+        assertThat(headers.getAll("Via")).containsExactly("duct");
+        assertThat(headers.getAll("Cookie")).containsExactly("this=that");
+        assertThat(headers.size()).isEqualTo(2);
+    }
+
+    @Test
+    void setAllReplacesOnlyNamesPresentInReplacement() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+        headers.add("Cookie", "this=that");
+        headers.add("Soup", "salad");
+
+        headers.setAll(List.of(Map.entry("Cookie", "a=b")));
+
+        assertThat(headers.getAll("Cookie")).containsExactly("a=b");
+        assertThat(headers.getAll("Via")).containsExactly("duct");
+        assertThat(headers.getAll("Soup")).containsExactly("salad");
+        assertThat(headers.size()).isEqualTo(3);
+    }
+
+    @Test
+    void setAllAddsNamesAbsentFromTarget() {
+        Headers headers = new Headers();
+        headers.add("Via", "duct");
+
+        headers.setAll(List.of(Map.entry("X-Netflix-Awesome", "true"), Map.entry("X-Netflix-Awesome", "yes")));
+
+        assertThat(headers.getAll("Via")).containsExactly("duct");
+        assertThat(headers.getAll("x-netflix-awesome")).containsExactly("true", "yes");
+        assertThat(headers.size()).isEqualTo(3);
+    }
+
+    @Test
+    void setAllReplacesInterleavedNamesAndKeepsUntouchedInPlace() {
+        Headers headers = new Headers();
+        headers.add("A", "1");
+        headers.add("B", "2");
+        headers.add("C", "3");
+        headers.add("B", "4");
+
+        headers.setAll(List.of(Map.entry("A", "x"), Map.entry("C", "y"), Map.entry("C", "z")));
+
+        assertThat(headers.getAll("A")).containsExactly("x");
+        assertThat(headers.getAll("B")).containsExactly("2", "4");
+        assertThat(headers.getAll("C")).containsExactly("y", "z");
+        assertThat(headers.size()).isEqualTo(5);
+    }
+
+    @Test
     void remove() {
         Headers headers = new Headers();
         headers.add("Via", "duct");


### PR DESCRIPTION
There's currently no way to bulk-replace a batch of headers from another source in one shot. Callers that want to overlay headers from say, a netty `HttpHeaders` collection, have to loop-set-per-entry, and because `set` is replace-all, it collapses any name that appears more than once in the input down to its last value. For example, feeding two `Set-Cookie` entries through a `set` loop leaves you with one.

This PR adds `setAll(Iterable<Map.Entry<String, String>>)` - a single pass that replaces every name present in the input (adding ones that aren't already there) while preserving its multiple values, and leaves headers not in the input untouched.