### PR TITLE
Add new connection pool options for using default buffer sizing

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolConfig.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolConfig.java
@@ -23,26 +23,45 @@ import com.netflix.zuul.origins.OriginName;
  */
 public interface ConnectionPoolConfig {
 
-    /* Origin name from connection pool */
+    /**
+     * Origin name from connection pool.
+     */
     OriginName getOriginName();
 
-    /* Max number of requests per connection before it needs to be recycled */
+    /**
+     * Max number of requests per connection before it needs to be recycled.
+     */
     int getMaxRequestsPerConnection();
 
-    /* Max connections per host */
+    /**
+     * Max connections per host.
+     */
     int maxConnectionsPerHost();
 
     int perServerWaterline();
 
-    /* Origin client TCP configuration options */
+    /**
+     * Origin client TCP configuration options.
+     */
     int getConnectTimeout();
 
-    /* number of milliseconds connection can stay idle in a connection pool before it is closed */
+    /**
+     * Number of milliseconds connection can stay idle in a connection pool before it is closed.
+     */
     int getIdleTimeout();
 
     int getTcpReceiveBufferSize();
 
     int getTcpSendBufferSize();
+
+    /**
+     * When true, connections do not explicitly set the SO_SNDBUF/SO_RCVBUF options as configured by
+     * {@link #getTcpReceiveBufferSize()} and {@link #getTcpSendBufferSize()}. Instead, the new channels will rely on
+     * the OS's default TCP buffer sizes. Enabling this setting will enable the use of kernel autotuning
+     */
+    default boolean useDefaultTcpBufferSizes() {
+        return false;
+    }
 
     int getNettyWriteBufferHighWaterMark();
 

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolConfigImpl.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolConfigImpl.java
@@ -21,10 +21,12 @@ import com.netflix.client.config.IClientConfig;
 import com.netflix.client.config.IClientConfigKey;
 import com.netflix.zuul.origins.OriginName;
 import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Created by saroskar on 3/24/16.
  */
+@NullMarked
 public class ConnectionPoolConfigImpl implements ConnectionPoolConfig {
 
     static final int DEFAULT_BUFFER_SIZE = 32 * 1024;
@@ -62,6 +64,9 @@ public class ConnectionPoolConfigImpl implements ConnectionPoolConfig {
 
     public static final IClientConfigKey<Integer> WRITE_BUFFER_LOW_WATER_MARK =
             new CommonClientConfigKey<>("WriteBufferLowWaterMark") {};
+
+    public static final IClientConfigKey<Boolean> USE_DEFAULT_TCP_BUFFER_SIZES =
+            new CommonClientConfigKey<>("UseDefaultTcpBufferSizes") {};
 
     private final OriginName originName;
     private final IClientConfig clientConfig;
@@ -121,6 +126,11 @@ public class ConnectionPoolConfigImpl implements ConnectionPoolConfig {
     @Override
     public int getTcpSendBufferSize() {
         return clientConfig.getPropertyAsInteger(IClientConfigKey.Keys.SendBufferSize, DEFAULT_BUFFER_SIZE);
+    }
+
+    @Override
+    public boolean useDefaultTcpBufferSizes() {
+        return clientConfig.getPropertyAsBoolean(USE_DEFAULT_TCP_BUFFER_SIZES, false);
     }
 
     @Override

--- a/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/NettyClientConnectionFactory.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/connectionpool/NettyClientConnectionFactory.java
@@ -16,6 +16,7 @@
 
 package com.netflix.zuul.netty.connectionpool;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.netflix.zuul.netty.server.Server;
 import com.netflix.zuul.passport.CurrentPassport;
 import io.netty.bootstrap.Bootstrap;
@@ -28,10 +29,12 @@ import io.netty.channel.WriteBufferWaterMark;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Created by saroskar on 3/16/16.
  */
+@NullMarked
 public class NettyClientConnectionFactory {
 
     private final ConnectionPoolConfig connPoolConfig;
@@ -50,6 +53,12 @@ public class NettyClientConnectionFactory {
             // This should be checked by the ClientConnectionManager
             assert !inetSocketAddress.isUnresolved() : socketAddress;
         }
+        return createBootstrap(eventLoop, socketAddress, passport, pool).connect();
+    }
+
+    @VisibleForTesting
+    Bootstrap createBootstrap(
+            EventLoop eventLoop, SocketAddress socketAddress, CurrentPassport passport, IConnectionPool pool) {
         Bootstrap bootstrap = new Bootstrap()
                 .channel(Server.defaultOutboundChannelType.get())
                 .handler(channelInitializer)
@@ -59,8 +68,6 @@ public class NettyClientConnectionFactory {
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connPoolConfig.getConnectTimeout())
                 .option(ChannelOption.SO_KEEPALIVE, connPoolConfig.getTcpKeepAlive())
                 .option(ChannelOption.TCP_NODELAY, connPoolConfig.getTcpNoDelay())
-                .option(ChannelOption.SO_SNDBUF, connPoolConfig.getTcpSendBufferSize())
-                .option(ChannelOption.SO_RCVBUF, connPoolConfig.getTcpReceiveBufferSize())
                 .option(
                         ChannelOption.WRITE_BUFFER_WATER_MARK,
                         new WriteBufferWaterMark(
@@ -68,6 +75,12 @@ public class NettyClientConnectionFactory {
                                 connPoolConfig.getNettyWriteBufferHighWaterMark()))
                 .option(ChannelOption.AUTO_READ, connPoolConfig.getNettyAutoRead())
                 .remoteAddress(socketAddress);
-        return bootstrap.connect();
+
+        if (!connPoolConfig.useDefaultTcpBufferSizes()) {
+            bootstrap.option(ChannelOption.SO_SNDBUF, connPoolConfig.getTcpSendBufferSize());
+            bootstrap.option(ChannelOption.SO_RCVBUF, connPoolConfig.getTcpReceiveBufferSize());
+        }
+
+        return bootstrap;
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolConfigImplTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/ConnectionPoolConfigImplTest.java
@@ -148,6 +148,17 @@ class ConnectionPoolConfigImplTest {
     }
 
     @Test
+    void testUseDefaultTcpBufferSizes() {
+        assertThat(connectionPoolConfig.useDefaultTcpBufferSizes()).isFalse();
+    }
+
+    @Test
+    void testUseDefaultTcpBufferSizesOverride() {
+        clientConfig.set(ConnectionPoolConfigImpl.USE_DEFAULT_TCP_BUFFER_SIZES, true);
+        assertThat(connectionPoolConfig.useDefaultTcpBufferSizes()).isTrue();
+    }
+
+    @Test
     void testGetNettyWriteBufferHighWaterMark() {
         assertThat(connectionPoolConfig.getNettyWriteBufferHighWaterMark())
                 .isEqualTo(ConnectionPoolConfigImpl.DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK);

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/NettyClientConnectionFactoryTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/connectionpool/NettyClientConnectionFactoryTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.zuul.netty.connectionpool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.netflix.client.config.DefaultClientConfigImpl;
+import com.netflix.client.config.IClientConfigKey;
+import com.netflix.zuul.netty.server.Server;
+import com.netflix.zuul.origins.OriginName;
+import com.netflix.zuul.passport.CurrentPassport;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoop;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Justin Guerra
+ * @since 7/10/26
+ */
+class NettyClientConnectionFactoryTest {
+
+    private static Class<? extends Channel> previousChannelType;
+
+    private DefaultClientConfigImpl clientConfig;
+    private NettyClientConnectionFactory factory;
+    private EventLoop eventLoop;
+    private IConnectionPool pool;
+
+    @BeforeAll
+    static void setupChannelType() {
+        previousChannelType = Server.defaultOutboundChannelType.getAndSet(NioSocketChannel.class);
+    }
+
+    @AfterAll
+    static void restoreChannelType() {
+        if (previousChannelType != null) {
+            Server.defaultOutboundChannelType.set(previousChannelType);
+        }
+    }
+
+    @BeforeEach
+    void setup() {
+        clientConfig = DefaultClientConfigImpl.getEmptyConfig();
+        ConnectionPoolConfig connPoolConfig =
+                new ConnectionPoolConfigImpl(OriginName.fromVipAndApp("whatever-secure", "whatever"), clientConfig);
+        factory = new NettyClientConnectionFactory(connPoolConfig, new ChannelInitializer<>() {
+            @Override
+            protected void initChannel(Channel ch) {}
+        });
+        eventLoop = new DefaultEventLoop();
+        pool = mock(IConnectionPool.class);
+    }
+
+    @AfterEach
+    void cleanup() {
+        eventLoop.shutdownGracefully();
+    }
+
+    @Test
+    void bootstrapAppliesConfiguredChannelOptions() {
+        Bootstrap bootstrap = factory.createBootstrap(eventLoop, originAddress(), CurrentPassport.create(), pool);
+
+        Map<ChannelOption<?>, Object> options = bootstrap.config().options();
+        assertThat(options)
+                .containsEntry(ChannelOption.CONNECT_TIMEOUT_MILLIS, ConnectionPoolConfigImpl.DEFAULT_CONNECT_TIMEOUT)
+                .containsEntry(ChannelOption.SO_KEEPALIVE, false)
+                .containsEntry(ChannelOption.TCP_NODELAY, true)
+                .containsEntry(ChannelOption.AUTO_READ, false)
+                .containsEntry(ChannelOption.SO_SNDBUF, ConnectionPoolConfigImpl.DEFAULT_BUFFER_SIZE)
+                .containsEntry(ChannelOption.SO_RCVBUF, ConnectionPoolConfigImpl.DEFAULT_BUFFER_SIZE);
+
+        WriteBufferWaterMark waterMark = (WriteBufferWaterMark) options.get(ChannelOption.WRITE_BUFFER_WATER_MARK);
+        assertThat(waterMark.low()).isEqualTo(ConnectionPoolConfigImpl.DEFAULT_WRITE_BUFFER_LOW_WATER_MARK);
+        assertThat(waterMark.high()).isEqualTo(ConnectionPoolConfigImpl.DEFAULT_WRITE_BUFFER_HIGH_WATER_MARK);
+
+        assertThat(bootstrap.config().attrs()).containsKey(CurrentPassport.CHANNEL_ATTR);
+    }
+
+    @Test
+    void bootstrapAppliesOverriddenSocketBufferSizes() {
+        clientConfig.set(IClientConfigKey.Keys.ReceiveBufferSize, 40000);
+        clientConfig.set(IClientConfigKey.Keys.SendBufferSize, 50000);
+
+        Bootstrap bootstrap = factory.createBootstrap(eventLoop, originAddress(), CurrentPassport.create(), pool);
+
+        assertThat(bootstrap.config().options())
+                .containsEntry(ChannelOption.SO_RCVBUF, 40000)
+                .containsEntry(ChannelOption.SO_SNDBUF, 50000);
+    }
+
+    @Test
+    void bootstrapOmitsSocketBufferOptionsWhenUsingDefault() {
+        clientConfig.set(ConnectionPoolConfigImpl.USE_DEFAULT_TCP_BUFFER_SIZES, true);
+
+        Bootstrap bootstrap = factory.createBootstrap(eventLoop, originAddress(), CurrentPassport.create(), pool);
+
+        assertThat(bootstrap.config().options())
+                .doesNotContainKey(ChannelOption.SO_SNDBUF)
+                .doesNotContainKey(ChannelOption.SO_RCVBUF)
+                .containsEntry(ChannelOption.TCP_NODELAY, true);
+    }
+
+    private static InetSocketAddress originAddress() {
+        return new InetSocketAddress(InetAddress.getLoopbackAddress(), 7001);
+    }
+}


### PR DESCRIPTION
This PR adds a new connection pool configuration that skips configuring TCP buffer sizes on origin connections. When the new flag is true, the connection pool will no longer explicitly set socket options for SNDBUF and RCVBUF, and instead the default OS setting is used. A benefit of relying on the OS is that we can allow it to autotune the buffer sizes for us