### PR TITLE
Add trusted-peer CIDR check for PROXY protocol

### DIFF
--- a/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java
+++ b/zuul-core/src/main/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandler.java
@@ -16,14 +16,23 @@
 
 package com.netflix.netty.common.proxyprotocol;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.netflix.config.DynamicBooleanProperty;
+import com.netflix.config.DynamicStringListProperty;
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.spectator.api.Registry;
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.ProtocolDetectionState;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
+import io.netty.handler.ipfilter.IpFilterRuleType;
+import io.netty.handler.ipfilter.IpSubnetFilterRule;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.List;
 import lombok.NonNull;
 
 /**
@@ -33,6 +42,15 @@ import lombok.NonNull;
 public final class ElbProxyProtocolChannelHandler extends ChannelInboundHandlerAdapter {
 
     public static final String NAME = ElbProxyProtocolChannelHandler.class.getSimpleName();
+
+    @VisibleForTesting
+    static DynamicStringListProperty TRUSTED_PEER_CIDRS =
+            new DynamicStringListProperty("zuul.proxyprotocol.trusted.cidrs", "");
+
+    @VisibleForTesting
+    static DynamicBooleanProperty ENFORCE_TRUSTED_PEER_CIDRS =
+            new DynamicBooleanProperty("zuul.proxyprotocol.trusted.cidrs.enforce", false);
+
     private final boolean withProxyProtocol;
     private final Registry registry;
 
@@ -51,6 +69,25 @@ public final class ElbProxyProtocolChannelHandler extends ChannelInboundHandlerA
             ctx.pipeline().remove(this);
             super.channelRead(ctx, msg);
             return;
+        }
+
+        if (!isTrustedPeer(ctx.channel())) {
+            int port = ctx.channel()
+                    .attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT)
+                    .get();
+            boolean enforce = ENFORCE_TRUSTED_PEER_CIDRS.get();
+            registry.counter(
+                            "zuul.hapm.untrusted_peer",
+                            "port",
+                            String.valueOf(port),
+                            "enforced",
+                            String.valueOf(enforce))
+                    .increment();
+            if (enforce) {
+                ctx.pipeline().remove(this);
+                super.channelRead(ctx, msg);
+                return;
+            }
         }
 
         ProtocolDetectionState haProxyState = getDetectionState(msg);
@@ -77,6 +114,42 @@ public final class ElbProxyProtocolChannelHandler extends ChannelInboundHandlerA
             ctx.pipeline().remove(this);
         }
         super.channelRead(ctx, msg);
+    }
+
+    /**
+     * Returns true if no trusted CIDR allowlist is configured (preserving legacy behavior), or if the channel's
+     * remote peer falls within one of the configured CIDRs.
+     */
+    @VisibleForTesting
+    static boolean isTrustedPeer(Channel channel) {
+        List<String> cidrs = TRUSTED_PEER_CIDRS.get();
+        if (cidrs.isEmpty()) {
+            return true;
+        }
+        SocketAddress remoteAddress = channel.remoteAddress();
+        if (!(remoteAddress instanceof InetSocketAddress inetRemoteAddress) || inetRemoteAddress.getAddress() == null) {
+            return false;
+        }
+        for (String cidr : cidrs) {
+            if (matchesCidr(inetRemoteAddress, cidr)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean matchesCidr(InetSocketAddress remoteAddress, String cidr) {
+        int slash = cidr.indexOf('/');
+        if (slash < 0) {
+            return false;
+        }
+        try {
+            String ipAddress = cidr.substring(0, slash);
+            int prefix = Integer.parseInt(cidr.substring(slash + 1));
+            return new IpSubnetFilterRule(ipAddress, prefix, IpFilterRuleType.ACCEPT).matches(remoteAddress);
+        } catch (RuntimeException e) {
+            return false;
+        }
     }
 
     private ProtocolDetectionState getDetectionState(Object msg) {

--- a/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandlerTest.java
+++ b/zuul-core/src/test/java/com/netflix/netty/common/proxyprotocol/ElbProxyProtocolChannelHandlerTest.java
@@ -19,6 +19,8 @@ package com.netflix.netty.common.proxyprotocol;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.net.InetAddresses;
+import com.netflix.config.DynamicBooleanProperty;
+import com.netflix.config.DynamicStringListProperty;
 import com.netflix.netty.common.SourceAddressChannelHandler;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
@@ -32,7 +34,9 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -47,6 +51,24 @@ class ElbProxyProtocolChannelHandlerTest {
     @BeforeEach
     void setup() {
         registry = new DefaultRegistry();
+    }
+
+    @AfterEach
+    void resetTrustedPeerConfig() {
+        ElbProxyProtocolChannelHandler.TRUSTED_PEER_CIDRS =
+                new DynamicStringListProperty("zuul.proxyprotocol.trusted.cidrs", "");
+        ElbProxyProtocolChannelHandler.ENFORCE_TRUSTED_PEER_CIDRS =
+                new DynamicBooleanProperty("zuul.proxyprotocol.trusted.cidrs.enforce", false);
+    }
+
+    private static EmbeddedChannel channelWithRemoteAddress(String host, int port) {
+        SocketAddress remoteAddress = new InetSocketAddress(InetAddresses.forString(host), port);
+        return new EmbeddedChannel() {
+            @Override
+            protected SocketAddress remoteAddress0() {
+                return remoteAddress;
+            }
+        };
     }
 
     @Test
@@ -359,5 +381,105 @@ class ElbProxyProtocolChannelHandlerTest {
                 .isEqualTo("192.168.0.1");
         assertThat(channel.attr(SourceAddressChannelHandler.ATTR_REMOTE_ADDR).get())
                 .isEqualTo(new InetSocketAddress(InetAddresses.forString("192.168.0.1"), 10008));
+    }
+
+    @Test
+    void trustedPeer_matchingCidr_parsesMessage() {
+        ElbProxyProtocolChannelHandler.TRUSTED_PEER_CIDRS =
+                new DynamicStringListProperty("zuul.proxyprotocol.trusted.cidrs", "10.0.0.0/8");
+
+        EmbeddedChannel channel = channelWithRemoteAddress("10.1.2.3", 5000);
+        channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(7007);
+
+        channel.pipeline()
+                .addLast(ElbProxyProtocolChannelHandler.NAME, new ElbProxyProtocolChannelHandler(registry, true));
+        ByteBuf buf = Unpooled.wrappedBuffer(
+                "PROXY TCP4 192.168.0.1 124.123.111.111 10008 443\r\n".getBytes(StandardCharsets.US_ASCII));
+        channel.writeInbound(buf);
+
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get())
+                .isEqualTo("192.168.0.1");
+        Counter untrustedCounter = registry.counter("zuul.hapm.untrusted_peer", "port", "7007", "enforced", "false");
+        assertThat(untrustedCounter.count()).isZero();
+    }
+
+    @Test
+    void untrustedPeer_shadowMode_stillParsesMessageButRecordsMetric() {
+        ElbProxyProtocolChannelHandler.TRUSTED_PEER_CIDRS =
+                new DynamicStringListProperty("zuul.proxyprotocol.trusted.cidrs", "10.0.0.0/8");
+        // ENFORCE_TRUSTED_PEER_CIDRS defaults to false (shadow mode).
+
+        EmbeddedChannel channel = channelWithRemoteAddress("203.0.113.5", 5000);
+        channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(7007);
+
+        channel.pipeline()
+                .addLast(ElbProxyProtocolChannelHandler.NAME, new ElbProxyProtocolChannelHandler(registry, true));
+        ByteBuf buf = Unpooled.wrappedBuffer(
+                "PROXY TCP4 192.168.0.1 124.123.111.111 10008 443\r\n".getBytes(StandardCharsets.US_ASCII));
+        channel.writeInbound(buf);
+
+        // Shadow mode: the spoofed source address is still honored (unchanged behavior)...
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get())
+                .isEqualTo("192.168.0.1");
+        // ...but the mismatch is now observable.
+        Counter untrustedCounter = registry.counter("zuul.hapm.untrusted_peer", "port", "7007", "enforced", "false");
+        assertThat(untrustedCounter.count()).isEqualTo(1);
+    }
+
+    @Test
+    void untrustedPeer_enforceMode_ignoresMessageAndKeepsRealAddress() {
+        ElbProxyProtocolChannelHandler.TRUSTED_PEER_CIDRS =
+                new DynamicStringListProperty("zuul.proxyprotocol.trusted.cidrs", "10.0.0.0/8");
+        ElbProxyProtocolChannelHandler.ENFORCE_TRUSTED_PEER_CIDRS =
+                new DynamicBooleanProperty("zuul.proxyprotocol.trusted.cidrs.enforce", true);
+
+        EmbeddedChannel channel = channelWithRemoteAddress("203.0.113.5", 5000);
+        channel.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        channel.attr(SourceAddressChannelHandler.ATTR_SERVER_LOCAL_PORT).set(7007);
+
+        channel.pipeline()
+                .addLast(ElbProxyProtocolChannelHandler.NAME, new ElbProxyProtocolChannelHandler(registry, true));
+        ByteBuf buf = Unpooled.wrappedBuffer(
+                "PROXY TCP4 192.168.0.1 124.123.111.111 10008 443\r\n".getBytes(StandardCharsets.US_ASCII));
+        channel.writeInbound(buf);
+
+        Object passedThrough = channel.readInbound();
+        assertThat(passedThrough).isEqualTo(buf);
+        buf.release();
+
+        // The spoofed PROXY message is ignored entirely; no source address is derived from it.
+        assertThat(channel.attr(SourceAddressChannelHandler.ATTR_SOURCE_ADDRESS).get())
+                .isNull();
+        assertThat(channel.attr(HAProxyMessageChannelHandler.ATTR_HAPROXY_MESSAGE)
+                        .get())
+                .isNull();
+        assertThat(channel.pipeline().context(ElbProxyProtocolChannelHandler.NAME))
+                .isNull();
+
+        Counter untrustedCounter = registry.counter("zuul.hapm.untrusted_peer", "port", "7007", "enforced", "true");
+        assertThat(untrustedCounter.count()).isEqualTo(1);
+    }
+
+    @Test
+    void isTrustedPeer_emptyAllowlist_defaultsToTrustAll() {
+        ElbProxyProtocolChannelHandler.TRUSTED_PEER_CIDRS =
+                new DynamicStringListProperty("zuul.proxyprotocol.trusted.cidrs", "");
+
+        EmbeddedChannel channel = channelWithRemoteAddress("203.0.113.5", 5000);
+        assertThat(ElbProxyProtocolChannelHandler.isTrustedPeer(channel)).isTrue();
+    }
+
+    @Test
+    void isTrustedPeer_ipv6Cidr_matches() {
+        ElbProxyProtocolChannelHandler.TRUSTED_PEER_CIDRS =
+                new DynamicStringListProperty("zuul.proxyprotocol.trusted.cidrs", "2001:db8::/32");
+
+        EmbeddedChannel trusted = channelWithRemoteAddress("2001:db8::1", 5000);
+        assertThat(ElbProxyProtocolChannelHandler.isTrustedPeer(trusted)).isTrue();
+
+        EmbeddedChannel untrusted = channelWithRemoteAddress("2001:db9::1", 5000);
+        assertThat(ElbProxyProtocolChannelHandler.isTrustedPeer(untrusted)).isFalse();
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2197.

`ElbProxyProtocolChannelHandler` currently trusts a HAProxy PROXY protocol preamble from any TCP peer once `withProxyProtocol` is enabled on a listener. If such a listener is reachable directly (not only through a trusted load balancer), a client can forge the PROXY header and spoof the source address that Zuul treats as the real client IP, since that value feeds `ClientRequestReceiver.getClientIp()` used for rate limiting, logging, and forwarded headers.

This adds an optional, dynamically reloadable trusted CIDR allowlist (`zuul.proxyprotocol.trusted.cidrs`) checked against the real socket peer (`channel.remoteAddress()`) before a PROXY message is honored.

- Empty allowlist (default): behavior unchanged.
- Allowlist configured, `zuul.proxyprotocol.trusted.cidrs.enforce=false` (default, shadow mode): mismatches are recorded via a new `zuul.hapm.untrusted_peer` counter but the request is still processed as before, so operators can validate the list against real traffic before enforcing.
- Allowlist configured with enforce enabled: PROXY messages from peers outside the allowlist are ignored and the real socket address is kept, same as the existing "not a PROXY protocol message" path.

## Test plan

- [x] `:zuul-core:test` (689 tests, 0 failures)
- [x] `:zuul-core:check` (license headers, spotless, compile, tests)
- [x] New tests: trusted peer match, shadow-mode mismatch + metric, enforce-mode mismatch + real address preserved, empty allowlist opt-out, IPv6 CIDR match/mismatch
- [x] All pre-existing tests for this handler pass unmodified