### PR TITLE
Skip filters with a no-op processContentChunk during chunk processing

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/BaseFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/BaseFilter.java
@@ -21,7 +21,6 @@ import com.netflix.spectator.api.Counter;
 import com.netflix.zuul.exception.ZuulFilterConcurrencyExceededException;
 import com.netflix.zuul.message.ZuulMessage;
 import com.netflix.zuul.netty.SpectatorUtils;
-import io.netty.handler.codec.http.HttpContent;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -43,6 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class BaseFilter<I extends ZuulMessage, O extends ZuulMessage> implements ZuulFilter<I, O> {
 
     private final String baseName;
+    private final boolean processesContentChunks;
     private final AtomicInteger concurrentCount;
     private final Counter concurrencyRejections;
     private final CachedDynamicBooleanProperty filterDisabled;
@@ -53,6 +53,7 @@ public abstract class BaseFilter<I extends ZuulMessage, O extends ZuulMessage> i
 
     protected BaseFilter() {
         baseName = getClass().getSimpleName() + "." + filterType();
+        processesContentChunks = ZuulFilter.overridesProcessContentChunk(getClass());
         concurrentCount = SpectatorUtils.newGauge("zuul.filter.concurrency.current", baseName, new AtomicInteger(0));
         concurrencyRejections = SpectatorUtils.newCounter("zuul.filter.concurrency.rejected", baseName);
         filterDisabled = new CachedDynamicBooleanProperty(disablePropertyName(), false);
@@ -67,6 +68,11 @@ public abstract class BaseFilter<I extends ZuulMessage, O extends ZuulMessage> i
     @Override
     public String filterName() {
         return getClass().getName();
+    }
+
+    @Override
+    public boolean processesContentChunks() {
+        return processesContentChunks;
     }
 
     @Override
@@ -115,11 +121,6 @@ public abstract class BaseFilter<I extends ZuulMessage, O extends ZuulMessage> i
     @Override
     public boolean needsBodyBuffered(I input) {
         return false;
-    }
-
-    @Override
-    public HttpContent processContentChunk(ZuulMessage zuulMessage, HttpContent chunk) {
-        return chunk;
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/SyncZuulFilterAdapter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/SyncZuulFilterAdapter.java
@@ -17,7 +17,6 @@
 package com.netflix.zuul.filters;
 
 import com.netflix.zuul.message.ZuulMessage;
-import io.netty.handler.codec.http.HttpContent;
 import rx.Observable;
 
 /**
@@ -37,6 +36,8 @@ import rx.Observable;
  */
 public abstract class SyncZuulFilterAdapter<I extends ZuulMessage, O extends ZuulMessage>
         implements SyncZuulFilter<I, O> {
+
+    private final boolean processesContentChunks = ZuulFilter.overridesProcessContentChunk(getClass());
 
     @Override
     public boolean isDisabled() {
@@ -80,8 +81,8 @@ public abstract class SyncZuulFilterAdapter<I extends ZuulMessage, O extends Zuu
     }
 
     @Override
-    public HttpContent processContentChunk(ZuulMessage zuulMessage, HttpContent chunk) {
-        return chunk;
+    public boolean processesContentChunks() {
+        return processesContentChunks;
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/ZuulFilter.java
@@ -138,5 +138,31 @@ public interface ZuulFilter<I extends ZuulMessage, O extends ZuulMessage> extend
     /**
      * Optionally transform HTTP content chunk received.
      */
-    HttpContent processContentChunk(ZuulMessage zuulMessage, HttpContent chunk);
+    default HttpContent processContentChunk(ZuulMessage zuulMessage, HttpContent chunk) {
+        return chunk;
+    }
+
+    /**
+     * Whether this filter transforms streaming body chunks in processContentChunk.
+     * Given filters _generally_ do not process chunks, this allows the filter running to
+     * skip processing shouldFilter for every chunk.
+     */
+    default boolean processesContentChunks() {
+        return true;
+    }
+
+    /**
+     * Determines if the given filterClass overrides processContentChunk.
+     */
+    static boolean overridesProcessContentChunk(Class<?> filterClass) {
+        try {
+            return filterClass
+                            .getMethod("processContentChunk", ZuulMessage.class, HttpContent.class)
+                            .getDeclaringClass()
+                    != ZuulFilter.class;
+        } catch (NoSuchMethodException e) {
+            // fallback to assuming it does
+            return true;
+        }
+    }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/ZuulMessageImpl.java
@@ -203,6 +203,10 @@ public class ZuulMessageImpl implements ZuulMessage {
 
     @Override
     public void runBufferedBodyContentThroughFilter(ZuulFilter<?, ?> filter) {
+        if (!filter.processesContentChunks()) {
+            return;
+        }
+
         // Loop optimized for the common case: Most filters' processContentChunk() return
         // original chunk passed in as is without any processing
         String filterName = filter.filterName();

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunner.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunner.java
@@ -80,6 +80,10 @@ public class ZuulFilterChainRunner<T extends ZuulMessage> extends BaseZuulFilter
             int limit = runningFilterIdx.get();
             for (int i = 0; i < limit; i++) {
                 ZuulFilter<T, T> filter = filters[i];
+                if (!filter.processesContentChunks()) {
+                    continue;
+                }
+
                 filterName = filter.filterName();
                 if (!filter.isDisabled() && !shouldSkipFilter(inMesg, filter)) {
                     ByteBufUtil.touch(chunk, "Filter runner processing chunk, filter: ", filterName);

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/ZuulFilterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/ZuulFilterTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.zuul.filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.zuul.filters.common.GZipResponseFilter;
+import com.netflix.zuul.message.ZuulMessage;
+import io.netty.handler.codec.http.HttpContent;
+import org.junit.jupiter.api.Test;
+import rx.Observable;
+
+class ZuulFilterTest {
+
+    @Test
+    void baseFilterWithNoOpProcessContentChunkReportsFalse() {
+        assertThat(new NoOpBaseFilter().processesContentChunks()).isFalse();
+    }
+
+    @Test
+    void baseFilterOverridingProcessContentChunkReportsTrue() {
+        assertThat(new ChunkBaseFilter().processesContentChunks()).isTrue();
+    }
+
+    @Test
+    void syncAdapterWithNoOpProcessContentChunkReportsFalse() {
+        assertThat(new NoOpSyncAdapter().processesContentChunks()).isFalse();
+    }
+
+    @Test
+    void syncAdapterOverridingProcessContentChunkReportsTrue() {
+        assertThat(new ChunkSyncAdapter().processesContentChunks()).isTrue();
+    }
+
+    @Test
+    void gzipResponseFilterReportsTrue() {
+        assertThat(new GZipResponseFilter().processesContentChunks()).isTrue();
+    }
+
+    @Test
+    void overridesProcessContentChunkDetectsInterfaceDefault() {
+        assertThat(ZuulFilter.overridesProcessContentChunk(NoOpBaseFilter.class))
+                .isFalse();
+        assertThat(ZuulFilter.overridesProcessContentChunk(ChunkBaseFilter.class))
+                .isTrue();
+    }
+
+    private static class NoOpBaseFilter extends BaseFilter<ZuulMessage, ZuulMessage> {
+        @Override
+        public Observable<ZuulMessage> applyAsync(ZuulMessage input) {
+            return Observable.just(input);
+        }
+
+        @Override
+        public FilterType filterType() {
+            return FilterType.INBOUND;
+        }
+
+        @Override
+        public boolean shouldFilter(ZuulMessage msg) {
+            return true;
+        }
+    }
+
+    private static class ChunkBaseFilter extends NoOpBaseFilter {
+        @Override
+        public HttpContent processContentChunk(ZuulMessage zuulMessage, HttpContent chunk) {
+            return chunk;
+        }
+    }
+
+    private static class NoOpSyncAdapter extends SyncZuulFilterAdapter<ZuulMessage, ZuulMessage> {
+        @Override
+        public String filterName() {
+            return getClass().getName();
+        }
+
+        @Override
+        public ZuulMessage apply(ZuulMessage input) {
+            return input;
+        }
+
+        @Override
+        public ZuulMessage getDefaultOutput(ZuulMessage input) {
+            return input;
+        }
+    }
+
+    private static class ChunkSyncAdapter extends NoOpSyncAdapter {
+        @Override
+        public HttpContent processContentChunk(ZuulMessage zuulMessage, HttpContent chunk) {
+            return chunk;
+        }
+    }
+}

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunnerTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/filter/ZuulFilterChainRunnerTest.java
@@ -15,8 +15,11 @@
  */
 package com.netflix.zuul.netty.filter;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -35,14 +38,18 @@ import com.netflix.zuul.filters.ZuulFilter;
 import com.netflix.zuul.filters.http.HttpInboundFilter;
 import com.netflix.zuul.filters.http.HttpOutboundFilter;
 import com.netflix.zuul.message.Headers;
+import com.netflix.zuul.message.ZuulMessage;
 import com.netflix.zuul.message.http.HttpQueryParams;
 import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpRequestMessageImpl;
 import com.netflix.zuul.message.http.HttpResponseMessage;
 import com.netflix.zuul.message.http.HttpResponseMessageImpl;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.HttpContent;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,13 +58,14 @@ import rx.Observable;
 class ZuulFilterChainRunnerTest {
     private HttpRequestMessage request;
     private HttpResponseMessage response;
+    private EmbeddedChannel channel;
 
     @BeforeEach
     void before() {
         SessionContext context = new SessionContext();
         Headers headers = new Headers();
 
-        EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
+        channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
         ChannelHandlerContext ctx = channel.pipeline().context(ChannelInboundHandlerAdapter.class);
         context.put(CommonContextKeys.NETTY_SERVER_CHANNEL_HANDLER_CONTEXT, ctx);
         request = new HttpRequestMessageImpl(
@@ -121,6 +129,50 @@ class ZuulFilterChainRunnerTest {
         verifyNoMoreInteractions(notifier);
     }
 
+    @Test
+    void chunkPathSkipsNoOpFiltersButStillForwardsChunk() {
+        SimpleOutboundFilter outbound1 = spy(new SimpleOutboundFilter(true));
+        SimpleOutboundFilter outbound2 = spy(new SimpleOutboundFilter(true));
+
+        ZuulFilter[] filters = new ZuulFilter[] {outbound1, outbound2};
+        ZuulFilterChainRunner runner = new ZuulFilterChainRunner(
+                filters, mock(FilterUsageNotifier.class), new FilterConstraints(List.of()), mock(Registry.class));
+
+        runner.filter(response);
+        channel.readInbound();
+        clearInvocations(outbound1, outbound2);
+
+        HttpContent chunk = new DefaultHttpContent(Unpooled.copiedBuffer("data".getBytes(UTF_8)));
+        runner.filter(response, chunk);
+
+        verify(outbound1, never()).shouldFilter(any());
+        verify(outbound1, never()).isDisabled();
+        verify(outbound1, never()).processContentChunk(any(), any());
+        verify(outbound2, never()).shouldFilter(any());
+        assertThat((HttpContent) channel.readInbound()).isSameAs(chunk);
+    }
+
+    @Test
+    void chunkPathStillRunsChunkTransformingFilters() {
+        SimpleOutboundFilter noOp = spy(new SimpleOutboundFilter(true));
+        ChunkTransformingOutboundFilter transformer = spy(new ChunkTransformingOutboundFilter());
+
+        ZuulFilter[] filters = new ZuulFilter[] {noOp, transformer};
+        ZuulFilterChainRunner runner = new ZuulFilterChainRunner(
+                filters, mock(FilterUsageNotifier.class), new FilterConstraints(List.of()), mock(Registry.class));
+
+        runner.filter(response);
+        channel.readInbound();
+        clearInvocations(noOp, transformer);
+
+        HttpContent chunk = new DefaultHttpContent(Unpooled.copiedBuffer("data".getBytes(UTF_8)));
+        runner.filter(response, chunk);
+
+        verify(noOp, never()).processContentChunk(any(), any());
+        verify(transformer, times(1)).processContentChunk(eq(response), eq(chunk));
+        assertThat((HttpContent) channel.readInbound()).isSameAs(transformer.replacement);
+    }
+
     @Filter(order = 1)
     class SimpleInboundFilter extends HttpInboundFilter {
         private final boolean shouldFilter;
@@ -176,6 +228,36 @@ class ZuulFilterChainRunnerTest {
         @Override
         public boolean shouldFilter(HttpResponseMessage msg) {
             return this.shouldFilter;
+        }
+    }
+
+    @Filter(order = 1)
+    class ChunkTransformingOutboundFilter extends HttpOutboundFilter {
+        final HttpContent replacement = new DefaultHttpContent(Unpooled.copiedBuffer("gz".getBytes(UTF_8)));
+
+        @Override
+        public int filterOrder() {
+            return 0;
+        }
+
+        @Override
+        public FilterType filterType() {
+            return FilterType.OUTBOUND;
+        }
+
+        @Override
+        public Observable<HttpResponseMessage> applyAsync(HttpResponseMessage input) {
+            return Observable.just(input);
+        }
+
+        @Override
+        public boolean shouldFilter(HttpResponseMessage msg) {
+            return true;
+        }
+
+        @Override
+        public HttpContent processContentChunk(ZuulMessage zuulMessage, HttpContent chunk) {
+            return replacement;
         }
     }
 }


### PR DESCRIPTION
`ZuulFilterChainRunner` checks _every_ filter on _every_ response body chunk before calling `processContentChunk`, even though almost all filters that call is a no-op pass-through. On a streaming response, that processing is pure per-chunk overhead (measured around ~18.6% of on-CPU samples) for it to not actually do any processing.

This PR adds an automatic detection to skip the `shouldFilter` overhead on filters that don't transform chunks (that is, don't implement `processContentChunk`), so only filters that actually touch the body (like `GZipResponseFilter`) run per chunk.