### PR TITLE
Revert to previous parsePath logic

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
@@ -179,28 +179,29 @@ public class HttpUtils {
     }
 
     /**
-     * Normalizes an origin-form request-target into a routable path, collapsing {@code .} and
-     * {@code ..} segments (and their {@code %2e} encodings) and clamping traversal back to root.
-     * Encoded slashes ({@code %2f}) are left intact, so the result is not fully decoded. Throws
-     * {@link URISyntaxException} for non-origin-form or malformed targets.
+     * Normalizes a request-target into a routable path, collapsing {@code .} and {@code ..}
+     * segments (and their {@code %2e} encodings) and clamping traversal back to root. Encoded
+     * slashes ({@code %2f}) are left intact, so the result is not fully decoded. Throws
+     * {@link URISyntaxException} for opaque or malformed targets.
      */
     public static String parsePath(String uri) throws URISyntaxException {
         Objects.requireNonNull(uri);
-        if (!uri.startsWith("/")) {
-            throw new URISyntaxException(uri, "path does not start with leading slash");
-        }
-
         int queryIndex = uri.indexOf('?');
         if (queryIndex > -1) {
             uri = uri.substring(0, queryIndex);
         }
 
+        URI uriObject = new URI(uri);
+        if (uriObject.isOpaque()) {
+            throw new URISyntaxException(uri, "opaque URI");
+        }
+
         // Decode %2e before parsing so URI.normalize() can collapse encoded ".."/"." segments.
-        String prepared = uri.replace("%2e", ".").replace("%2E", ".");
+        String prepared = uriObject.getRawPath().replace("%2e", ".").replace("%2E", ".");
         String normalized = new URI(prepared).normalize().getRawPath();
         while (normalized.equals("/..") || normalized.startsWith("/../")) {
             normalized = normalized.substring(3);
         }
-        return normalized.isEmpty() ? "/" : normalized;
+        return normalized;
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
@@ -46,7 +46,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.List;
-import lombok.NonNull;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -119,20 +119,17 @@ class ClientRequestReceiverTest {
 
     @Test
     void parseUriFromNetty_unknown() {
+
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
         channel.writeInbound(
                 new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "asdf", Unpooled.buffer()));
-        channel.readInbound();
-        channel.close();
+        HttpRequestMessageImpl result = channel.readInbound();
+        result.disposeBufferedBody();
 
-        HttpRequestMessage request = ClientRequestReceiver.getRequestFromChannel(channel);
-        SessionContext context = request.getContext();
-        assertThat(context.get(CommonContextKeys.BAD_URI_REASON)).isEqualTo("path does not start with /");
-        assertThat(StatusCategoryUtils.getStatusCategory(context))
-                .isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
-        // Raw URI preserved for access logging.
-        assertThat(request.getPath()).isEqualTo("asdf");
+        assertThat(result.getPath()).isEqualTo("asdf");
+
+        channel.close();
     }
 
     @Test
@@ -645,7 +642,7 @@ class ClientRequestReceiverTest {
         HttpRequestMessageImpl result = channel.readInbound();
         result.disposeBufferedBody();
 
-        assertThat(result.getPath()).isEqualTo("/");
+        assertThat(result.getPath()).isEqualTo("");
         channel.close();
     }
 

--- a/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/netty/server/ClientRequestReceiverTest.java
@@ -100,7 +100,25 @@ class ClientRequestReceiverTest {
     }
 
     @Test
-    void unknownFormUri_rejected() {
+    void parseUriFromNetty_absolute() {
+
+        EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
+        channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
+        channel.writeInbound(new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1,
+                HttpMethod.POST,
+                "https://www.netflix.com/foo/bar/somePath/%5E1.0.0?param1=foo&param2=bar&param3=baz",
+                Unpooled.buffer()));
+        HttpRequestMessageImpl result = channel.readInbound();
+        result.disposeBufferedBody();
+
+        assertThat(result.getPath()).isEqualTo("/foo/bar/somePath/%5E1.0.0");
+
+        channel.close();
+    }
+
+    @Test
+    void parseUriFromNetty_unknown() {
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
         channel.writeInbound(
@@ -110,7 +128,7 @@ class ClientRequestReceiverTest {
 
         HttpRequestMessage request = ClientRequestReceiver.getRequestFromChannel(channel);
         SessionContext context = request.getContext();
-        assertThat(context.get(CommonContextKeys.BAD_URI_REASON)).isEqualTo("path does not start with leading slash");
+        assertThat(context.get(CommonContextKeys.BAD_URI_REASON)).isEqualTo("path does not start with /");
         assertThat(StatusCategoryUtils.getStatusCategory(context))
                 .isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
         // Raw URI preserved for access logging.
@@ -603,7 +621,7 @@ class ClientRequestReceiverTest {
     }
 
     @Test
-    void authorityFormUri_rejected() {
+    void opaqueUri_rejected() {
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
         channel.writeInbound(new DefaultFullHttpRequest(
@@ -616,23 +634,19 @@ class ClientRequestReceiverTest {
         assertThat(context.get(CommonContextKeys.BAD_URI_REASON)).isNotNull();
         assertThat(StatusCategoryUtils.getStatusCategory(context))
                 .isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
-        assertThat(StatusCategoryUtils.getStatusCategoryReason(context))
-                .isEqualTo("path does not start with leading slash");
+        assertThat(StatusCategoryUtils.getStatusCategoryReason(context)).isEqualTo("opaque URI");
     }
 
     @Test
-    void emptyUri_rejected() {
+    void pathNormalization_emptyPath() {
         EmbeddedChannel channel = new EmbeddedChannel(new ClientRequestReceiver(null));
         channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(1234);
         channel.writeInbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "", Unpooled.buffer()));
-        channel.readInbound();
-        channel.close();
+        HttpRequestMessageImpl result = channel.readInbound();
+        result.disposeBufferedBody();
 
-        SessionContext context =
-                ClientRequestReceiver.getRequestFromChannel(channel).getContext();
-        assertThat(context.get(CommonContextKeys.BAD_URI_REASON)).isEqualTo("path does not start with leading slash");
-        assertThat(StatusCategoryUtils.getStatusCategory(context))
-                .isEqualTo(ZuulStatusCategory.FAILURE_CLIENT_BAD_REQUEST);
+        assertThat(result.getPath()).isEqualTo("/");
+        channel.close();
     }
 
     @Test

--- a/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
@@ -162,28 +162,24 @@ class HttpUtilsTest {
         assertThat(parsePath(uri)).isEqualTo(expected);
     }
 
-    // The guard requires origin-form (leading slash), so every other request-target form - relative,
-    // absolute-form, asterisk, opaque scheme, empty - is rejected up front. The caller turns the
-    // URISyntaxException into a 400 (see ClientRequestReceiver), so nothing non-origin-form is routed.
+    // Opaque targets have no path to route on at all. The caller turns the URISyntaxException into
+    // a 400 (see ClientRequestReceiver).
     @ParameterizedTest
-    @ValueSource(
-            strings = {
-                "../../etc/passwd",
-                "..%2f..%2fetc",
-                "....//",
-                "http://host/../../etc/passwd",
-                "http://host/a/../b",
-                "mailto:foo@bar.com",
-                "tel:12345",
-                "javascript:alert(1)",
-                "urn:isbn:123",
-                "*",
-                "",
-            })
-    void parsePath_rejectsNonOriginFormTargets(String uri) {
+    @ValueSource(strings = {"mailto:foo@bar.com", "tel:12345", "javascript:alert(1)", "urn:isbn:123"})
+    void parsePath_rejectsOpaqueUris(String uri) {
         assertThatThrownBy(() -> HttpUtils.parsePath(uri))
                 .isInstanceOf(URISyntaxException.class)
-                .hasMessageContaining("leading slash");
+                .hasMessageContaining("opaque URI");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "http://host/../../etc/passwd, /etc/passwd",
+        "http://host/a/../b, /b",
+        "https://www.netflix.com/foo/bar?x=1, /foo/bar",
+    })
+    void parsePath_extractsPathFromAbsoluteFormTargets(String uri, String expected) {
+        assertThat(parsePath(uri)).isEqualTo(expected);
     }
 
     @ParameterizedTest
@@ -215,9 +211,6 @@ class HttpUtilsTest {
 
     @ParameterizedTest
     @CsvSource({
-        // a pure "/.." chain clamps to root, not to an empty path
-        "/.., /",
-        "/../.., /",
         "/../, /",
         "/../etc, /etc",
         "/../../etc, /etc",


### PR DESCRIPTION
When I moved `parsePath` I also made it a little stricter - too strict turns out. This PR restores the logic to it's previous state and undoes test changes. 