### PR TITLE
Respect gzip quality value in Accept-Encoding

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/util/HttpUtils.java
@@ -16,6 +16,7 @@
 package com.netflix.zuul.util;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.netflix.zuul.message.Headers;
 import com.netflix.zuul.message.ZuulMessage;
@@ -27,6 +28,7 @@ import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http2.Http2StreamChannel;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import org.jspecify.annotations.NullMarked;
@@ -99,8 +101,40 @@ public class HttpUtils {
     }
 
     public static boolean acceptsGzip(Headers headers) {
-        String ae = headers.getFirst(HttpHeaderNames.ACCEPT_ENCODING);
-        return ae != null && ae.contains(HttpHeaderValues.GZIP.toString());
+        String acceptEncoding = headers.getFirst(HttpHeaderNames.ACCEPT_ENCODING);
+        if (acceptEncoding == null) {
+            return false;
+        }
+
+        for (String encoding : Splitter.on(',').trimResults().split(acceptEncoding)) {
+            List<String> parts = Splitter.on(';').trimResults().splitToList(encoding);
+
+            if (!parts.get(0).equals(HttpHeaderValues.GZIP.toString())) {
+                continue;
+            }
+
+            double quality = 1.0;
+
+            for (int i = 1; i < parts.size(); i++) {
+                String parameter = parts.get(i);
+                int separator = parameter.indexOf('=');
+
+                if (separator > 0 && parameter.substring(0, separator).trim().equalsIgnoreCase("q")) {
+                    try {
+                        quality = Double.parseDouble(
+                                parameter.substring(separator + 1).trim());
+                    } catch (NumberFormatException e) {
+                        quality = 0.0;
+                    }
+                }
+            }
+
+            if (quality > 0.0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/util/HttpUtilsTest.java
@@ -84,6 +84,27 @@ class HttpUtilsTest {
     }
 
     @Test
+    void rejectsGzipWithZeroQuality() {
+        Headers headers = new Headers();
+        headers.add("Accept-Encoding", "gzip;q=0");
+        assertThat(HttpUtils.acceptsGzip(headers)).isFalse();
+    }
+
+    @Test
+    void acceptsGzipWithPositiveQuality() {
+        Headers headers = new Headers();
+        headers.add("Accept-Encoding", "gzip;q=0.5");
+        assertThat(HttpUtils.acceptsGzip(headers)).isTrue();
+    }
+
+    @Test
+    void acceptsGzipWithoutQuality() {
+        Headers headers = new Headers();
+        headers.add("Accept-Encoding", "gzip");
+        assertThat(HttpUtils.acceptsGzip(headers)).isTrue();
+    }
+
+    @Test
     void stripMaliciousHeaderChars() {
         assertThat(HttpUtils.stripMaliciousHeaderChars("some\r\nthing")).isEqualTo("something");
         assertThat(HttpUtils.stripMaliciousHeaderChars("some thing")).isEqualTo("some thing");


### PR DESCRIPTION
### Summary

Respect the gzip quality value when evaluating the `Accept-Encoding` header.

Previously, `HttpUtils.acceptsGzip()` only checked whether the header contained `gzip`. As a result, a request such as:

```text
Accept-Encoding: gzip;q=0
```

was treated as accepting gzip even though a quality value of `0` means the encoding is not acceptable.

### Changes

* Parse `Accept-Encoding` entries when checking for gzip support.
* Treat `gzip;q=0` as not accepting gzip.
* Continue accepting gzip when no quality value is specified.
* Continue accepting gzip when the quality value is greater than zero.
* Add regression tests for zero, positive, and omitted gzip quality values.

### Testing

Ran:

```text
./gradlew :zuul-core:test \
  --tests com.netflix.zuul.util.HttpUtilsTest
```
