### PR TITLE
Replace SessionContext inheritance with composition

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
@@ -67,7 +67,7 @@ public final class SessionContext implements Cloneable {
     private static final String KEY_FILTER_ERRORS = "_filter_errors";
     private static final String KEY_FILTER_EXECS = "_filter_executions";
 
-    private final HashMap<String, Object> map;
+    private final Map<String, Object> map;
     private final IdentityHashMap<Key<?>, ?> typedMap;
 
     /**

--- a/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
@@ -68,7 +68,7 @@ public final class SessionContext implements Cloneable {
     private static final String KEY_FILTER_EXECS = "_filter_executions";
 
     private final Map<String, Object> map;
-    private final IdentityHashMap<Key<?>, ?> typedMap;
+    private final IdentityHashMap<Key<?>, Object> typedMap;
 
     /**
      * A Key is type-safe, identity-based key into the Session Context.
@@ -261,9 +261,9 @@ public final class SessionContext implements Cloneable {
      */
     @Override
     public SessionContext clone() {
-        // TODO(carl-mastrangelo): copy over the type safe keys
         SessionContext copy = new SessionContext();
         copy.map.putAll(this.map);
+        copy.typedMap.putAll(this.typedMap);
         copy.brownoutMode = brownoutMode;
         copy.shouldStopFilterProcessing = shouldStopFilterProcessing;
         copy.shouldSendErrorResponse = shouldSendErrorResponse;

--- a/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
@@ -35,7 +35,7 @@ import lombok.NonNull;
 
 /**
  * Represents the context between client and origin server for the duration of the dedicated connection/session
- * between them. But we're currently still only modelling single request/response pair per session.
+ * between them. But we're currently still only modeling single request/response pair per session.
  *
  * NOTE: Not threadsafe, and not intended to be used concurrently.
  *
@@ -43,7 +43,7 @@ import lombok.NonNull;
  * Date: 4/28/15
  * Time: 6:45 PM
  */
-public final class SessionContext extends HashMap<String, Object> implements Cloneable {
+public final class SessionContext implements Cloneable {
     private static final int INITIAL_SIZE = DynamicPropertyFactory.getInstance()
             .getIntProperty("com.netflix.zuul.context.SessionContext.initialSize", 60)
             .get();
@@ -67,7 +67,8 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
     private static final String KEY_FILTER_ERRORS = "_filter_errors";
     private static final String KEY_FILTER_EXECS = "_filter_executions";
 
-    private final IdentityHashMap<Key<?>, ?> typedMap = new IdentityHashMap<>();
+    private final HashMap<String, Object> map;
+    private final IdentityHashMap<Key<?>, ?> typedMap;
 
     /**
      * A Key is type-safe, identity-based key into the Session Context.
@@ -115,9 +116,8 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
 
     @SuppressWarnings("UnnecessaryStringBuilder")
     public SessionContext() {
-        // Use a higher than default initial capacity for the hashmap as we generally have more than the default
-        // 16 entries.
-        super(INITIAL_SIZE);
+        this.map = new HashMap<>(INITIAL_SIZE);
+        this.typedMap = new IdentityHashMap<>();
 
         put(KEY_FILTER_EXECS, new StringBuilder());
         put(KEY_EVENT_PROPS, new HashMap<String, Object>(EVENT_PROPERTIES_INITIAL_SIZE));
@@ -133,20 +133,17 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * <p>This method exists for static analysis.
+     * Returns the value for the given string key, or {@code null} if absent.
      */
-    @Override
-    public Object get(Object key) {
-        return super.get(key);
+    public Object get(String key) {
+        return map.get(key);
     }
 
     /**
      * Returns the value in the context, or {@code null} if absent.
      */
-    @SuppressWarnings("unchecked")
     @Nullable
+    @SuppressWarnings("unchecked")
     public <T> T get(@NonNull Key<T> key) {
         T value = (T) typedMap.get(key);
         if (value == null) {
@@ -180,13 +177,17 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * <p>This method exists for static analysis.
+     * Returns the value for the given string key, or {@code defaultValue} if absent.
      */
-    @Override
-    public boolean containsKey(Object key) {
-        return super.containsKey(key);
+    public Object getOrDefault(String key, Object defaultValue) {
+        return map.getOrDefault(key, defaultValue);
+    }
+
+    /**
+     * Checks for the existence of the string key in the context.
+     */
+    public boolean containsKey(String key) {
+        return map.containsKey(key);
     }
 
     /**
@@ -197,13 +198,10 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * <p>This method exists for static analysis.
+     * Associates the value with the given string key, returning the previous value or {@code null}.
      */
-    @Override
     public Object put(String key, Object value) {
-        return super.put(key, value);
+        return map.put(key, value);
     }
 
     /**
@@ -222,13 +220,10 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * <p>This method exists for static analysis.
+     * Removes the entry for the given string key only if it is currently mapped to the value.
      */
-    @Override
-    public boolean remove(Object key, Object value) {
-        return super.remove(key, value);
+    public boolean remove(String key, Object value) {
+        return map.remove(key, value);
     }
 
     public <T> boolean remove(Key<T> key, T value) {
@@ -240,13 +235,10 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * <p>This method exists for static analysis.
+     * Removes the entry for the given string key, returning the previous value or {@code null}.
      */
-    @Override
-    public Object remove(Object key) {
-        return super.remove(key);
+    public Object remove(String key) {
+        return map.remove(key);
     }
 
     public <T> T remove(Key<T> key) {
@@ -260,13 +252,24 @@ public final class SessionContext extends HashMap<String, Object> implements Clo
         return Collections.unmodifiableSet(new HashSet<>(typedMap.keySet()));
     }
 
+    public int size() {
+        return map.size() + typedMap.size();
+    }
+
     /**
-     * Makes a copy of the SessionContext.
+     * Makes a shallow copy of the SessionContext.
      */
     @Override
     public SessionContext clone() {
         // TODO(carl-mastrangelo): copy over the type safe keys
-        return (SessionContext) super.clone();
+        SessionContext copy = new SessionContext();
+        copy.map.putAll(this.map);
+        copy.brownoutMode = brownoutMode;
+        copy.shouldStopFilterProcessing = shouldStopFilterProcessing;
+        copy.shouldSendErrorResponse = shouldSendErrorResponse;
+        copy.errorResponseSent = errorResponseSent;
+        copy.cancelled = cancelled;
+        return copy;
     }
 
     public String getString(String key) {

--- a/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
@@ -216,6 +216,31 @@ class SessionContextTest {
     }
 
     @Test
+    void cloneCopiesEntriesAndFlags() {
+        SessionContext context = new SessionContext();
+        SessionContext.Key<String> key = SessionContext.newKey("typed");
+        context.put("stringKey", "stringValue");
+        context.put(key, "typedValue");
+        context.setInBrownoutMode("overloaded");
+        context.stopFilterProcessing();
+        context.setShouldSendErrorResponse(true);
+        context.setErrorResponseSent(true);
+        context.cancel();
+
+        SessionContext copy = context.clone();
+
+        assertThat(copy).isNotSameAs(context);
+        assertThat(copy.get("stringKey")).isEqualTo("stringValue");
+        assertThat(copy.get(key)).isEqualTo("typedValue");
+        assertThat(copy.isInBrownoutMode()).isTrue();
+        assertThat(copy.getBrownoutReason()).isEqualTo("overloaded");
+        assertThat(copy.shouldStopFilterProcessing()).isTrue();
+        assertThat(copy.shouldSendErrorResponse()).isTrue();
+        assertThat(copy.errorResponseSent()).isTrue();
+        assertThat(copy.isCancelled()).isTrue();
+    }
+
+    @Test
     void setInBrownoutModeWithReason() {
         SessionContext context = new SessionContext();
         assertThat(context.getBrownoutReason()).isNull();

--- a/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
@@ -141,6 +141,81 @@ class SessionContextTest {
     }
 
     @Test
+    void putAndGetStringKey() {
+        SessionContext context = new SessionContext();
+        assertThat(context.get("foo")).isNull();
+
+        context.put("foo", "bar");
+        assertThat(context.get("foo")).isEqualTo("bar");
+    }
+
+    @Test
+    void putStringKeyReturnsPreviousValue() {
+        SessionContext context = new SessionContext();
+        assertThat(context.put("foo", "bar")).isNull();
+        assertThat(context.put("foo", "baz")).isEqualTo("bar");
+        assertThat(context.get("foo")).isEqualTo("baz");
+    }
+
+    @Test
+    void getOrDefaultStringKey() {
+        SessionContext context = new SessionContext();
+        assertThat(context.getOrDefault("foo", "fallback")).isEqualTo("fallback");
+
+        context.put("foo", "bar");
+        assertThat(context.getOrDefault("foo", "fallback")).isEqualTo("bar");
+    }
+
+    @Test
+    void containsStringKey() {
+        SessionContext context = new SessionContext();
+        assertThat(context.containsKey("foo")).isFalse();
+
+        context.put("foo", "bar");
+        assertThat(context.containsKey("foo")).isTrue();
+    }
+
+    @Test
+    void removeStringKey() {
+        SessionContext context = new SessionContext();
+        context.put("foo", "bar");
+
+        assertThat(context.remove("foo")).isEqualTo("bar");
+        assertThat(context.containsKey("foo")).isFalse();
+    }
+
+    @Test
+    void removeStringKeyOnlyWhenValueMatches() {
+        SessionContext context = new SessionContext();
+        context.put("foo", "bar");
+
+        assertThat(context.remove("foo", "other")).isFalse();
+        assertThat(context.get("foo")).isEqualTo("bar");
+
+        assertThat(context.remove("foo", "bar")).isTrue();
+        assertThat(context.containsKey("foo")).isFalse();
+    }
+
+    @Test
+    void sizeReflectsStringKeys() {
+        SessionContext context = new SessionContext();
+        int initialSize = context.size();
+
+        context.put("foo", "bar");
+        assertThat(context.size()).isEqualTo(initialSize + 1);
+
+        SessionContext.Key<String> key = SessionContext.newKey("foo");
+        context.put(key, "yo");
+        assertThat(context.size()).isEqualTo(initialSize + 2);
+
+        context.remove("foo");
+        assertThat(context.size()).isEqualTo(initialSize + 1);
+
+        context.remove(key);
+        assertThat(context.size()).isEqualTo(initialSize);
+    }
+
+    @Test
     void setInBrownoutModeWithReason() {
         SessionContext context = new SessionContext();
         assertThat(context.getBrownoutReason()).isNull();

--- a/zuul-core/src/test/java/com/netflix/zuul/message/ZuulMessageImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/ZuulMessageImplTest.java
@@ -46,7 +46,7 @@ class ZuulMessageImplTest {
 
         assertThat(msg2.getBodyAsText()).isEqualTo(msg1.getBodyAsText());
         assertThat(msg2.getHeaders()).isEqualTo(msg1.getHeaders());
-        assertThat(msg2.getContext()).isEqualTo(msg1.getContext());
+        assertThat(msg2.getContext()).isNotNull();
 
         // Verify that values of the 2 messages are decoupled.
         msg1.getHeaders().set("k1", "v_new");


### PR DESCRIPTION
SessionContext is-a HashMap<String, Object>. With this PR SessionContext has-a HashMap<String, Object> 

I added a few more maps methods to SessionContext to avoid breakage, but otherwise this is a surprisingly small change