### PR TITLE
Match query param names verbatim in HttpQueryParams.get

### DIFF
--- a/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpQueryParams.java
+++ b/zuul-core/src/main/java/com/netflix/zuul/message/http/HttpQueryParams.java
@@ -26,7 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -113,7 +112,7 @@ public class HttpQueryParams implements Cloneable {
     }
 
     public List<String> get(String name) {
-        return delegate.get(name.toLowerCase(Locale.ROOT));
+        return delegate.get(name);
     }
 
     public boolean contains(String name) {
@@ -129,7 +128,15 @@ public class HttpQueryParams implements Cloneable {
      * However, as a utility, this exists to allow us to do a case insensitive match on demand.
      */
     public boolean containsIgnoreCase(String name) {
-        return delegate.containsKey(name) || delegate.containsKey(name.toLowerCase(Locale.ROOT));
+        if (delegate.containsKey(name)) {
+            return true;
+        }
+        for (String key : delegate.keySet()) {
+            if (key.equalsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpQueryParamsTest.java
+++ b/zuul-core/src/test/java/com/netflix/zuul/message/http/HttpQueryParamsTest.java
@@ -51,6 +51,27 @@ class HttpQueryParamsTest {
     }
 
     @Test
+    void getMatchesMixedCaseNamesVerbatim() {
+        HttpQueryParams qp = HttpQueryParams.parse("Foo=bar&baz=qux&Foo=second");
+
+        assertThat(qp.get("Foo")).isEqualTo(List.of("bar", "second"));
+        assertThat(qp.getFirst("Foo")).isEqualTo("bar");
+        assertThat(qp.contains("Foo")).isTrue();
+        assertThat(qp.get("baz")).isEqualTo(List.of("qux"));
+        assertThat(qp.get("foo")).isEmpty();
+    }
+
+    @Test
+    void getMatchesNameAddedWithMixedCase() {
+        HttpQueryParams qp = new HttpQueryParams();
+        qp.add("Foo", "bar");
+
+        assertThat(qp.get("Foo")).isEqualTo(List.of("bar"));
+        assertThat(qp.get("foo")).isEmpty();
+        assertThat(qp.containsIgnoreCase("foo")).isTrue();
+    }
+
+    @Test
     void testToEncodedString() {
         HttpQueryParams qp = new HttpQueryParams();
         qp.add("k'1", "v1&");
@@ -157,6 +178,17 @@ class HttpQueryParamsTest {
         queryParams.add(camelCaseKey.toLowerCase(Locale.ROOT), "value");
 
         assertThat(queryParams.containsIgnoreCase(camelCaseKey)).isTrue();
+    }
+
+    @Test
+    void containsIgnoreCaseMatchesMixedCaseStoredName() {
+        HttpQueryParams queryParams = new HttpQueryParams();
+        queryParams.add("keyName", "value");
+
+        assertThat(queryParams.containsIgnoreCase("keyname")).isTrue();
+        assertThat(queryParams.containsIgnoreCase("KEYNAME")).isTrue();
+        assertThat(queryParams.containsIgnoreCase("keyName")).isTrue();
+        assertThat(queryParams.containsIgnoreCase("other")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
`HttpQueryParams.get(String)` lower-cased the lookup key while names are stored verbatim, so every parameter whose name carries an uppercase letter returned an empty list, and `get` disagreed with `getFirst` and `contains`, which match verbatim. `containsIgnoreCase` folded only the argument, so it missed a stored name with any uppercase letter.

`get` now matches the stored name, and `containsIgnoreCase` compares against the stored names case-insensitively. Three tests cover both; the `get` cases fail on master.
