### PR TITLE
Retry on CLOSE_NOTIFY_CONNECTION

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/filters/endpoint/ProxyEndpoint.java
@@ -799,14 +799,23 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
     }
 
     protected boolean isRetryable(ErrorType err) {
-        if ((err == OutboundErrorType.RESET_CONNECTION)
-                || (err == OutboundErrorType.CONNECT_ERROR)
-                || (err == OutboundErrorType.READ_TIMEOUT
-                        && IDEMPOTENT_HTTP_METHODS.contains(
-                                zuulRequest.getMethod().toUpperCase(Locale.ROOT)))) {
+        // Connection failures: safe to retry for ANY method, because the origin almost
+        // certainly never processed the request.
+        if (err == OutboundErrorType.RESET_CONNECTION || err == OutboundErrorType.CONNECT_ERROR) {
             return isRequestReplayable();
         }
+
+        // Ambiguous failures: the origin MAY have already processed the request, so only
+        // retry idempotent methods to avoid duplicating side effects.
+        if (err == OutboundErrorType.READ_TIMEOUT || err == OutboundErrorType.CLOSE_NOTIFY_CONNECTION) {
+            return isIdempotentRequest(zuulRequest) && isRequestReplayable();
+        }
+
         return false;
+    }
+
+    private static boolean isIdempotentRequest(HttpRequestMessage request) {
+        return IDEMPOTENT_HTTP_METHODS.contains(request.getMethod().toUpperCase(Locale.ROOT));
     }
 
     /**
@@ -1033,7 +1042,7 @@ public class ProxyEndpoint extends SyncZuulFilterAdapter<HttpRequestMessage, Htt
             }
             // Retry if this is an idempotent http method AND status code was retriable for idempotent methods.
             else if (RETRIABLE_STATUSES_FOR_IDEMPOTENT_METHODS.get().contains(status)
-                    && IDEMPOTENT_HTTP_METHODS.contains(zuulRequest.getMethod().toUpperCase(Locale.ROOT))) {
+                    && isIdempotentRequest(zuulRequest)) {
                 return true;
             }
         }

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/ProxyEndpointTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/ProxyEndpointTest.java
@@ -264,12 +264,9 @@ class ProxyEndpointTest {
 
     @Test
     void closeNotifyConnectionRetriedOnlyForIdempotentMethods() {
-        // POST (non-idempotent): the origin may have already processed the request before sending
-        // close_notify, so retrying risks duplicating side effects -> must NOT retry.
         assertThat(proxyEndpoint.isRetryable(OutboundErrorType.CLOSE_NOTIFY_CONNECTION))
                 .isFalse();
 
-        // GET (idempotent): safe to replay on a fresh connection -> must retry.
         HttpRequestMessage getRequest = createRequest(context, "GET", "/some/where");
         getRequest.setBody(new byte[0]);
         getRequest.storeInboundRequest();
@@ -292,9 +289,6 @@ class ProxyEndpointTest {
 
     @Test
     void connectionErrorsRetriedForAnyMethod() {
-        // Regression guard: RESET_CONNECTION and CONNECT_ERROR must stay retryable for all methods,
-        // including a non-idempotent (POST) request. A '&&' instead of '||' here would make the
-        // condition impossible and silently disable connection-failure retries.
         assertThat(proxyEndpoint.isRetryable(OutboundErrorType.RESET_CONNECTION))
                 .isTrue();
         assertThat(proxyEndpoint.isRetryable(OutboundErrorType.CONNECT_ERROR)).isTrue();

--- a/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/ProxyEndpointTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/filters/endpoint/ProxyEndpointTest.java
@@ -263,6 +263,44 @@ class ProxyEndpointTest {
     }
 
     @Test
+    void closeNotifyConnectionRetriedOnlyForIdempotentMethods() {
+        // POST (non-idempotent): the origin may have already processed the request before sending
+        // close_notify, so retrying risks duplicating side effects -> must NOT retry.
+        assertThat(proxyEndpoint.isRetryable(OutboundErrorType.CLOSE_NOTIFY_CONNECTION))
+                .isFalse();
+
+        // GET (idempotent): safe to replay on a fresh connection -> must retry.
+        HttpRequestMessage getRequest = createRequest(context, "GET", "/some/where");
+        getRequest.setBody(new byte[0]);
+        getRequest.storeInboundRequest();
+        ProxyEndpoint getProxyEndpoint =
+                spy(new ProxyEndpoint(getRequest, chc, null, MethodBinding.NO_OP_BINDING, attemptFactory) {
+                    @Override
+                    public NettyOrigin getOrigin(HttpRequestMessage request) {
+                        return nettyOrigin;
+                    }
+
+                    @Override
+                    protected OriginTimeoutManager getTimeoutManager(NettyOrigin origin) {
+                        return timeoutManager;
+                    }
+                });
+
+        assertThat(getProxyEndpoint.isRetryable(OutboundErrorType.CLOSE_NOTIFY_CONNECTION))
+                .isTrue();
+    }
+
+    @Test
+    void connectionErrorsRetriedForAnyMethod() {
+        // Regression guard: RESET_CONNECTION and CONNECT_ERROR must stay retryable for all methods,
+        // including a non-idempotent (POST) request. A '&&' instead of '||' here would make the
+        // condition impossible and silently disable connection-failure retries.
+        assertThat(proxyEndpoint.isRetryable(OutboundErrorType.RESET_CONNECTION))
+                .isTrue();
+        assertThat(proxyEndpoint.isRetryable(OutboundErrorType.CONNECT_ERROR)).isTrue();
+    }
+
+    @Test
     public void lastContentAfterProxyStartedIsConsideredReplayable() {
         Promise<PooledConnection> promise = channel.eventLoop().newPromise();
 


### PR DESCRIPTION
Zuul was not retrying requests that failed with `CLOSE_NOTIFY_CONNECTION` because most close_notifies came from malformed requests, but Zuul now validates headers upstream, so the remaining cases are safe to retry.

This change adds `CLOSE_NOTIFY_CONNECTION` to `isRetryable`, gated on idempotent methods (GET/HEAD/OPTIONS) so a POST the origin may have already processed is never replayed. The retry logic is refactored into two intent-named branches (connection failures retry for any method; ambiguous failures retry idempotent methods only), and the duplicated idempotency check is pulled into a shared isIdempotentRequest helper. Adds unit tests covering GET vs POST on close_notify, plus a regression guard that `RESET_CONNECTION`/`CONNECT_ERROR` stay retryable for all methods.

