### PR TITLE
Extract parse path to helper

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/netty/server/ClientRequestReceiver.java
@@ -67,7 +67,6 @@ import io.perfmark.PerfMark;
 import io.perfmark.TaskCloseable;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Iterator;
 import java.util.Locale;
@@ -370,7 +369,7 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
         // Strip off the query from the path.
         String path;
         try {
-            path = parsePath(preProcessPath(nativeRequest.uri()));
+            path = HttpUtils.parsePath(preProcessPath(nativeRequest.uri()));
         } catch (URISyntaxException ex) {
             path = nativeRequest.uri();
             context.put(CommonContextKeys.BAD_URI_REASON, ex.getReason());
@@ -422,25 +421,6 @@ public class ClientRequestReceiver extends ChannelDuplexHandler {
 
     protected String preProcessPath(String uri) {
         return uri;
-    }
-
-    private String parsePath(String uri) throws URISyntaxException {
-        int queryIndex = uri.indexOf('?');
-        if (queryIndex > -1) {
-            uri = uri.substring(0, queryIndex);
-        }
-
-        URI uriObject = new URI(uri);
-        if (uriObject.isOpaque()) {
-            throw new URISyntaxException(uri, "opaque URI");
-        }
-        String rawPath = uriObject.getRawPath();
-        String prepared = rawPath.replace("%2e", ".").replace("%2E", ".");
-        String normalized = new URI(prepared).normalize().getRawPath();
-        while (normalized.equals("/..") || normalized.startsWith("/../")) {
-            normalized = normalized.substring(3);
-        }
-        return normalized;
     }
 
     private static Headers copyHeaders(HttpRequest req) {

--- a/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
@@ -25,8 +25,12 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http2.Http2StreamChannel;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Locale;
-import javax.annotation.Nullable;
+import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +39,7 @@ import org.slf4j.LoggerFactory;
  * Date: 4/28/15
  * Time: 11:05 PM
  */
+@NullMarked
 public class HttpUtils {
     private static final Logger LOG = LoggerFactory.getLogger(HttpUtils.class);
     private static final char[] MALICIOUS_HEADER_CHARS = {'\r', '\n'};
@@ -48,6 +53,7 @@ public class HttpUtils {
      * @param request <code>HttpRequestMessage</code>
      * @return <code>String</code> IP address
      */
+    @Nullable
     public static String getClientIP(HttpRequestInfo request) {
         String xForwardedFor = request.getHeaders().getFirst(HttpHeaderNames.X_FORWARDED_FOR);
         String clientIP;
@@ -65,12 +71,13 @@ public class HttpUtils {
      * @param xForwardedFor a <code>String</code> value
      * @return a <code>String</code> value
      */
-    public static String extractClientIpFromXForwardedFor(String xForwardedFor) {
+    @Nullable
+    public static String extractClientIpFromXForwardedFor(@Nullable String xForwardedFor) {
         if (xForwardedFor == null) {
             return null;
         }
         xForwardedFor = xForwardedFor.trim();
-        String tokenized[] = xForwardedFor.split(",", -1);
+        String[] tokenized = xForwardedFor.split(",", -1);
         if (tokenized.length == 0) {
             return null;
         } else {
@@ -102,6 +109,7 @@ public class HttpUtils {
      * @param input - decoded header string
      * @return - clean header string
      */
+    @Nullable
     public static String stripMaliciousHeaderChars(@Nullable String input) {
         if (input == null) {
             return null;
@@ -120,6 +128,7 @@ public class HttpUtils {
         return (contentLengthVal != null) && (contentLengthVal > 0);
     }
 
+    @Nullable
     public static Integer getContentLengthIfPresent(ZuulMessage msg) {
         String contentLengthValue =
                 msg.getHeaders().getFirst(com.netflix.zuul.message.http.HttpHeaderNames.CONTENT_LENGTH);
@@ -133,6 +142,7 @@ public class HttpUtils {
         return null;
     }
 
+    @Nullable
     public static Integer getBodySizeIfKnown(ZuulMessage msg) {
         Integer bodySize = getContentLengthIfPresent(msg);
         if (bodySize != null) {
@@ -166,5 +176,31 @@ public class HttpUtils {
             return channel.parent();
         }
         return channel;
+    }
+
+    /**
+     * Normalizes an origin-form request-target into a routable path, collapsing {@code .} and
+     * {@code ..} segments (and their {@code %2e} encodings) and clamping traversal back to root.
+     * Encoded slashes ({@code %2f}) are left intact, so the result is not fully decoded. Throws
+     * {@link URISyntaxException} for non-origin-form or malformed targets.
+     */
+    public static String parsePath(String uri) throws URISyntaxException {
+        Objects.requireNonNull(uri);
+        if (!uri.startsWith("/")) {
+            throw new URISyntaxException(uri, "path does not start with leading slash");
+        }
+
+        int queryIndex = uri.indexOf('?');
+        if (queryIndex > -1) {
+            uri = uri.substring(0, queryIndex);
+        }
+
+        // Decode %2e before parsing so URI.normalize() can collapse encoded ".."/"." segments.
+        String prepared = uri.replace("%2e", ".").replace("%2E", ".");
+        String normalized = new URI(prepared).normalize().getRawPath();
+        while (normalized.equals("/..") || normalized.startsWith("/../")) {
+            normalized = normalized.substring(3);
+        }
+        return normalized.isEmpty() ? "/" : normalized;
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
@@ -100,36 +100,21 @@ class ClientRequestReceiverTest {
     }
 
     @Test
-    void parseUriFromNetty_absolute() {
-
-        EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
-        channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
-        channel.writeInbound(new DefaultFullHttpRequest(
-                HttpVersion.HTTP_1_1,
-                HttpMethod.POST,
-                "https://www.netflix.com/foo/bar/somePath/%5E1.0.0?param1=foo&param2=bar&param3=baz",
-                Unpooled.buffer()));
-        HttpRequestMessageImpl result = channel.readInbound();
-        result.disposeBufferedBody();
-
-        assertThat(result.getPath()).isEqualTo("/foo/bar/somePath/%5E1.0.0");
-
-        channel.close();
-    }
-
-    @Test
-    void parseUriFromNetty_unknown() {
-
+    void unknownFormUri_rejected() {
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
         channel.writeInbound(
                 new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "asdf", Unpooled.buffer()));
-        HttpRequestMessageImpl result = channel.readInbound();
-        result.disposeBufferedBody();
-
-        assertThat(result.getPath()).isEqualTo("asdf");
-
+        channel.readInbound();
         channel.close();
+
+        HttpRequestMessage request = ClientRequestReceiver.getRequestFromChannel(channel);
+        SessionContext context = request.getContext();
+        assertThat(context.get(CommonContextKeys.BAD_URI_REASON)).isEqualTo("path does not start with leading slash");
+        assertThat(StatusCategoryUtils.getStatusCategory(context))
+                .isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
+        // Raw URI preserved for access logging.
+        assertThat(request.getPath()).isEqualTo("asdf");
     }
 
     @Test
@@ -618,7 +603,7 @@ class ClientRequestReceiverTest {
     }
 
     @Test
-    void opaqueUri_rejected() {
+    void authorityFormUri_rejected() {
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
         channel.writeInbound(new DefaultFullHttpRequest(
@@ -631,19 +616,23 @@ class ClientRequestReceiverTest {
         assertThat(context.get(CommonContextKeys.BAD_URI_REASON)).isNotNull();
         assertThat(StatusCategoryUtils.getStatusCategory(context))
                 .isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
-        assertThat(StatusCategoryUtils.getStatusCategoryReason(context)).isEqualTo("opaque URI");
+        assertThat(StatusCategoryUtils.getStatusCategoryReason(context))
+                .isEqualTo("path does not start with leading slash");
     }
 
     @Test
-    void pathNormalization_emptyPath() {
+    void emptyUri_rejected() {
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
         channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "", Unpooled.buffer()));
-        HttpRequestMessageImpl result = channel.readInbound();
-        result.disposeBufferedBody();
-
-        assertThat(result.getPath()).isEqualTo("");
+        channel.readInbound();
         channel.close();
+
+        SessionContext context =
+                ClientRequestReceiver.getRequestFromChannel(channel).getContext();
+        assertThat(context.get(CommonContextKeys.BAD_URI_REASON)).isEqualTo("path does not start with leading slash");
+        assertThat(StatusCategoryUtils.getStatusCategory(context))
+                .isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
@@ -17,6 +17,7 @@
 package com.netflix.zuul.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.netflix.zuul.context.SessionContext;
 import com.netflix.zuul.message.Headers;
@@ -27,7 +28,11 @@ import com.netflix.zuul.message.http.HttpRequestMessage;
 import com.netflix.zuul.message.http.HttpRequestMessageImpl;
 import com.netflix.zuul.message.http.HttpResponseMessage;
 import com.netflix.zuul.message.http.HttpResponseMessageImpl;
+import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Unit tests for {@link HttpUtils}.
@@ -116,5 +121,166 @@ class HttpUtilsTest {
         Headers headers = new Headers();
         ZuulMessage msg = new ZuulMessageImpl(context, headers);
         assertThat(HttpUtils.getBodySizeIfKnown(msg)).isNull();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "/path?a=b, /path",
+        "/path?, /path",
+        "/path#frag, /path",
+        "/path?a=b#frag, /path",
+        // traversal hidden in the query is discarded, not normalized into the path
+        "/path?a=../../etc, /path",
+        // path is still normalized after the query is stripped
+        "/../etc?x=1, /etc",
+    })
+    void parsePath_stripsQueryAndFragment(String uri, String expected) {
+        assertThat(parsePath(uri)).isEqualTo(expected);
+    }
+
+    // The query is stripped by hand precisely because java.net.URI rejects characters that are legal
+    // in real query strings; a valid path with a "dirty" query must resolve, not 400. Guards the
+    // manual strip - without it, parsing the full URI-with-query would throw on these.
+    @ParameterizedTest
+    @CsvSource({
+        "/search?q=a|b|c, /search",
+        "/p?x=a b, /p",
+        "/p?v=^1.0, /p",
+        "/p?j={a:1}, /p",
+    })
+    void parsePath_stripsQueryWithUriIllegalChars(String uri, String expected) {
+        assertThat(parsePath(uri)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "/api/v1/resource, /api/v1/resource",
+        "/, /",
+        "/a/b/c/, /a/b/c/",
+    })
+    void parsePath_returnsCleanPathUnchanged(String uri, String expected) {
+        assertThat(parsePath(uri)).isEqualTo(expected);
+    }
+
+    // The guard requires origin-form (leading slash), so every other request-target form - relative,
+    // absolute-form, asterisk, opaque scheme, empty - is rejected up front. The caller turns the
+    // URISyntaxException into a 400 (see ClientRequestReceiver), so nothing non-origin-form is routed.
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "../../etc/passwd",
+                "..%2f..%2fetc",
+                "....//",
+                "http://host/../../etc/passwd",
+                "http://host/a/../b",
+                "mailto:foo@bar.com",
+                "tel:12345",
+                "javascript:alert(1)",
+                "urn:isbn:123",
+                "*",
+                "",
+            })
+    void parsePath_rejectsNonOriginFormTargets(String uri) {
+        assertThatThrownBy(() -> HttpUtils.parsePath(uri))
+                .isInstanceOf(URISyntaxException.class)
+                .hasMessageContaining("leading slash");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "/a/b/../c, /a/c",
+        "/a/./b, /a/b",
+        "/a/b/.., /a/",
+        "/a/b/../, /a/",
+        "/a/./../b, /b",
+        "/./../a, /a",
+        "/a//b, /a/b",
+    })
+    void parsePath_collapsesPlainDotSegments(String uri, String expected) {
+        assertThat(parsePath(uri)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "/a/%2e%2e/b, /b",
+        "/a/%2E%2E/b, /b",
+        "/a/%2e/b, /a/b",
+        "/a/.%2e/b, /b",
+        "/.%2e/.%2e/etc, /etc",
+        "/%2e%2e/%2e%2e/etc, /etc",
+    })
+    void parsePath_decodesThenCollapsesPercentEncodedDots(String uri, String expected) {
+        assertThat(parsePath(uri)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        // a pure "/.." chain clamps to root, not to an empty path
+        "/.., /",
+        "/../.., /",
+        "/../, /",
+        "/../etc, /etc",
+        "/../../etc, /etc",
+        "/../../../../etc/passwd, /etc/passwd",
+        "/a/../../etc, /etc",
+        "/%2e%2e/etc, /etc",
+        // authority-form: the fake host is dropped and the escape neutralized
+        "//etc/passwd, /passwd",
+        "//host/../../x, /x",
+    })
+    void parsePath_clampsLeadingEscapesToRoot(String uri, String expected) {
+        assertThat(parsePath(uri)).isEqualTo(expected);
+    }
+
+    // %2f stays encoded, so a ".." wrapped in encoded slashes is a single opaque segment that
+    // normalize cannot see through. This is the defense boundary: downstream code that later
+    // decodes %2f must not treat the result as an already-normalized path.
+    @ParameterizedTest
+    @CsvSource({
+        "/a%2f..%2f..%2fb, /a%2f..%2f..%2fb",
+        "/..%2f..%2fetc, /..%2f..%2fetc",
+        "/%2e%2e%2f%2e%2e%2fetc, /..%2f..%2fetc",
+        "/a/%2e%2e%2f%2e%2e/etc, /a/..%2f../etc",
+        // uppercase %2F is left encoded too - only %2e/%2E are decoded
+        "/a%2F..%2F..%2Fb, /a%2F..%2F..%2Fb",
+    })
+    void parsePath_doesNotDecodeEncodedSlashes(String uri, String expected) {
+        assertThat(parsePath(uri)).isEqualTo(expected);
+    }
+
+    // None of these are a "." or ".." path segment, so there is nothing for normalize to collapse -
+    // they pass through verbatim rather than being mistaken for traversal.
+    @ParameterizedTest
+    @CsvSource({
+        "/%252e%252e/etc, /%252e%252e/etc",
+        "/..%00, /..%00",
+        "/a/..;/b, /a/..;/b",
+        "/..., /...",
+        "/...., /....",
+        "/foo/....//bar, /foo/..../bar",
+        // interior traversal still collapses even with an adjacent encoded null byte
+        "/a%00/../b, /b",
+    })
+    void parsePath_leavesNonDotDotSequencesUntouched(String uri, String expected) {
+        assertThat(parsePath(uri)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"//", "/\\..\\..\\etc"})
+    void parsePath_rejectsMalformedUris(String uri) {
+        assertThatThrownBy(() -> HttpUtils.parsePath(uri)).isInstanceOf(URISyntaxException.class);
+    }
+
+    @Test
+    void parsePath_throwsNpeOnNull() {
+        assertThatThrownBy(() -> HttpUtils.parsePath(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    private static String parsePath(String uri) {
+        try {
+            return HttpUtils.parsePath(uri);
+        } catch (URISyntaxException e) {
+            throw new AssertionError("did not expect parsePath to reject [" + uri + "]", e);
+        }
     }
 }


### PR DESCRIPTION
For re-use elsewhere. After moving the method I generated extensive unit tests which uncovered some unexpected results around string that don't start with "/". I reworked the validation to replace the isOpaque check with a simple starts with "/" which allowed me to remove the double URI parse. I also fixed an edge case where the path could be reduced to an empty string. If that happens it now returns an empty path ("/") instead 