### PR TITLE
Make http2 graceful shutdown timeouts configurable

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/channel/config/CommonChannelConfigKeys.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/channel/config/CommonChannelConfigKeys.java
@@ -87,4 +87,6 @@ public class CommonChannelConfigKeys {
             new ChannelConfigKey<>("http2ConnectProtocolEnabled", false);
     public static final ChannelConfigKey<Integer> http2EncoderMaxConsecutiveContinuationFrames =
             new ChannelConfigKey<>("http2EncoderMaxConsecutiveContinuationFrames", 16);
+    public static final ChannelConfigKey<Integer> http2GracefulShutdownTimeoutMillis =
+            new ChannelConfigKey<>("http2GracefulShutdownTimeoutMillis", 30000);
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2OrHttpHandler.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/http2/Http2OrHttpHandler.java
@@ -66,6 +66,7 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
     private final int maxEncoderRstFrames;
     private final int maxEncoderRstFramesWindow;
     private final int maxConsecutiveContinuationFrames;
+    private final int gracefulShutdownTimeoutMillis;
     private final Consumer<ChannelPipeline> addHttpHandlerFn;
 
     public Http2OrHttpHandler(
@@ -82,6 +83,8 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
         this.maxEncoderRstFrames = channelConfig.get(CommonChannelConfigKeys.http2EncoderMaxResetFrames);
         this.maxEncoderRstFramesWindow = channelConfig.get(CommonChannelConfigKeys.http2EncoderMaxResetFramesWindow);
         this.connectProtocolEnabled = channelConfig.get(CommonChannelConfigKeys.http2ConnectProtocolEnabled);
+        this.gracefulShutdownTimeoutMillis =
+                channelConfig.get(CommonChannelConfigKeys.http2GracefulShutdownTimeoutMillis);
         this.maxConsecutiveContinuationFrames =
                 channelConfig.get(CommonChannelConfigKeys.http2EncoderMaxConsecutiveContinuationFrames);
         this.addHttpHandlerFn = addHttpHandlerFn;
@@ -158,6 +161,7 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
                 .validateHeaders(true)
                 .encoderEnforceMaxRstFramesPerWindow(maxEncoderRstFrames, maxEncoderRstFramesWindow)
                 .decoderEnforceMaxSmallContinuationFrames(maxConsecutiveContinuationFrames)
+                .gracefulShutdownTimeoutMillis(gracefulShutdownTimeoutMillis)
                 .build();
         Http2Connection conn = frameCodec.connection();
         // Use the uniform byte distributor until https://github.com/netty/netty/issues/10525 is fixed.

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2OrHttpHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/http2/Http2OrHttpHandlerTest.java
@@ -126,6 +126,7 @@ class Http2OrHttpHandlerTest {
         int initialWindowSize = CommonChannelConfigKeys.initialWindowSize.defaultValue() + 1;
         int maxHeaderTableSize = CommonChannelConfigKeys.maxHttp2HeaderTableSize.defaultValue() + 1;
         int maxHeaderListSize = 1024;
+        int gracefulShutdownTimeout = CommonChannelConfigKeys.http2GracefulShutdownTimeoutMillis.defaultValue() + 1;
 
         channelConfig.add(
                 new ChannelConfigValue<>(CommonChannelConfigKeys.http2ConnectProtocolEnabled, connectProtocolEnabled));
@@ -134,6 +135,8 @@ class Http2OrHttpHandlerTest {
         channelConfig.add(
                 new ChannelConfigValue<>(CommonChannelConfigKeys.maxHttp2HeaderTableSize, maxHeaderTableSize));
         channelConfig.add(new ChannelConfigValue<>(CommonChannelConfigKeys.maxHttp2HeaderListSize, maxHeaderListSize));
+        channelConfig.add(new ChannelConfigValue<>(
+                CommonChannelConfigKeys.http2GracefulShutdownTimeoutMillis, gracefulShutdownTimeout));
 
         Http2OrHttpHandler http2OrHttpHandler =
                 new Http2OrHttpHandler(new ChannelInboundHandlerAdapter(), channelConfig, cp -> {});
@@ -146,6 +149,8 @@ class Http2OrHttpHandlerTest {
         channel.pipeline().fireChannelActive();
 
         Http2FrameCodec http2FrameCodec = channel.pipeline().get(Http2FrameCodec.class);
+        assertThat(http2FrameCodec.gracefulShutdownTimeoutMillis()).isEqualTo(gracefulShutdownTimeout);
+
         Http2Settings http2Settings = http2FrameCodec.encoder().pollSentSettings();
 
         assertThat(http2Settings.connectProtocolEnabled()).isEqualTo(connectProtocolEnabled);


### PR DESCRIPTION
Allows per-listener configuration of the http2 gracefulShutdownTimeoutMillis setting (how long netty will wait after sending a go-away before closing the connection). For the default I used the same as netty (30 seconds) 