### PR TITLE
Validate zstd compression

### DIFF
--- a/zuul-core/dependencies.lock
+++ b/zuul-core/dependencies.lock
@@ -12,10 +12,10 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "locked": "33.6.0-jre"
@@ -48,7 +48,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -140,10 +140,10 @@
     },
     "jmhCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "locked": "33.6.0-jre"
@@ -176,7 +176,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -253,10 +253,10 @@
     },
     "jmhRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -307,7 +307,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -417,10 +417,10 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -471,7 +471,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -550,10 +550,10 @@
     },
     "testCompileClasspath": {
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "locked": "33.6.0-jre"
@@ -586,7 +586,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true
@@ -681,10 +681,10 @@
     },
     "testRuntimeClasspath": {
         "com.fasterxml.jackson.core:jackson-core": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -735,7 +735,7 @@
             "locked": "0.13.2"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-discovery": {
             "project": true

--- a/zuul-integration-test/build.gradle
+++ b/zuul-integration-test/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     // netty release depends on without pinning it ourselves.
     testImplementation platform("io.netty:netty-parent:${versions_netty}")
     testImplementation "com.aayushatharva.brotli4j:brotli4j"
+    testImplementation "com.github.luben:zstd-jni"
     testRuntimeOnly 'org.apache.logging.log4j:log4j-core:2.26.1'
     testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j2-impl:2.26.1'
     testRuntimeOnly "com.aayushatharva.brotli4j:native-osx-aarch64"

--- a/zuul-integration-test/dependencies.lock
+++ b/zuul-integration-test/dependencies.lock
@@ -4,13 +4,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.errorprone:error_prone_core": {
             "locked": "2.45.0"
@@ -78,7 +78,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -225,7 +225,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -276,7 +276,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -386,7 +386,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -437,7 +437,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -547,13 +547,16 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
+        },
+        "com.github.luben:zstd-jni": {
+            "locked": "1.5.7-7"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -617,7 +620,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -809,13 +812,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -879,7 +882,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1034,7 +1037,10 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
+        },
+        "com.github.luben:zstd-jni": {
+            "locked": "1.5.7-7"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -1085,7 +1091,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1228,13 +1234,16 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
+        },
+        "com.github.luben:zstd-jni": {
+            "locked": "1.5.7-7"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -1298,7 +1307,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true

--- a/zuul-integration-test/src/test/java/com/netflix/zuul/integration/BaseIntegrationTest.java
+++ b/zuul-integration-test/src/test/java/com/netflix/zuul/integration/BaseIntegrationTest.java
@@ -44,6 +44,7 @@ import com.netflix.zuul.integration.server.HeaderNames;
 import com.netflix.zuul.integration.server.TestUtil;
 import io.netty.channel.epoll.Epoll;
 import io.netty.handler.codec.compression.Brotli;
+import io.netty.handler.codec.compression.Zstd;
 import io.netty.util.ResourceLeakDetector;
 import java.io.IOException;
 import java.io.InputStream;
@@ -590,6 +591,37 @@ abstract class BaseIntegrationTest {
         DirectDecompress decompressResult = DirectDecompress.decompress(compressedData);
         assertThat(decompressResult.getResultStatus()).isEqualTo(DecoderJNI.Status.DONE);
         assertThat(new String(decompressResult.getDecompressedData(), TestUtil.CHARSET))
+                .isEqualTo("Hello Hello Hello Hello Hello");
+
+        inputStream.close();
+        connection.disconnect();
+    }
+
+    @Test
+    void zstdOnly() throws Throwable {
+        Zstd.ensureAvailability();
+        String expectedResponseBody = TestUtil.COMPRESSIBLE_CONTENT;
+
+        wireMock.register(get(anyUrl())
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withBody(expectedResponseBody)
+                        .withHeader("Content-Type", TestUtil.COMPRESSIBLE_CONTENT_TYPE)));
+
+        URL url = new URL(zuulBaseUri);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("GET");
+        connection.setAllowUserInteraction(false);
+        connection.setRequestProperty("Accept-Encoding", "zstd");
+        InputStream inputStream = connection.getInputStream();
+        assertThat(connection.getResponseCode()).isEqualTo(200);
+        assertThat(connection.getHeaderField("Content-Type")).isEqualTo("text/plain");
+        assertThat(connection.getHeaderField("Content-Encoding")).isEqualTo("zstd");
+        byte[] compressedData = IOUtils.toByteArray(inputStream);
+        assertThat(compressedData.length > 0).isTrue();
+        byte[] decompressResult = com.github.luben.zstd.Zstd.decompress(compressedData);
+        assertThat(decompressResult).hasSizeGreaterThan(0);
+        assertThat(new String(decompressResult, TestUtil.CHARSET))
                 .isEqualTo("Hello Hello Hello Hello Hello");
 
         inputStream.close();

--- a/zuul-processor/dependencies.lock
+++ b/zuul-processor/dependencies.lock
@@ -12,7 +12,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "locked": "33.6.0-jre"
@@ -63,7 +63,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -167,7 +167,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "locked": "33.6.0-jre"
@@ -218,7 +218,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -307,13 +307,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -377,7 +377,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -536,13 +536,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -606,7 +606,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -744,13 +744,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.errorprone:error_prone_core": {
             "locked": "2.45.0"
@@ -818,7 +818,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -965,7 +965,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "locked": "33.6.0-jre"
@@ -1016,7 +1016,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1114,13 +1114,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -1184,7 +1184,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true

--- a/zuul-sample/dependencies.lock
+++ b/zuul-sample/dependencies.lock
@@ -4,13 +4,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.errorprone:error_prone_core": {
             "locked": "2.45.0"
@@ -78,7 +78,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "firstLevelTransitive": [
@@ -225,7 +225,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -273,7 +273,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -392,7 +392,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -440,7 +440,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -544,13 +544,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -614,7 +614,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -773,13 +773,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -843,7 +843,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1004,7 +1004,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.netflix.archaius:archaius-core": {
             "firstLevelTransitive": [
@@ -1052,7 +1052,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true
@@ -1150,13 +1150,13 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "2.21.5"
+            "locked": "2.21.6"
         },
         "com.google.guava:guava": {
             "firstLevelTransitive": [
@@ -1220,7 +1220,7 @@
             "firstLevelTransitive": [
                 "com.netflix.zuul:zuul-core"
             ],
-            "locked": "1.10.4"
+            "locked": "1.10.7"
         },
         "com.netflix.zuul:zuul-core": {
             "project": true


### PR DESCRIPTION
Adds an integration test that validates zstd response compression end-to-end.

`zstdOnly()` sends `Accept-Encoding: zstd`, asserts Zuul responds with `Content-Encoding: zstd`, and decompresses the body with `com.github.luben.zstd.Zstd` to confirm the payload round-trips correctly. This mirrors the existing brotli-only test, which only checked headers/length without verifying the compressed bytes are actually valid.

- Adds `com.github.luben:zstd-jni` as a `testImplementation` dependency in `zuul-integration-test` (version comes from the `netty-parent` BOM already on the test classpath).
- `Zstd.ensureAvailability()` guards the test so it fails loudly rather than silently if native support is missing.

The `dependencies.lock` churn (jackson 2.21.5 → 2.21.6, spectator 1.10.4 → 1.10.7) is from regenerating the lock files.

