### PR TITLE
Upgrade Netty to v4.2.16.Final

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 versions_ribbon=2.4.4
-versions_netty=4.2.15.Final
+versions_netty=4.2.16.Final
 release.scope=patch
 release.version=3.3.0-SNAPSHOT
 org.gradle.jvmargs=-Xms1g -Xmx2g

--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -4,7 +4,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         },
         "org.projectlombok:lombok": {
             "locked": "1.18.42"
@@ -48,43 +48,43 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -135,7 +135,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         }
     },
     "jmhCompileClasspath": {
@@ -176,43 +176,43 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -307,7 +307,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -316,40 +316,40 @@
             "locked": "1.10"
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -471,46 +471,46 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -545,7 +545,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         }
     },
     "testCompileClasspath": {
@@ -586,7 +586,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -595,37 +595,37 @@
             "locked": "1.10"
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"
@@ -735,7 +735,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -744,40 +744,40 @@
             "locked": "1.10"
         },
         "io.netty:netty-bom": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "locked": "0.27.0"

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/CoalescingBufferQueueReaderIndexDesyncTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/CoalescingBufferQueueReaderIndexDesyncTest.java
@@ -17,39 +17,26 @@
 package com.netflix.zuul.filters.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelConfig;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.CoalescingBufferQueue;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.http2.DefaultHttp2Connection;
