### PR TITLE
Strip X-Forwarded-Host, X-Forwarded-Prefix and Forwarded from untrusted connections

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandler.java
@@ -49,10 +49,13 @@ public class StripUntrustedProxyHeadersHandler extends ChannelInboundHandlerAdap
 
     private static final Collection<AsciiString> HEADERS_TO_STRIP = Sets.newHashSet(
             new AsciiString("x-forwarded-for"),
+            new AsciiString("x-forwarded-host"),
             new AsciiString("x-forwarded-port"),
+            new AsciiString("x-forwarded-prefix"),
             new AsciiString("x-forwarded-proto"),
             new AsciiString("x-forwarded-proto-version"),
-            new AsciiString("x-real-ip"));
+            new AsciiString("x-real-ip"),
+            new AsciiString("forwarded"));
 
     private final AllowWhen allowWhen;
 

--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandler.java
@@ -17,7 +17,6 @@
 package com.netflix.netty.common.proxyprotocol;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Sets;
 import com.netflix.config.DynamicStringListProperty;
 import com.netflix.netty.common.ssl.SslHandshakeInfo;
 import com.netflix.zuul.netty.server.ssl.SslHandshakeInfoHandler;
@@ -32,6 +31,7 @@ import io.netty.handler.ssl.ClientAuth;
 import io.netty.util.AsciiString;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Strip out any X-Forwarded-* headers from inbound http requests if connection is not trusted.
@@ -47,7 +47,7 @@ public class StripUntrustedProxyHeadersHandler extends ChannelInboundHandlerAdap
         NEVER
     }
 
-    private static final Collection<AsciiString> HEADERS_TO_STRIP = Sets.newHashSet(
+    private static final Collection<AsciiString> HEADERS_TO_STRIP = Set.of(
             new AsciiString("x-forwarded-for"),
             new AsciiString("x-forwarded-host"),
             new AsciiString("x-forwarded-port"),

--- a/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/StripUntrustedProxyHeadersHandlerTest.java
@@ -157,6 +157,20 @@ class StripUntrustedProxyHeadersHandlerTest {
         assertThat(headers.contains("x-forwarded-for")).isFalse();
     }
 
+    @Test
+    void strip_hostRewritingHeaders() {
+        StripUntrustedProxyHeadersHandler stripHandler = getHandler(AllowWhen.MUTUAL_SSL_AUTH);
+
+        headers.add("x-forwarded-host", "evil.attacker.com");
+        headers.add("x-forwarded-prefix", "/evil");
+        headers.add("forwarded", "host=evil.attacker.com");
+        stripHandler.stripXFFHeaders(msg);
+
+        assertThat(headers.contains("x-forwarded-host")).isFalse();
+        assertThat(headers.contains("x-forwarded-prefix")).isFalse();
+        assertThat(headers.contains("forwarded")).isFalse();
+    }
+
     private StripUntrustedProxyHeadersHandler getHandler(AllowWhen allowWhen) {
         return spy(new StripUntrustedProxyHeadersHandler(allowWhen));
     }


### PR DESCRIPTION
## Summary

Fixes #2170.

`StripUntrustedProxyHeadersHandler` is documented to "Strip out any X-Forwarded-* headers from inbound http requests if connection is not trusted", but its `HEADERS_TO_STRIP` set omitted three headers:

- `X-Forwarded-Host`
- `X-Forwarded-Prefix`
- `Forwarded` (RFC 7239)

`X-Forwarded-Host` is the impactful one: `HttpRequestMessageImpl.getOriginalHost()` prefers it over the validated `Host` header and it is propagated to origins. Since it was never stripped (even under the security-hardened `AllowWhen.NEVER` default), an untrusted client could spoof it, enabling host-header-based attacks in downstream origins that build URLs or cache keys from the value (web cache poisoning, password-reset link poisoning, open redirect).

Zuul itself is not directly vulnerable (routing is VIP-based); this is a defense-in-depth hardening that aligns the handler's behavior with its documented contract. `X-Forwarded-Prefix` and `Forwarded` are added for completeness even though they are not currently consumed internally.

## Change

Add `x-forwarded-host`, `x-forwarded-prefix`, and `forwarded` to `HEADERS_TO_STRIP`.

## Testing

- Added `strip_hostRewritingHeaders` to `StripUntrustedProxyHeadersHandlerTest` asserting the three headers are removed by `stripXFFHeaders`.
- `./gradlew :zuul-core:test --tests "*StripUntrustedProxyHeadersHandlerTest"` passes.
- `./gradlew :zuul-core:spotlessCheck` passes.