### PR TITLE
Nullmark SessionContext

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/context/SessionContext.java
@@ -19,19 +19,16 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.zuul.filters.FilterError;
 import com.netflix.zuul.message.http.HttpResponseMessage;
-import jakarta.annotation.Nullable;
-import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
-import lombok.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the context between client and origin server for the duration of the dedicated connection/session
@@ -43,6 +40,7 @@ import lombok.NonNull;
  * Date: 4/28/15
  * Time: 6:45 PM
  */
+@NullMarked
 public final class SessionContext implements Cloneable {
     private static final int INITIAL_SIZE = DynamicPropertyFactory.getInstance()
             .getIntProperty("com.netflix.zuul.context.SessionContext.initialSize", 60)
@@ -52,23 +50,27 @@ public final class SessionContext implements Cloneable {
             .getIntProperty("com.netflix.zuul.context.SessionContext.eventProperties.initialSize", 128)
             .get();
 
+    private static final SessionContext.Key<String> KEY_UUID = SessionContext.newKey("_uuid");
+    private static final SessionContext.Key<String> KEY_VIP = SessionContext.newKey("routeVIP");
+    private static final SessionContext.Key<String> KEY_ENDPOINT = SessionContext.newKey("_endpoint");
+    private static final SessionContext.Key<HttpResponseMessage> KEY_STATIC_RESPONSE =
+            SessionContext.newKey("_static_response");
+    private static final SessionContext.Key<Throwable> KEY_ERROR = SessionContext.newKey("_error");
+    private static final SessionContext.Key<String> KEY_ERROR_ENDPOINT = SessionContext.newKey("_error-endpoint");
+    private static final SessionContext.Key<Integer> KEY_ORIGIN_REPORTED_DURATION =
+            SessionContext.newKey("_originReportedDuration");
+
     private boolean brownoutMode = false;
     private boolean shouldStopFilterProcessing = false;
     private boolean shouldSendErrorResponse = false;
     private boolean errorResponseSent = false;
     private boolean cancelled = false;
 
-    private static final String KEY_UUID = "_uuid";
-    private static final String KEY_VIP = "routeVIP";
-    private static final String KEY_ENDPOINT = "_endpoint";
-    private static final String KEY_STATIC_RESPONSE = "_static_response";
-
-    private static final String KEY_EVENT_PROPS = "eventProperties";
-    private static final String KEY_FILTER_ERRORS = "_filter_errors";
-    private static final String KEY_FILTER_EXECS = "_filter_executions";
-
     private final Map<String, Object> map;
     private final IdentityHashMap<Key<?>, Object> typedMap;
+    private final StringBuilder filterExecutionSummary;
+    private final Map<String, Object> eventProperties;
+    private final List<FilterError> filterErrors;
 
     /**
      * A Key is type-safe, identity-based key into the Session Context.
@@ -77,9 +79,11 @@ public final class SessionContext implements Cloneable {
     public static final class Key<T> {
 
         private final String name;
+
+        @Nullable
         private final Supplier<T> defaultValueSupplier;
 
-        private Key(String name, Supplier<T> defaultValueSupplier) {
+        private Key(String name, @Nullable Supplier<T> defaultValueSupplier) {
             this.name = Objects.requireNonNull(name, "name");
             this.defaultValueSupplier = defaultValueSupplier;
         }
@@ -97,7 +101,7 @@ public final class SessionContext implements Cloneable {
          * This method exists solely to indicate that Keys are based on identity and not name.
          */
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             return super.equals(o);
         }
 
@@ -109,32 +113,36 @@ public final class SessionContext implements Cloneable {
             return super.hashCode();
         }
 
+        @Nullable
         public T defaultValue() {
             return defaultValueSupplier != null ? defaultValueSupplier.get() : null;
         }
     }
 
-    @SuppressWarnings("UnnecessaryStringBuilder")
     public SessionContext() {
-        this.map = new HashMap<>(INITIAL_SIZE);
-        this.typedMap = new IdentityHashMap<>();
+        this(INITIAL_SIZE, EVENT_PROPERTIES_INITIAL_SIZE);
+    }
 
-        put(KEY_FILTER_EXECS, new StringBuilder());
-        put(KEY_EVENT_PROPS, new HashMap<String, Object>(EVENT_PROPERTIES_INITIAL_SIZE));
-        put(KEY_FILTER_ERRORS, new ArrayList<FilterError>());
+    public SessionContext(int initialMapSize, int initialEventPropertiesSize) {
+        this.map = new HashMap<>(initialMapSize);
+        this.typedMap = new IdentityHashMap<>(initialMapSize);
+        this.filterExecutionSummary = new StringBuilder();
+        this.eventProperties = new HashMap<>(initialEventPropertiesSize);
+        this.filterErrors = new ArrayList<>();
     }
 
     public static <T> Key<T> newKey(String name) {
         return newKey(name, null);
     }
 
