### PR TITLE
Switch ConnCounter to rely on PolledMeters

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
@@ -46,6 +46,10 @@ public final class ConnCounter {
 
     private static final Attrs EMPTY = Attrs.newInstance();
 
+    /**
+     * PER_EVENT_LOOP_COUNTERS exists to reduce the number of PolledMeters that are created. Any given Id will have a
+     * PolledMeter created for every event loop, with spectator responsible for summing up the values.
+     */
     private static final ThreadLocal<Map<Id, AtomicInteger>> PER_EVENT_LOOP_COUNTERS =
             ThreadLocal.withInitial(HashMap::new);
 
@@ -103,8 +107,6 @@ public final class ConnCounter {
                 .withTags(metricBase.tags())
                 .withTags(dimTags);
 
-        // PER_EVENT_LOOP_COUNTERS exists to reduce the number of PolledMeters for a given Id to 1 per event loop
-        // instead of 1 per connection
         AtomicInteger count = PER_EVENT_LOOP_COUNTERS.get().computeIfAbsent(id, key -> {
             AtomicInteger counter = new AtomicInteger();
             PolledMeter.using(registry).withId(key).monitorValue(counter);
@@ -133,6 +135,8 @@ public final class ConnCounter {
             return;
         }
 
+        // remove the strong reference when the counter hits zero so the gauge can eventually be GC'd. This is so we
+        // don't waste memory around higher cardinality attributes that can be short-lived (like vips)
         PER_EVENT_LOOP_COUNTERS.get().computeIfPresent(id, (k, v) -> v.decrementAndGet() <= 0 ? null : v);
     }
 

--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
@@ -108,8 +108,7 @@ public final class ConnCounter {
                 .withTags(dimTags);
 
         // PER_EVENT_LOOP_COUNTERS exists to reduce the number of PolledMeters for a given Id to 1 per event loop
-        // instead
-        // of 1 per connection
+        // instead of 1 per connection
         AtomicInteger count = PER_EVENT_LOOP_COUNTERS.get().computeIfAbsent(id, key -> {
             AtomicInteger counter = new AtomicInteger();
             PolledMeter.using(registry).withId(key).monitorValue(counter);

--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
@@ -16,9 +16,9 @@
 
 package com.netflix.zuul.monitoring;
 
-import com.netflix.spectator.api.Gauge;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.patterns.PolledMeter;
 import com.netflix.zuul.Attrs;
 import com.netflix.zuul.netty.server.Server;
 import io.netty.channel.Channel;
@@ -26,50 +26,41 @@ import io.netty.util.AttributeKey;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * A counter for connection stats.  Not thread-safe.
  */
-@SuppressWarnings("ErroneousBitwiseExpression")
+@NullMarked
 public final class ConnCounter {
 
     private static final Logger logger = LoggerFactory.getLogger(ConnCounter.class);
 
-    private static final AttributeKey<ConnCounter> CONN_COUNTER = AttributeKey.newInstance("zuul.conncounter");
-
-    private static final int LOCK_COUNT = 256;
-    private static final int LOCK_MASK = LOCK_COUNT - 1;
+    private static final AttributeKey<@Nullable ConnCounter> CONN_COUNTER =
+            AttributeKey.newInstance("zuul.conncounter");
 
     private static final Attrs EMPTY = Attrs.newInstance();
 
-    /**
-     * An array of locks to guard the gauges.   This is the same as Guava's Striped, but avoids the dep.
-     * <p>
-     * This can be removed after https://github.com/Netflix/spectator/issues/862 is fixed.
-     */
-    private static final Object[] locks = new Object[LOCK_COUNT];
-
-    static {
-        assert (LOCK_COUNT & LOCK_MASK) == 0;
-        for (int i = 0; i < locks.length; i++) {
-            locks[i] = new Object();
-        }
-    }
+    private static final ThreadLocal<Map<Id, AtomicInteger>> PER_EVENT_LOOP_COUNTERS =
+            ThreadLocal.withInitial(HashMap::new);
 
     private final Registry registry;
     private final Channel chan;
     private final Id metricBase;
+    private final Map<String, AtomicInteger> counts;
 
+    @Nullable
     private String lastCountKey;
-
-    private final Map<String, Gauge> counts = new HashMap<>();
 
     private ConnCounter(Registry registry, Channel chan, Id metricBase) {
         this.registry = Objects.requireNonNull(registry);
         this.chan = Objects.requireNonNull(chan);
         this.metricBase = Objects.requireNonNull(metricBase);
+        this.counts = new HashMap<>();
     }
 
     public static ConnCounter install(Channel chan, Registry registry, Id metricBase) {
@@ -115,40 +106,36 @@ public final class ConnCounter {
         Id id = registry.createId(metricBase.name() + '.' + event)
                 .withTags(metricBase.tags())
                 .withTags(dimTags);
-        Gauge gauge = registry.gauge(id);
 
-        synchronized (getLock(id)) {
-            double current = gauge.value();
-            gauge.set(Double.isNaN(current) ? 1 : current + 1);
-        }
-        counts.put(event, gauge);
+        // PER_EVENT_LOOP_COUNTERS exists to reduce the number of PolledMeters for a given Id to 1 per event loop
+        // instead
+        // of 1 per connection
+        AtomicInteger count = PER_EVENT_LOOP_COUNTERS.get().computeIfAbsent(id, key -> {
+            AtomicInteger counter = new AtomicInteger();
+            PolledMeter.using(registry).withId(key).monitorValue(counter);
+            return counter;
+        });
+        count.incrementAndGet();
+        counts.put(event, count);
     }
 
     public double getCurrentActiveConns() {
-        return counts.containsKey("active") ? counts.get("active").value() : 0.0;
+        AtomicInteger value = counts.get("active");
+        return value == null ? 0.0 : value.doubleValue();
     }
 
     public void decrement(String event) {
         Objects.requireNonNull(event);
-        Gauge gauge = counts.remove(event);
-        if (gauge == null) {
+        AtomicInteger value = counts.remove(event);
+        if (value == null) {
             // TODO(carl-mastrangelo): make this throw IllegalStateException after verifying this doesn't happen.
             logger.warn("Missing conn counter increment {}", event);
             return;
         }
-        synchronized (getLock(gauge.id())) {
-            // Noop gauges break this assertion in tests, but the type is package private.   Check to make sure
-            // the gauge has a value, or by implementation cannot have a value.
-            assert !Double.isNaN(gauge.value())
-                    || gauge.getClass().getName().equals("com.netflix.spectator.api.NoopGauge");
-            gauge.set(gauge.value() - 1);
-        }
+        value.decrementAndGet();
     }
 
-    // This is here to pick the correct lock stripe.   This avoids multiple threads synchronizing on the
-    // same lock in the common case.   This can go away once there is an atomic gauge update implemented
-    // in spectator.
-    private static Object getLock(Id id) {
-        return locks[id.hashCode() & LOCK_MASK];
+    static void clearCache() {
+        PER_EVENT_LOOP_COUNTERS.get().clear();
     }
 }

--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
@@ -16,6 +16,7 @@
 
 package com.netflix.zuul.monitoring;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.patterns.PolledMeter;
@@ -53,9 +54,6 @@ public final class ConnCounter {
     private final Id metricBase;
     private final Map<String, AtomicInteger> counts;
 
-    @Nullable
-    private String lastCountKey;
-
     private ConnCounter(Registry registry, Channel chan, Id metricBase) {
         this.registry = Objects.requireNonNull(registry);
         this.chan = Objects.requireNonNull(chan);
@@ -68,6 +66,7 @@ public final class ConnCounter {
         if (!chan.attr(CONN_COUNTER).compareAndSet(null, counter)) {
             throw new IllegalStateException("pre-existing counter already present");
         }
+
         return counter;
     }
 
@@ -101,8 +100,6 @@ public final class ConnCounter {
         connDims.forEach((k, v) -> dimTags.put(k.name(), String.valueOf(v)));
         extraDimensions.forEach((k, v) -> dimTags.put(k.name(), String.valueOf(v)));
 
-        dimTags.put("from", lastCountKey != null ? lastCountKey : "nascent");
-        lastCountKey = event;
         Id id = registry.createId(metricBase.name() + '.' + event)
                 .withTags(metricBase.tags())
                 .withTags(dimTags);
@@ -134,6 +131,7 @@ public final class ConnCounter {
         value.decrementAndGet();
     }
 
+    @VisibleForTesting
     static void clearCache() {
         PER_EVENT_LOOP_COUNTERS.get().clear();
     }

--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
@@ -52,13 +52,13 @@ public final class ConnCounter {
     private final Registry registry;
     private final Channel chan;
     private final Id metricBase;
-    private final Map<String, AtomicInteger> counts;
+    private final Map<String, Id> eventToIdLookup;
 
     private ConnCounter(Registry registry, Channel chan, Id metricBase) {
         this.registry = Objects.requireNonNull(registry);
         this.chan = Objects.requireNonNull(chan);
         this.metricBase = Objects.requireNonNull(metricBase);
-        this.counts = new HashMap<>();
+        this.eventToIdLookup = new HashMap<>();
     }
 
     public static ConnCounter install(Channel chan, Registry registry, Id metricBase) {
@@ -66,7 +66,6 @@ public final class ConnCounter {
         if (!chan.attr(CONN_COUNTER).compareAndSet(null, counter)) {
             throw new IllegalStateException("pre-existing counter already present");
         }
-
         return counter;
     }
 
@@ -89,7 +88,7 @@ public final class ConnCounter {
     public void increment(String event, Attrs extraDimensions) {
         Objects.requireNonNull(event);
         Objects.requireNonNull(extraDimensions);
-        if (counts.containsKey(event)) {
+        if (eventToIdLookup.containsKey(event)) {
             // TODO(carl-mastrangelo): make this throw IllegalStateException after verifying this doesn't happen.
             logger.warn("Duplicate conn counter increment {}", event);
             return;
@@ -112,23 +111,37 @@ public final class ConnCounter {
             return counter;
         });
         count.incrementAndGet();
-        counts.put(event, count);
+        eventToIdLookup.put(event, id);
     }
 
     public double getCurrentActiveConns() {
-        AtomicInteger value = counts.get("active");
-        return value == null ? 0.0 : value.doubleValue();
+        Id id = eventToIdLookup.get("active");
+        if (id == null) {
+            return 0.0;
+        }
+
+        AtomicInteger count = PER_EVENT_LOOP_COUNTERS.get().get(id);
+        return count == null ? 0.0 : count.get();
     }
 
     public void decrement(String event) {
         Objects.requireNonNull(event);
-        AtomicInteger value = counts.remove(event);
-        if (value == null) {
-            // TODO(carl-mastrangelo): make this throw IllegalStateException after verifying this doesn't happen.
+        Id tags = eventToIdLookup.get(event);
+
+        if (tags == null) {
             logger.warn("Missing conn counter increment {}", event);
             return;
         }
-        value.decrementAndGet();
+
+        PER_EVENT_LOOP_COUNTERS.get().computeIfPresent(tags, (k, v) -> {
+            int count = v.decrementAndGet();
+            if (count <= 0) {
+                eventToIdLookup.remove(event);
+                return null;
+            } else {
+                return v;
+            }
+        });
     }
 
     @VisibleForTesting

--- a/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/monitoring/ConnCounter.java
@@ -126,22 +126,14 @@ public final class ConnCounter {
 
     public void decrement(String event) {
         Objects.requireNonNull(event);
-        Id tags = eventToIdLookup.get(event);
+        Id id = eventToIdLookup.remove(event);
 
-        if (tags == null) {
+        if (id == null) {
             logger.warn("Missing conn counter increment {}", event);
             return;
         }
 
-        PER_EVENT_LOOP_COUNTERS.get().computeIfPresent(tags, (k, v) -> {
-            int count = v.decrementAndGet();
-            if (count <= 0) {
-                eventToIdLookup.remove(event);
-                return null;
-            } else {
-                return v;
-            }
-        });
+        PER_EVENT_LOOP_COUNTERS.get().computeIfPresent(id, (k, v) -> v.decrementAndGet() <= 0 ? null : v);
     }
 
     @VisibleForTesting

--- a/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
@@ -17,13 +17,27 @@
 package com.netflix.zuul.monitoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.netflix.spectator.api.AbstractRegistry;
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.DefaultRegistry;
+import com.netflix.spectator.api.DistributionSummary;
 import com.netflix.spectator.api.Gauge;
+import com.netflix.spectator.api.Id;
+import com.netflix.spectator.api.ManualClock;
+import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
+import com.netflix.spectator.api.Timer;
 import com.netflix.zuul.Attrs;
 import com.netflix.zuul.netty.server.Server;
+import io.netty.channel.DefaultChannelId;
 import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 
 class ConnCounterTest {
@@ -42,15 +56,15 @@ class ConnCounterTest {
 
         Gauge meter1 = registry.gauge(registry.createId("foo.start", "from", "nascent"));
         assertThat(meter1).isNotNull();
-        assertThat(meter1.value()).isCloseTo(1.0, org.assertj.core.data.Offset.offset(0.0));
+        assertThat(meter1.value()).isCloseTo(1.0, Offset.offset(0.0));
 
         Gauge meter2 = registry.gauge(registry.createId("foo.middle", "from", "start"));
         assertThat(meter2).isNotNull();
-        assertThat(meter2.value()).isCloseTo(1.0, org.assertj.core.data.Offset.offset(0.0));
+        assertThat(meter2.value()).isCloseTo(1.0, Offset.offset(0.0));
 
         Gauge meter3 = registry.gauge(registry.createId("foo.end", "from", "middle", "bar", "baz"));
         assertThat(meter3).isNotNull();
-        assertThat(meter3.value()).isCloseTo(1.0, org.assertj.core.data.Offset.offset(0.0));
+        assertThat(meter3.value()).isCloseTo(1.0, Offset.offset(0.0));
     }
 
     @Test
@@ -66,7 +80,214 @@ class ConnCounterTest {
         ConnCounter.from(channel).increment("active");
         ConnCounter.from(channel).increment("active");
 
-        assertThat(ConnCounter.from(channel).getCurrentActiveConns())
-                .isCloseTo(1.0, org.assertj.core.data.Offset.offset(0.0));
+        assertThat(ConnCounter.from(channel).getCurrentActiveConns()).isCloseTo(1.0, Offset.offset(0.0));
+    }
+
+    @Test
+    void decrementReturnsGaugeToZeroAndAllowsReincrement() {
+        EmbeddedChannel chan = new EmbeddedChannel();
+        chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        Registry registry = new DefaultRegistry();
+        ConnCounter counter = ConnCounter.install(chan, registry, registry.createId("foo"));
+
+        counter.increment("tls");
+        counter.decrement("tls");
+        assertThat(registry.gauge(registry.createId("foo.tls", "from", "nascent"))
+                        .value())
+                .isCloseTo(0.0, Offset.offset(0.0));
+
+        // decrement cleared the counts entry, so this is not deduped; "from" now chains off the prior tls event
+        counter.increment("tls");
+        assertThat(registry.gauge(registry.createId("foo.tls", "from", "tls")).value())
+                .isCloseTo(1.0, Offset.offset(0.0));
+    }
+
+    @Test
+    void gaugeIsSharedAcrossChannelsWithMatchingId() {
+        Registry registry = new DefaultRegistry();
+        Id base = registry.createId("foo");
+
+        EmbeddedChannel chanA = new EmbeddedChannel();
+        chanA.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        ConnCounter counterA = ConnCounter.install(chanA, registry, base);
+
+        EmbeddedChannel chanB = new EmbeddedChannel();
+        chanB.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        ConnCounter counterB = ConnCounter.install(chanB, registry, base);
+
+        counterA.increment("tls");
+        counterB.increment("tls");
+        Id tlsId = registry.createId("foo.tls", "from", "nascent");
+        assertThat(registry.gauge(tlsId).value()).isCloseTo(2.0, Offset.offset(0.0));
+
+        counterA.decrement("tls");
+        assertThat(registry.gauge(tlsId).value()).isCloseTo(1.0, Offset.offset(0.0));
+    }
+
+    @Test
+    void fromResolvesToParentChannelCounter() {
+        EmbeddedChannel parent = new EmbeddedChannel();
+        parent.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        Registry registry = new DefaultRegistry();
+        ConnCounter parentCounter = ConnCounter.install(parent, registry, registry.createId("foo"));
+
+        EmbeddedChannel child = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), false, false);
+
+        assertThat(ConnCounter.from(child)).isSameAs(parentCounter);
+    }
+
+    @Test
+    void installThrowsWhenCounterAlreadyPresent() {
+        EmbeddedChannel chan = new EmbeddedChannel();
+        chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        Registry registry = new DefaultRegistry();
+        ConnCounter.install(chan, registry, registry.createId("foo"));
+
+        assertThatThrownBy(() -> ConnCounter.install(chan, registry, registry.createId("foo")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("pre-existing counter");
+    }
+
+    @Test
+    void fromThrowsWhenNoCounterInstalled() {
+        assertThatThrownBy(() -> ConnCounter.from(new EmbeddedChannel()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("no counter on channel");
+    }
+
+    @Test
+    void decrementOfUnseenEventIsNoOp() {
+        EmbeddedChannel chan = new EmbeddedChannel();
+        chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        Registry registry = new DefaultRegistry();
+        ConnCounter counter = ConnCounter.install(chan, registry, registry.createId("foo"));
+
+        assertThatCode(() -> counter.decrement("tls")).doesNotThrowAnyException();
+        // no gauge was ever touched, so nothing was driven negative
+        assertThat(registry.gauge(registry.createId("foo.tls", "from", "nascent"))
+                        .value())
+                .isNaN();
+    }
+
+    @Test
+    void getCurrentActiveConnsIsZeroWhenNeverIncremented() {
+        EmbeddedChannel chan = new EmbeddedChannel();
+        chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        Registry registry = new DefaultRegistry();
+        ConnCounter counter = ConnCounter.install(chan, registry, registry.createId("foo"));
+
+        assertThat(counter.getCurrentActiveConns()).isCloseTo(0.0, Offset.offset(0.0));
+    }
+
+    // Reproduces the negative-connection-count bug. registry.gauge() hands back a SwapGauge; when the
+    // underlying gauge outlives its TTL (as long-lived origin connections do between increment at
+    // handshake and decrement at close) it is evicted by removeExpiredMeters(). The next access
+    // re-resolves a fresh gauge whose value is 0, so decrement subtracts from 0 and reports -1.
+    @Test
+    void decrementAfterGaugeExpiryGoesNegative() {
+        ManualClock clock = new ManualClock();
+        long ttlMillis = TimeUnit.MINUTES.toMillis(15);
+        ExpiringRegistry registry = new ExpiringRegistry(clock, ttlMillis);
+
+        EmbeddedChannel chan = new EmbeddedChannel();
+        chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        ConnCounter counter = ConnCounter.install(chan, registry, registry.createId("foo"));
+
+        counter.increment("tls");
+        Id tlsId = registry.createId("foo.tls", "from", "nascent");
+        assertThat(registry.gauge(tlsId).value()).isCloseTo(1.0, Offset.offset(0.0));
+
+        // Connection stays open past the meter TTL, then the publish loop evicts the idle gauge.
+        clock.setWallTime(ttlMillis + 1);
+        registry.removeExpiredMeters();
+
+        counter.decrement("tls");
+
+        assertThat(registry.gauge(tlsId).value()).isCloseTo(-1.0, Offset.offset(0.0));
+    }
+
+    /**
+     * Minimal registry whose gauges expire after a TTL, mirroring the production AtlasRegistry.
+     * A freshly created gauge starts at 0.0 and {@code set} refreshes the last-updated time, so an
+     * unmodified gauge is dropped once the clock advances past its TTL.
+     */
+    private static final class ExpiringRegistry extends AbstractRegistry {
+        private final long ttlMillis;
+
+        ExpiringRegistry(Clock clock, long ttlMillis) {
+            super(clock);
+            this.ttlMillis = ttlMillis;
+        }
+
+        @Override
+        public void removeExpiredMeters() {
+            super.removeExpiredMeters();
+        }
+
+        @Override
+        protected Gauge newGauge(Id id) {
+            return new ExpiringGauge(clock(), id, ttlMillis);
+        }
+
+        @Override
+        protected Gauge newMaxGauge(Id id) {
+            return newGauge(id);
+        }
+
+        @Override
+        protected Counter newCounter(Id id) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected DistributionSummary newDistributionSummary(Id id) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected Timer newTimer(Id id) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static final class ExpiringGauge implements Gauge {
+        private final Clock clock;
+        private final Id id;
+        private final long ttlMillis;
+        private double value;
+        private long lastUpdated;
+
+        ExpiringGauge(Clock clock, Id id, long ttlMillis) {
+            this.clock = clock;
+            this.id = id;
+            this.ttlMillis = ttlMillis;
+            this.lastUpdated = clock.wallTime();
+        }
+
+        @Override
+        public Id id() {
+            return id;
+        }
+
+        @Override
+        public Iterable<Measurement> measure() {
+            return Collections.singletonList(new Measurement(id, clock.wallTime(), value));
+        }
+
+        @Override
+        public boolean hasExpired() {
+            return clock.wallTime() - lastUpdated > ttlMillis;
+        }
+
+        @Override
+        public void set(double v) {
+            value = v;
+            lastUpdated = clock.wallTime();
+        }
+
+        @Override
+        public double value() {
+            return value;
+        }
     }
 }

--- a/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
@@ -63,15 +63,15 @@ class ConnCounterTest {
         counter.increment("end");
         PolledMeter.update(registry);
 
-        Gauge meter1 = registry.gauge(registry.createId("foo.start", "from", "nascent"));
+        Gauge meter1 = registry.gauge(registry.createId("foo.start"));
         assertThat(meter1).isNotNull();
         assertThat(meter1.value()).isCloseTo(1.0, Offset.offset(0.0));
 
-        Gauge meter2 = registry.gauge(registry.createId("foo.middle", "from", "start"));
+        Gauge meter2 = registry.gauge(registry.createId("foo.middle"));
         assertThat(meter2).isNotNull();
         assertThat(meter2.value()).isCloseTo(1.0, Offset.offset(0.0));
 
-        Gauge meter3 = registry.gauge(registry.createId("foo.end", "from", "middle", "bar", "baz"));
+        Gauge meter3 = registry.gauge(registry.createId("foo.end", "bar", "baz"));
         assertThat(meter3).isNotNull();
         assertThat(meter3.value()).isCloseTo(1.0, Offset.offset(0.0));
     }
@@ -102,11 +102,10 @@ class ConnCounterTest {
         counter.increment("tls");
         counter.decrement("tls");
 
-        // decrement cleared the counts entry, so this is not deduped; "from" now chains off the prior tls event
+        // decrement cleared the counts entry, so this increment is not deduped
         counter.increment("tls");
         PolledMeter.update(registry);
-        assertThat(registry.gauge(registry.createId("foo.tls", "from", "tls")).value())
-                .isCloseTo(1.0, Offset.offset(0.0));
+        assertThat(registry.gauge(registry.createId("foo.tls")).value()).isCloseTo(1.0, Offset.offset(0.0));
     }
 
     @Test
@@ -124,7 +123,7 @@ class ConnCounterTest {
 
         counterA.increment("tls");
         counterB.increment("tls");
-        Id tlsId = registry.createId("foo.tls", "from", "nascent");
+        Id tlsId = registry.createId("foo.tls");
         PolledMeter.update(registry);
         assertThat(registry.gauge(tlsId).value()).isCloseTo(2.0, Offset.offset(0.0));
 
@@ -173,9 +172,7 @@ class ConnCounterTest {
 
         assertThatCode(() -> counter.decrement("tls")).doesNotThrowAnyException();
         // no gauge was ever touched, so nothing was driven negative
-        assertThat(registry.gauge(registry.createId("foo.tls", "from", "nascent"))
-                        .value())
-                .isNaN();
+        assertThat(registry.gauge(registry.createId("foo.tls")).value()).isNaN();
     }
 
     @Test
@@ -199,7 +196,7 @@ class ConnCounterTest {
         ConnCounter counter = ConnCounter.install(chan, registry, registry.createId("foo"));
 
         counter.increment("tls");
-        Id tlsId = registry.createId("foo.tls", "from", "nascent");
+        Id tlsId = registry.createId("foo.tls");
         PolledMeter.update(registry);
         assertThat(registry.gauge(tlsId).value()).isCloseTo(1.0, Offset.offset(0.0));
 

--- a/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
@@ -37,12 +37,26 @@ import com.netflix.zuul.netty.server.Server;
 import io.netty.channel.DefaultChannelId;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ConnCounterTest {
+
+    private Registry registry;
+    private Attrs connDimensions;
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        registry = new DefaultRegistry();
+        connDimensions = Attrs.newInstance();
+        channel = new EmbeddedChannel();
+        channel.attr(Server.CONN_DIMENSIONS).set(connDimensions);
+    }
 
     @AfterEach
     void tearDown() {
@@ -51,163 +65,220 @@ class ConnCounterTest {
 
     @Test
     void record() {
-        EmbeddedChannel chan = new EmbeddedChannel();
-        Attrs attrs = Attrs.newInstance();
-        chan.attr(Server.CONN_DIMENSIONS).set(attrs);
-        Registry registry = new DefaultRegistry();
-        ConnCounter counter = ConnCounter.install(chan, registry, registry.createId("foo"));
+        ConnCounter counter = install();
 
         counter.increment("start");
         counter.increment("middle");
-        Attrs.newKey("bar").put(attrs, "baz");
+        Attrs.newKey("bar").put(connDimensions, "baz");
         counter.increment("end");
         PolledMeter.update(registry);
 
-        Gauge meter1 = registry.gauge(registry.createId("foo.start"));
-        assertThat(meter1).isNotNull();
-        assertThat(meter1.value()).isCloseTo(1.0, Offset.offset(0.0));
-
-        Gauge meter2 = registry.gauge(registry.createId("foo.middle"));
-        assertThat(meter2).isNotNull();
-        assertThat(meter2.value()).isCloseTo(1.0, Offset.offset(0.0));
-
-        Gauge meter3 = registry.gauge(registry.createId("foo.end", "bar", "baz"));
-        assertThat(meter3).isNotNull();
-        assertThat(meter3.value()).isCloseTo(1.0, Offset.offset(0.0));
+        assertThat(registry.gauge(registry.createId("foo.start")).value()).isEqualTo(1.0);
+        assertThat(registry.gauge(registry.createId("foo.middle")).value()).isEqualTo(1.0);
+        assertThat(registry.gauge(registry.createId("foo.end", "bar", "baz")).value())
+                .isEqualTo(1.0);
     }
 
     @Test
-    void activeConnsCount() {
-        EmbeddedChannel channel = new EmbeddedChannel();
-        Attrs attrs = Attrs.newInstance();
-        channel.attr(Server.CONN_DIMENSIONS).set(attrs);
-        Registry registry = new DefaultRegistry();
+    void duplicateIncrementIsDeduped() {
+        install();
 
-        ConnCounter.install(channel, registry, registry.createId("foo"));
-
-        // Dedup increments
         ConnCounter.from(channel).increment("active");
         ConnCounter.from(channel).increment("active");
+        PolledMeter.update(registry);
 
-        assertThat(ConnCounter.from(channel).getCurrentActiveConns()).isCloseTo(1.0, Offset.offset(0.0));
+        assertThat(ConnCounter.from(channel).getCurrentActiveConns()).isEqualTo(1.0);
+        assertThat(registry.gauge(registry.createId("foo.active")).value()).isEqualTo(1.0);
+    }
+
+    @Test
+    void incrementMergesExtraDimensionsOverConnDimensions() {
+        Attrs.newKey("proto").put(connDimensions, "h2");
+        Attrs.newKey("cipher").put(connDimensions, "unknown");
+        ConnCounter counter = install();
+
+        Attrs extraDimensions = Attrs.newInstance();
+        Attrs.newKey("cipher").put(extraDimensions, "TLS_AES_128_GCM_SHA256");
+        counter.increment("tls", extraDimensions);
+        PolledMeter.update(registry);
+
+        assertThat(registry.gauge(registry.createId("foo.tls", "proto", "h2", "cipher", "TLS_AES_128_GCM_SHA256"))
+                        .value())
+                .isEqualTo(1.0);
     }
 
     @Test
     void incrementAfterDecrementIsNotDeduped() {
-        EmbeddedChannel chan = new EmbeddedChannel();
-        chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
-        Registry registry = new DefaultRegistry();
-        ConnCounter counter = ConnCounter.install(chan, registry, registry.createId("foo"));
+        ConnCounter counter = install();
 
         counter.increment("tls");
         counter.decrement("tls");
-
-        // decrement cleared the counts entry, so this increment is not deduped
         counter.increment("tls");
         PolledMeter.update(registry);
-        assertThat(registry.gauge(registry.createId("foo.tls")).value()).isCloseTo(1.0, Offset.offset(0.0));
+
+        assertThat(registry.gauge(registry.createId("foo.tls")).value()).isEqualTo(1.0);
     }
 
     @Test
     void gaugeIsSharedAcrossChannelsWithMatchingId() {
-        Registry registry = new DefaultRegistry();
-        Id base = registry.createId("foo");
-
-        EmbeddedChannel chanA = new EmbeddedChannel();
-        chanA.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
-        ConnCounter counterA = ConnCounter.install(chanA, registry, base);
-
-        EmbeddedChannel chanB = new EmbeddedChannel();
-        chanB.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
-        ConnCounter counterB = ConnCounter.install(chanB, registry, base);
+        ConnCounter counterA = install();
+        ConnCounter counterB = installOnNewChannel();
 
         counterA.increment("tls");
         counterB.increment("tls");
         Id tlsId = registry.createId("foo.tls");
         PolledMeter.update(registry);
-        assertThat(registry.gauge(tlsId).value()).isCloseTo(2.0, Offset.offset(0.0));
+        assertThat(registry.gauge(tlsId).value()).isEqualTo(2.0);
 
         counterA.decrement("tls");
         PolledMeter.update(registry);
-        assertThat(registry.gauge(tlsId).value()).isCloseTo(1.0, Offset.offset(0.0));
+        assertThat(registry.gauge(tlsId).value()).isEqualTo(1.0);
+    }
+
+    @Test
+    void reincrementIsNotSuppressedWhileAnotherConnectionHoldsTheEvent() {
+        ConnCounter counterA = install();
+        ConnCounter counterB = installOnNewChannel();
+
+        counterA.increment("tls");
+        counterB.increment("tls");
+        counterA.decrement("tls");
+        counterA.increment("tls");
+        PolledMeter.update(registry);
+
+        assertThat(registry.gauge(registry.createId("foo.tls")).value()).isEqualTo(2.0);
+    }
+
+    @Test
+    void doubleDecrementDoesNotConsumeAnotherConnectionsCount() {
+        ConnCounter counterA = install();
+        ConnCounter counterB = installOnNewChannel();
+
+        counterA.increment("tls");
+        counterB.increment("tls");
+        counterA.decrement("tls");
+        counterA.decrement("tls");
+        PolledMeter.update(registry);
+
+        assertThat(registry.gauge(registry.createId("foo.tls")).value()).isEqualTo(1.0);
+    }
+
+    @Test
+    void decrementUsesTheIdCapturedAtIncrementTime() {
+        ConnCounter counter = install();
+
+        counter.increment("active");
+        // callers stamp SELF_CLOSE into the conn dimensions just before decrementing
+        Attrs.newKey("selfclose").put(connDimensions, "true");
+        counter.decrement("active");
+        PolledMeter.update(registry);
+
+        assertThat(registry.gauge(registry.createId("foo.active")).value()).isEqualTo(0.0);
+        assertThat(registry.get(registry.createId("foo.active", "selfclose", "true")))
+                .isNull();
+    }
+
+    @Test
+    void countsFromDifferentEventLoopsSumIntoOneGauge() throws Exception {
+        ExecutorService loopA = Executors.newSingleThreadExecutor();
+        ExecutorService loopB = Executors.newSingleThreadExecutor();
+
+        try {
+            loopA.submit(() -> installOnNewChannel().increment("tls")).get(5, TimeUnit.SECONDS);
+            loopB.submit(() -> installOnNewChannel().increment("tls")).get(5, TimeUnit.SECONDS);
+            PolledMeter.update(registry);
+
+            assertThat(registry.gauge(registry.createId("foo.tls")).value()).isEqualTo(2.0);
+        } finally {
+            clearCacheAndShutdown(loopA);
+            clearCacheAndShutdown(loopB);
+        }
     }
 
     @Test
     void fromResolvesToParentChannelCounter() {
-        EmbeddedChannel parent = new EmbeddedChannel();
-        parent.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
-        Registry registry = new DefaultRegistry();
-        ConnCounter parentCounter = ConnCounter.install(parent, registry, registry.createId("foo"));
+        ConnCounter parentCounter = install();
 
-        EmbeddedChannel child = new EmbeddedChannel(parent, DefaultChannelId.newInstance(), false, false);
+        EmbeddedChannel child = new EmbeddedChannel(channel, DefaultChannelId.newInstance(), false, false);
 
         assertThat(ConnCounter.from(child)).isSameAs(parentCounter);
     }
 
     @Test
     void installThrowsWhenCounterAlreadyPresent() {
-        EmbeddedChannel chan = new EmbeddedChannel();
-        chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
-        Registry registry = new DefaultRegistry();
-        ConnCounter.install(chan, registry, registry.createId("foo"));
+        install();
 
-        assertThatThrownBy(() -> ConnCounter.install(chan, registry, registry.createId("foo")))
+        assertThatThrownBy(this::install)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("pre-existing counter");
     }
 
     @Test
     void fromThrowsWhenNoCounterInstalled() {
-        assertThatThrownBy(() -> ConnCounter.from(new EmbeddedChannel()))
+        assertThatThrownBy(() -> ConnCounter.from(channel))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("no counter on channel");
     }
 
     @Test
     void decrementOfUnseenEventIsNoOp() {
-        EmbeddedChannel chan = new EmbeddedChannel();
-        chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
-        Registry registry = new DefaultRegistry();
-        ConnCounter counter = ConnCounter.install(chan, registry, registry.createId("foo"));
+        ConnCounter counter = install();
 
         assertThatCode(() -> counter.decrement("tls")).doesNotThrowAnyException();
-        // no gauge was ever touched, so nothing was driven negative
-        assertThat(registry.gauge(registry.createId("foo.tls")).value()).isNaN();
+        assertThat(registry.stream()).isEmpty();
     }
 
     @Test
     void getCurrentActiveConnsIsZeroWhenNeverIncremented() {
-        EmbeddedChannel chan = new EmbeddedChannel();
-        chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
-        Registry registry = new DefaultRegistry();
-        ConnCounter counter = ConnCounter.install(chan, registry, registry.createId("foo"));
-
-        assertThat(counter.getCurrentActiveConns()).isCloseTo(0.0, Offset.offset(0.0));
+        assertThat(install().getCurrentActiveConns()).isEqualTo(0.0);
     }
 
     @Test
     void gaugeStaysCorrectWhenConnectionOutlivesMeterTtl() {
         ManualClock clock = new ManualClock();
         long ttlMillis = TimeUnit.MINUTES.toMillis(15);
-        ExpiringRegistry registry = new ExpiringRegistry(clock, ttlMillis);
-
-        EmbeddedChannel chan = new EmbeddedChannel();
-        chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
-        ConnCounter counter = ConnCounter.install(chan, registry, registry.createId("foo"));
+        ExpiringRegistry expiringRegistry = new ExpiringRegistry(clock, ttlMillis);
+        ConnCounter counter = ConnCounter.install(channel, expiringRegistry, expiringRegistry.createId("foo"));
 
         counter.increment("tls");
-        Id tlsId = registry.createId("foo.tls");
-        PolledMeter.update(registry);
-        assertThat(registry.gauge(tlsId).value()).isCloseTo(1.0, Offset.offset(0.0));
+        PolledMeter.update(expiringRegistry);
+
+        // PolledMeter keeps writing to the Gauge it captured at registration, so hold that instance - once the
+        // registry evicts it, expiringRegistry.gauge(...) mints a fresh one whose value defaults to 0.0.
+        Gauge polled = expiringRegistry.gauge(expiringRegistry.createId("foo.tls"));
+        assertThat(polled.value()).isEqualTo(1.0);
 
         // Connection stays open past the meter TTL, then the publish loop evicts the idle gauge.
         clock.setWallTime(ttlMillis + 1);
-        registry.removeExpiredMeters();
+        expiringRegistry.removeExpiredMeters();
 
         counter.decrement("tls");
-        PolledMeter.update(registry);
+        PolledMeter.update(expiringRegistry);
 
-        assertThat(registry.gauge(tlsId).value()).isCloseTo(0.0, Offset.offset(0.0));
+        assertThat(polled.value()).isEqualTo(0.0);
+    }
+
+    private ConnCounter install() {
+        return ConnCounter.install(channel, registry, registry.createId("foo"));
+    }
+
+    /**
+     * Installs a counter on a second connection sharing the registry, for tests that need two channels.
+     */
+    private ConnCounter installOnNewChannel() {
+        EmbeddedChannel chan = new EmbeddedChannel();
+        chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
+        return ConnCounter.install(chan, registry, registry.createId("foo"));
+    }
+
+    /**
+     * Clears the thread-local counts on the given loop before shutting it down, so no count leaks into
+     * subsequent tests.  {@link ConnCounter#clearCache()} only clears the calling thread's map.
+     */
+    private static void clearCacheAndShutdown(ExecutorService loop) throws Exception {
+        loop.submit(ConnCounter::clearCache).get(5, TimeUnit.SECONDS);
+        loop.shutdown();
+        assertThat(loop.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
     }
 
     private static final class ExpiringRegistry extends AbstractRegistry {

--- a/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
@@ -31,6 +31,7 @@ import com.netflix.spectator.api.ManualClock;
 import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.Timer;
+import com.netflix.spectator.api.patterns.PolledMeter;
 import com.netflix.zuul.Attrs;
 import com.netflix.zuul.netty.server.Server;
 import io.netty.channel.DefaultChannelId;
@@ -38,9 +39,16 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 class ConnCounterTest {
+
+    @AfterEach
+    void tearDown() {
+        ConnCounter.clearCache();
+    }
+
     @Test
     void record() {
         EmbeddedChannel chan = new EmbeddedChannel();
@@ -53,6 +61,7 @@ class ConnCounterTest {
         counter.increment("middle");
         Attrs.newKey("bar").put(attrs, "baz");
         counter.increment("end");
+        PolledMeter.update(registry);
 
         Gauge meter1 = registry.gauge(registry.createId("foo.start", "from", "nascent"));
         assertThat(meter1).isNotNull();
@@ -84,7 +93,7 @@ class ConnCounterTest {
     }
 
     @Test
-    void decrementReturnsGaugeToZeroAndAllowsReincrement() {
+    void incrementAfterDecrementIsNotDeduped() {
         EmbeddedChannel chan = new EmbeddedChannel();
         chan.attr(Server.CONN_DIMENSIONS).set(Attrs.newInstance());
         Registry registry = new DefaultRegistry();
@@ -92,12 +101,10 @@ class ConnCounterTest {
 
         counter.increment("tls");
         counter.decrement("tls");
-        assertThat(registry.gauge(registry.createId("foo.tls", "from", "nascent"))
-                        .value())
-                .isCloseTo(0.0, Offset.offset(0.0));
 
         // decrement cleared the counts entry, so this is not deduped; "from" now chains off the prior tls event
         counter.increment("tls");
+        PolledMeter.update(registry);
         assertThat(registry.gauge(registry.createId("foo.tls", "from", "tls")).value())
                 .isCloseTo(1.0, Offset.offset(0.0));
     }
@@ -118,9 +125,11 @@ class ConnCounterTest {
         counterA.increment("tls");
         counterB.increment("tls");
         Id tlsId = registry.createId("foo.tls", "from", "nascent");
+        PolledMeter.update(registry);
         assertThat(registry.gauge(tlsId).value()).isCloseTo(2.0, Offset.offset(0.0));
 
         counterA.decrement("tls");
+        PolledMeter.update(registry);
         assertThat(registry.gauge(tlsId).value()).isCloseTo(1.0, Offset.offset(0.0));
     }
 
@@ -179,12 +188,8 @@ class ConnCounterTest {
         assertThat(counter.getCurrentActiveConns()).isCloseTo(0.0, Offset.offset(0.0));
     }
 
-    // Reproduces the negative-connection-count bug. registry.gauge() hands back a SwapGauge; when the
-    // underlying gauge outlives its TTL (as long-lived origin connections do between increment at
-    // handshake and decrement at close) it is evicted by removeExpiredMeters(). The next access
-    // re-resolves a fresh gauge whose value is 0, so decrement subtracts from 0 and reports -1.
     @Test
-    void decrementAfterGaugeExpiryGoesNegative() {
+    void gaugeStaysCorrectWhenConnectionOutlivesMeterTtl() {
         ManualClock clock = new ManualClock();
         long ttlMillis = TimeUnit.MINUTES.toMillis(15);
         ExpiringRegistry registry = new ExpiringRegistry(clock, ttlMillis);
@@ -195,6 +200,7 @@ class ConnCounterTest {
 
         counter.increment("tls");
         Id tlsId = registry.createId("foo.tls", "from", "nascent");
+        PolledMeter.update(registry);
         assertThat(registry.gauge(tlsId).value()).isCloseTo(1.0, Offset.offset(0.0));
 
         // Connection stays open past the meter TTL, then the publish loop evicts the idle gauge.
@@ -202,15 +208,11 @@ class ConnCounterTest {
         registry.removeExpiredMeters();
 
         counter.decrement("tls");
+        PolledMeter.update(registry);
 
-        assertThat(registry.gauge(tlsId).value()).isCloseTo(-1.0, Offset.offset(0.0));
+        assertThat(registry.gauge(tlsId).value()).isCloseTo(0.0, Offset.offset(0.0));
     }
 
-    /**
-     * Minimal registry whose gauges expire after a TTL, mirroring the production AtlasRegistry.
-     * A freshly created gauge starts at 0.0 and {@code set} refreshes the last-updated time, so an
-     * unmodified gauge is dropped once the clock advances past its TTL.
-     */
     private static final class ExpiringRegistry extends AbstractRegistry {
         private final long ttlMillis;
 

--- a/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/monitoring/ConnCounterTest.java
@@ -271,10 +271,6 @@ class ConnCounterTest {
         return ConnCounter.install(chan, registry, registry.createId("foo"));
     }
 
-    /**
-     * Clears the thread-local counts on the given loop before shutting it down, so no count leaks into
-     * subsequent tests.  {@link ConnCounter#clearCache()} only clears the calling thread's map.
-     */
     private static void clearCacheAndShutdown(ExecutorService loop) throws Exception {
         loop.submit(ConnCounter::clearCache).get(5, TimeUnit.SECONDS);
         loop.shutdown();


### PR DESCRIPTION
`ConnCounter` tracks connection counts by manually updating a gauge. This approach can lead to negative connection counts when gauges expire. The gauges used in this class expire 15 mins after the last update. Stable http/2 connections to origins are especially susceptible to getting lost.

The new approach relies on a PolledMeter monitoring an AtomicLong. Each event loop independently tracks its own counts (internally gauges maintain a list of all monitored numbers with the same id, and sum them up). I did this to simplify the cleanup logic

