### PR TITLE
ci: run stale workflow once daily (cron */10 fires every 10 minutes)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues and PRs'
 on:
   schedule:
-    - cron: "*/10 5 * * *"
+    - cron: "10 5 * * *"
 
 jobs:
   stale:


### PR DESCRIPTION
Hi, and thank you for Zuul.

One-character CI fix: `stale.yml`'s schedule is

```yaml
- cron: "*/10 5 * * *"
```

`*/10` in the minutes field means **every 10 minutes during hour 05 UTC** — up to 6 runs a day for a job that only needs one (the run history shows the repeats, e.g. 05:45 and 06:32 today). It looks like a typo for the common "once daily at 05:10":

```yaml
- cron: "10 5 * * *"
```

That's the whole change — same behavior, 6× fewer runner minutes and API calls.

For transparency: I used AI assistance to spot and draft this; I verified the cron line and the duplicate run history myself.