-    public static <T> Key<T> newKey(String name, Supplier<T> defaultValueSupplier) {
+    public static <T> Key<T> newKey(String name, @Nullable Supplier<T> defaultValueSupplier) {
         return new Key<>(name, defaultValueSupplier);
     }
 
     /**
      * Returns the value for the given string key, or {@code null} if absent.
      */
+    @Nullable
     public Object get(String key) {
         return map.get(key);
     }
@@ -144,7 +152,7 @@ public final class SessionContext implements Cloneable {
      */
     @Nullable
     @SuppressWarnings("unchecked")
-    public <T> T get(@NonNull Key<T> key) {
+    public <T> T get(Key<T> key) {
         T value = (T) typedMap.get(key);
         if (value == null) {
             value = key.defaultValue();
@@ -157,8 +165,7 @@ public final class SessionContext implements Cloneable {
      * Returns the value in the context, or default value from the
      * typed key default value supplier if absent.
      */
-    @NonNull
-    public <T> T getOrDefault(@NonNull Key<T> key) {
+    public <T> T getOrDefault(Key<T> key) {
         return Objects.requireNonNull(this.get(key), "expected non-null value or defaultValue supplier");
     }
 
@@ -200,6 +207,7 @@ public final class SessionContext implements Cloneable {
     /**
      * Associates the value with the given string key, returning the previous value or {@code null}.
      */
+    @Nullable
     public Object put(String key, Object value) {
         return map.put(key, value);
     }
@@ -214,8 +222,8 @@ public final class SessionContext implements Cloneable {
         Objects.requireNonNull(key, "key");
         Objects.requireNonNull(value, "value");
 
-        @SuppressWarnings("unchecked") // Sorry.
-        T res = ((Map<Key<T>, T>) (Map) typedMap).put(key, value);
+        @SuppressWarnings("unchecked")
+        T res = (T) typedMap.put(key, value);
         return res;
     }
 
@@ -229,27 +237,27 @@ public final class SessionContext implements Cloneable {
     public <T> boolean remove(Key<T> key, T value) {
         Objects.requireNonNull(key, "key");
         Objects.requireNonNull(value, "value");
-        @SuppressWarnings("unchecked") // sorry
-        boolean res = ((Map<Key<T>, T>) (Map) typedMap).remove(key, value);
-        return res;
+        return typedMap.remove(key, value);
     }
 
     /**
      * Removes the entry for the given string key, returning the previous value or {@code null}.
      */
+    @Nullable
     public Object remove(String key) {
         return map.remove(key);
     }
 
+    @Nullable
     public <T> T remove(Key<T> key) {
         Objects.requireNonNull(key, "key");
-        @SuppressWarnings("unchecked") // sorry
-        T res = ((Map<Key<T>, T>) (Map) typedMap).remove(key);
+        @SuppressWarnings("unchecked")
+        T res = (T) typedMap.remove(key);
         return res;
     }
 
     public Set<Key<?>> keys() {
-        return Collections.unmodifiableSet(new HashSet<>(typedMap.keySet()));
+        return Set.copyOf(typedMap.keySet());
     }
 
     public int size() {
@@ -264,6 +272,9 @@ public final class SessionContext implements Cloneable {
         SessionContext copy = new SessionContext();
         copy.map.putAll(this.map);
         copy.typedMap.putAll(this.typedMap);
+        copy.filterExecutionSummary.append(this.filterExecutionSummary);
+        copy.eventProperties.putAll(this.eventProperties);
+        copy.filterErrors.addAll(this.filterErrors);
         copy.brownoutMode = brownoutMode;
         copy.shouldStopFilterProcessing = shouldStopFilterProcessing;
         copy.shouldSendErrorResponse = shouldSendErrorResponse;
@@ -272,6 +283,7 @@ public final class SessionContext implements Cloneable {
         return copy;
     }
 
+    @Nullable
     public String getString(String key) {
         return (String) get(key);
     }
@@ -279,7 +291,7 @@ public final class SessionContext implements Cloneable {
     /**
      * Convenience method to return a boolean value for a given key
      *
-     * @return true or false depending what was set. default is false
+     * @return true or false depending on what was set. default is false
      */
     public boolean getBoolean(String key) {
         return getBoolean(key, false);
@@ -309,7 +321,7 @@ public final class SessionContext implements Cloneable {
      * puts the key, value into the map. a null value will remove the key from the map
      *
      */
-    public void set(String key, Object value) {
+    public void set(String key, @Nullable Object value) {
         if (value != null) {
             put(key, value);
         } else {
@@ -317,8 +329,20 @@ public final class SessionContext implements Cloneable {
         }
     }
 
+    /**
+     * Puts the key, value into the context. A null value removes the key from the map.
+     */
+    public <T> void set(Key<T> key, @Nullable T value) {
+        if (value != null) {
+            put(key, value);
+        } else {
+            remove(key);
+        }
+    }
+
+    @Nullable
     public String getUUID() {
-        return getString(KEY_UUID);
+        return get(KEY_UUID);
     }
 
     public void setUUID(String uuid) {
@@ -329,54 +353,35 @@ public final class SessionContext implements Cloneable {
         set(KEY_STATIC_RESPONSE, response);
     }
 
+    @Nullable
     public HttpResponseMessage getStaticResponse() {
-        return (HttpResponseMessage) get(KEY_STATIC_RESPONSE);
+        return get(KEY_STATIC_RESPONSE);
     }
 
     /**
      * Gets the throwable that will be use in the Error endpoint.
      *
      */
+    @Nullable
     public Throwable getError() {
-        return (Throwable) get("_error");
+        return get(KEY_ERROR);
     }
 
     /**
-     * Sets throwable to use for generating a response in the Error endpoint.
+     * Sets throwable to use for generating a response in the Error endpoint. A null throwable clears any existing
+     * error.
      */
-    public void setError(Throwable th) {
-        put("_error", th);
+    public void setError(@Nullable Throwable th) {
+        set(KEY_ERROR, th);
     }
 
+    @Nullable
     public String getErrorEndpoint() {
-        return (String) get("_error-endpoint");
+        return get(KEY_ERROR_ENDPOINT);
     }
 
-    public void setErrorEndpoint(String name) {
-        put("_error-endpoint", name);
-    }
-
-    /**
-     * removes "routeHost" key
-     */
-    public void removeRouteHost() {
-        remove("routeHost");
-    }
-
-    /**
-     * sets routeHost
-     *
-     * @param routeHost a URL
-     */
-    public void setRouteHost(URL routeHost) {
-        set("routeHost", routeHost);
-    }
-
-    /**
-     * @return "routeHost" URL
-     */
-    public URL getRouteHost() {
-        return (URL) get("routeHost");
+    public void setErrorEndpoint(@Nullable String name) {
+        set(KEY_ERROR_ENDPOINT, name);
     }
 
     /**
@@ -385,7 +390,7 @@ public final class SessionContext implements Cloneable {
      */
     public void addFilterExecutionSummary(String name, String status, long time) {
         StringBuilder sb = getFilterExecutionSummary();
-        if (sb.length() > 0) {
+        if (!sb.isEmpty()) {
             sb.append(", ");
         }
         sb.append(name)
@@ -401,7 +406,7 @@ public final class SessionContext implements Cloneable {
      * @return String that represents the filter execution history for the current request
      */
     public StringBuilder getFilterExecutionSummary() {
-        return (StringBuilder) get(KEY_FILTER_EXECS);
+        return filterExecutionSummary;
     }
 
     public boolean shouldSendErrorResponse() {
@@ -443,12 +448,13 @@ public final class SessionContext implements Cloneable {
         this.brownoutMode = true;
     }
 
-    public void setInBrownoutMode(@NonNull String reason) {
+    public void setInBrownoutMode(String reason) {
         this.brownoutMode = true;
         put(CommonContextKeys.BROWNOUT_REASON, reason);
     }
 
-    public @Nullable String getBrownoutReason() {
+    @Nullable
+    public String getBrownoutReason() {
         return get(CommonContextKeys.BROWNOUT_REASON);
     }
 
@@ -468,8 +474,9 @@ public final class SessionContext implements Cloneable {
      * returns the routeVIP; that is the Eureka "vip" of registered instances
      *
      */
+    @Nullable
     public String getRouteVIP() {
-        return (String) get(KEY_VIP);
+        return get(KEY_VIP);
     }
 
     /**
@@ -480,11 +487,12 @@ public final class SessionContext implements Cloneable {
     }
 
     public void setEndpoint(String endpoint) {
-        put(KEY_ENDPOINT, endpoint);
+        set(KEY_ENDPOINT, endpoint);
     }
 
+    @Nullable
     public String getEndpoint() {
-        return (String) get(KEY_ENDPOINT);
+        return get(KEY_ENDPOINT);
     }
 
     public void setEventProperty(String key, Object value) {
@@ -492,21 +500,21 @@ public final class SessionContext implements Cloneable {
     }
 
     public Map<String, Object> getEventProperties() {
-        return (Map<String, Object>) this.get(KEY_EVENT_PROPS);
+        return eventProperties;
     }
 
     public List<FilterError> getFilterErrors() {
-        return (List<FilterError>) get(KEY_FILTER_ERRORS);
+        return filterErrors;
     }
 
     public void setOriginReportedDuration(int duration) {
-        put("_originReportedDuration", duration);
+        set(KEY_ORIGIN_REPORTED_DURATION, duration);
     }
 
     public int getOriginReportedDuration() {
-        Object value = get("_originReportedDuration");
+        Integer value = get(KEY_ORIGIN_REPORTED_DURATION);
         if (value != null) {
-            return (Integer) value;
+            return value;
         }
         return -1;
     }

--- a/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
@@ -18,6 +18,7 @@ package com.netflix.zuul.context;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.netflix.zuul.filters.FilterError;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -238,6 +239,28 @@ class SessionContextTest {
         assertThat(copy.shouldSendErrorResponse()).isTrue();
         assertThat(copy.errorResponseSent()).isTrue();
         assertThat(copy.isCancelled()).isTrue();
+    }
+
+    @Test
+    void cloneCopiesCollectionsIndependently() {
+        SessionContext context = new SessionContext();
+        context.addFilterExecutionSummary("filterA", "SUCCESS", 1);
+        context.setEventProperty("evt", "original");
+        context.getFilterErrors().add(new FilterError("filterA", "inbound", new RuntimeException("boom")));
+
+        SessionContext copy = context.clone();
+        assertThat(copy.getFilterExecutionSummary().toString())
+                .isEqualTo(context.getFilterExecutionSummary().toString());
+        assertThat(copy.getEventProperties()).containsEntry("evt", "original");
+        assertThat(copy.getFilterErrors()).hasSize(1);
+
+        copy.addFilterExecutionSummary("filterB", "SUCCESS", 2);
+        copy.setEventProperty("evt", "mutated");
+        copy.getFilterErrors().add(new FilterError("filterB", "outbound", new RuntimeException("boom2")));
+
+        assertThat(context.getFilterExecutionSummary().toString()).doesNotContain("filterB");
+        assertThat(context.getEventProperties()).containsEntry("evt", "original");
+        assertThat(context.getFilterErrors()).hasSize(1);
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/context/SessionContextTest.java
@@ -227,6 +227,9 @@ class SessionContextTest {
         context.setShouldSendErrorResponse(true);
         context.setErrorResponseSent(true);
         context.cancel();
+        context.addFilterExecutionSummary("filterA", "SUCCESS", 1);
+        context.setEventProperty("evt", "original");
+        context.getFilterErrors().add(new FilterError("filterA", "inbound", new RuntimeException("boom")));
 
         SessionContext copy = context.clone();
 
@@ -239,21 +242,12 @@ class SessionContextTest {
         assertThat(copy.shouldSendErrorResponse()).isTrue();
         assertThat(copy.errorResponseSent()).isTrue();
         assertThat(copy.isCancelled()).isTrue();
-    }
-
-    @Test
-    void cloneCopiesCollectionsIndependently() {
-        SessionContext context = new SessionContext();
-        context.addFilterExecutionSummary("filterA", "SUCCESS", 1);
-        context.setEventProperty("evt", "original");
-        context.getFilterErrors().add(new FilterError("filterA", "inbound", new RuntimeException("boom")));
-
-        SessionContext copy = context.clone();
         assertThat(copy.getFilterExecutionSummary().toString())
                 .isEqualTo(context.getFilterExecutionSummary().toString());
         assertThat(copy.getEventProperties()).containsEntry("evt", "original");
         assertThat(copy.getFilterErrors()).hasSize(1);
 
+        // the collections must be independent copies, not shared references
         copy.addFilterExecutionSummary("filterB", "SUCCESS", 2);
         copy.setEventProperty("evt", "mutated");
         copy.getFilterErrors().add(new FilterError("filterB", "outbound", new RuntimeException("boom2")));


### PR DESCRIPTION
The primary change in this PR is null marking SessionContext. As part of nullmarking, I converted some of the fields that were stored as elements in the map into proper member variables. For example, EventProperties used to be stored in the map which would have required marking `getEventProperties()` as @Nullable, but by making it a member variable I'm able to ensure it is never null. 

For other elements that are still saved in the map (e.g. uuid) I switched to typed keys. I also cleaned up some messy generic usage around the typed map, and added logic to pre-size it