-import io.netty.handler.codec.http2.DefaultHttp2RemoteFlowController;
-import io.netty.handler.codec.http2.Http2Exception;
-import io.netty.handler.codec.http2.Http2RemoteFlowController;
-import io.netty.handler.codec.http2.Http2Stream;
-import io.netty.util.concurrent.EventExecutor;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 
 /**
- * Replaying a chunk to a retried origin with a shared reader index can leave the real CoalescingBufferQueue
- * reporting readable bytes it can never produce, and a frame stuck in that state spins the real
- * DefaultHttp2RemoteFlowController emitting empty DATA frames forever. retainedDuplicate gives each attempt
- * its own reader index over the shared memory, so it drains cleanly.
+ * Replaying a chunk to a retried origin with a shared reader index (retain) can drain the buffer out from
+ * under a CoalescingBufferQueue, leaving it empty. As of netty 4.2.16 the queue reconciles its readable byte
+ * count back to zero once it drains empty (netty/netty#16946) instead of reporting bytes it can never produce,
+ * so it no longer desyncs. retainedDuplicate gives each attempt its own reader index over the shared memory,
+ * so it drains cleanly and actually produces the bytes.
  */
 class CoalescingBufferQueueReaderIndexDesyncTest {
 
     private static final byte[] BODY = "Hello There".getBytes(StandardCharsets.UTF_8);
 
     @Test
-    void retainSharesReaderIndexAndDesyncsRealCoalescingBufferQueue() {
+    void retainSharesReaderIndexAndNettyReconcilesDrainedQueueToZero() {
         EmbeddedChannel channel = new EmbeddedChannel();
         ByteBuf body = channel.alloc().buffer().writeBytes(BODY);
         int bodyLength = body.readableBytes();
@@ -63,9 +50,10 @@ class CoalescingBufferQueueReaderIndexDesyncTest {
 
         ByteBuf produced = slowAttempt.remove(channel.alloc(), bodyLength, channel.newPromise());
 
+        // netty 4.2.16 reconciles readableBytes to 0 once the queue drains empty instead of reporting phantom bytes
         assertThat(produced.readableBytes()).isZero();
         assertThat(slowAttempt.isEmpty()).isTrue();
-        assertThat(slowAttempt.readableBytes()).isEqualTo(bodyLength);
+        assertThat(slowAttempt.readableBytes()).isZero();
 
         produced.release();
         body.release();
@@ -93,84 +81,5 @@ class CoalescingBufferQueueReaderIndexDesyncTest {
         produced.release();
         body.release();
         channel.finishAndReleaseAll();
-    }
-
-    // TODO(netty #16946): this asserts the *unbounded* spin present in our netty (4.2.15). Once the netty fix
-    // lands writeAllocatedBytes bails after a bounded number of no-progress passes, so flip this to assert
-    // the frame is errored after a small emitted count.
-    @Test
-    @Timeout(value = 20, unit = TimeUnit.SECONDS, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
-    void desyncedFrameSpinsRealFlowControllerEmittingUnboundedEmptyFrames() throws Http2Exception {
-        long emptyFrameCap = 200_000L;
-
-        DefaultHttp2Connection connection = new DefaultHttp2Connection(false);
-        DefaultHttp2RemoteFlowController controller = new DefaultHttp2RemoteFlowController(connection);
-        connection.remote().flowController(controller);
-        Http2Stream stream = connection.local().createStream(1, false);
-
-        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
-        Channel channel = mock(Channel.class);
-        ChannelConfig config = mock(ChannelConfig.class);
-        EventExecutor executor = mock(EventExecutor.class);
-        when(channel.isWritable()).thenReturn(true);
-        when(channel.bytesBeforeUnwritable()).thenReturn(Long.MAX_VALUE);
-        when(channel.config()).thenReturn(config);
-        when(executor.inEventLoop()).thenReturn(true);
-        when(ctx.channel()).thenReturn(channel);
-        when(ctx.executor()).thenReturn(executor);
-        controller.channelHandlerContext(ctx);
-
-        StuckBodyFrame frame = new StuckBodyFrame(BODY.length, emptyFrameCap);
-        controller.addFlowControlled(stream, frame);
-
-        controller.writePendingBytes();
-
-        assertThat(frame.emitted.get()).isGreaterThanOrEqualTo(emptyFrameCap);
-        assertThat(frame.error).isInstanceOf(Http2Exception.class);
-    }
-
-    private static final class StuckBodyFrame implements Http2RemoteFlowController.FlowControlled {
-
-        private final int size;
-        private final long cap;
-        private final AtomicLong emitted = new AtomicLong();
-        private Throwable error;
-
-        StuckBodyFrame(int size, long cap) {
-            this.size = size;
-            this.cap = cap;
-        }
-
-        @Override
-        public int size() {
-            return size;
-        }
-
-        @Override
-        public void error(ChannelHandlerContext ctx, Throwable cause) {
-            error = cause;
-        }
-
-        @Override
-        public void writeComplete() {}
-
-        @Override
-        public void write(ChannelHandlerContext ctx, int allowedBytes) {
-            // size() never shrinks so the frame is never removed; the cap throws to break netty's unbounded loop
-            if (emitted.incrementAndGet() >= cap) {
-                throw new SpinDetected();
-            }
-        }
-
-        @Override
-        public boolean merge(ChannelHandlerContext ctx, Http2RemoteFlowController.FlowControlled next) {
-            return false;
-        }
-    }
-
-    private static final class SpinDetected extends RuntimeException {
-        SpinDetected() {
-            super("flow controller emitted the capped number of empty frames without making progress");
-        }
     }
 }

--- a/zuul-discovery/dependencies.lock
+++ b/zuul-discovery/dependencies.lock
@@ -4,7 +4,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         }
     },
     "compileClasspath": {
@@ -51,7 +51,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         }
     },
     "jmhCompileClasspath": {
@@ -167,7 +167,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         }
     },
     "testCompileClasspath": {

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -78,7 +78,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -96,79 +96,79 @@
             "project": true
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -276,7 +276,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -294,46 +294,46 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -378,7 +378,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         }
     },
     "jmhCompileClasspath": {
@@ -437,7 +437,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -455,46 +455,46 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -617,7 +617,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -638,79 +638,79 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-parent": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -879,7 +879,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -897,76 +897,76 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1023,7 +1023,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         }
     },
     "testCompileClasspath": {
@@ -1085,7 +1085,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1106,52 +1106,52 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-parent": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1298,7 +1298,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1319,79 +1319,79 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-parent": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-classes-epoll": {
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -4,7 +4,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         }
     },
     "compileClasspath": {
@@ -63,7 +63,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -78,43 +78,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -159,7 +159,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         }
     },
     "jmhCompileClasspath": {
@@ -218,7 +218,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -233,43 +233,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -377,7 +377,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -392,73 +392,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -606,7 +606,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -621,73 +621,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -818,7 +818,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -836,79 +836,79 @@
             "project": true
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -1016,7 +1016,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1031,43 +1031,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1184,7 +1184,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1199,73 +1199,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -78,7 +78,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -96,79 +96,79 @@
             "project": true
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         },
         "io.netty:netty-bom": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -273,7 +273,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -291,43 +291,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -384,7 +384,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         }
     },
     "jmhCompileClasspath": {
@@ -440,7 +440,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -458,43 +458,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -614,7 +614,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -632,73 +632,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -843,7 +843,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -861,73 +861,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [
@@ -996,7 +996,7 @@
             "locked": "2.45.0"
         },
         "com.uber.nullaway:nullaway": {
-            "locked": "0.13.1"
+            "locked": "0.13.7"
         }
     },
     "testCompileClasspath": {
@@ -1052,7 +1052,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1070,43 +1070,43 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
@@ -1220,7 +1220,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.9.8"
+            "locked": "1.10.1"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1238,73 +1238,73 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-buffer": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-haproxy": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-codec-http2": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-common": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-handler": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-tcnative-boringssl-static": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.0.77.Final"
+            "locked": "2.0.78.Final"
         },
         "io.netty:netty-transport": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-epoll": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-io_uring": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.netty:netty-transport-native-kqueue": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "4.2.15.Final"
+            "locked": "4.2.16.Final"
         },
         "io.perfmark:perfmark-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
https://netty.io/news/2026/07/06/4-2-16-Final.html

Includes netty fix for #2146 OOM, so updated `CoalescingBufferQueueReaderIndexDesyncTest` tests to match the new behavior in the desynced queue mode.